### PR TITLE
UnsafeBuffer.java - correct type conversion size issue.

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
@@ -540,7 +540,7 @@ public class UnsafeBuffer implements AtomicBuffer
         if (NATIVE_BYTE_ORDER != byteOrder)
         {
             final int bits = Integer.reverseBytes(Float.floatToRawIntBits(value));
-            UNSAFE.putLong(byteArray, addressOffset + index, bits);
+            UNSAFE.putInt(byteArray, addressOffset + index, bits);
         }
         else
         {


### PR DESCRIPTION
32 bit rather than 64 put of a long (if this code is ever used).