### PR TITLE
Might be problem with offsets in BroadcastBufferDescriptor.

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/broadcast/BroadcastBufferDescriptor.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/broadcast/BroadcastBufferDescriptor.java
@@ -33,7 +33,7 @@ public class BroadcastBufferDescriptor
     public static final int LATEST_COUNTER_OFFSET = TAIL_COUNTER_OFFSET + BitUtil.SIZE_OF_LONG;
 
     /** Total size of the trailer */
-    public static final int TRAILER_LENGTH = BitUtil.CACHE_LINE_LENGTH * 2;
+    public static final int TRAILER_LENGTH = BitUtil.CACHE_LINE_LENGTH * 3;
 
     /**
      * Check the the buffer capacity is the correct size.

--- a/src/main/java/uk/co/real_logic/agrona/concurrent/broadcast/BroadcastBufferDescriptor.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/broadcast/BroadcastBufferDescriptor.java
@@ -24,16 +24,30 @@ import uk.co.real_logic.agrona.BitUtil;
 public class BroadcastBufferDescriptor
 {
     /** Offset within the trailer for where the tail intended value is stored. */
-    public static final int TAIL_INTENT_COUNTER_OFFSET = 0;
+    public static final int TAIL_INTENT_COUNTER_OFFSET;
 
     /** Offset within the trailer for where the tail value is stored. */
-    public static final int TAIL_COUNTER_OFFSET = TAIL_INTENT_COUNTER_OFFSET + BitUtil.SIZE_OF_LONG;
+    public static final int TAIL_COUNTER_OFFSET;
 
     /** Offset within the trailer for where the latest sequence value is stored. */
-    public static final int LATEST_COUNTER_OFFSET = TAIL_COUNTER_OFFSET + BitUtil.SIZE_OF_LONG;
+    public static final int LATEST_COUNTER_OFFSET;
 
     /** Total size of the trailer */
-    public static final int TRAILER_LENGTH = BitUtil.CACHE_LINE_LENGTH * 3;
+    public static final int TRAILER_LENGTH;
+
+    static {
+        int offset = 0;
+        TAIL_INTENT_COUNTER_OFFSET = offset;
+
+        offset += BitUtil.CACHE_LINE_LENGTH;
+        TAIL_COUNTER_OFFSET = offset;
+
+        offset += BitUtil.CACHE_LINE_LENGTH;
+        LATEST_COUNTER_OFFSET = offset;
+
+        offset += BitUtil.CACHE_LINE_LENGTH;
+        TRAILER_LENGTH = offset;
+    }
 
     /**
      * Check the the buffer capacity is the correct size.

--- a/src/main/java/uk/co/real_logic/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
@@ -30,7 +30,7 @@ public class RingBufferDescriptor
     /** Offset within the trailer for where the head value is stored. */
     public static final int HEAD_COUNTER_OFFSET;
 
-    /** Offset within the trailer for where the head value is stored. */
+    /** Offset within the trailer for where the correlation counter value is stored. */
     public static final int CORRELATION_COUNTER_OFFSET;
 
     /** Offset within the trailer for where the consumer heartbeat time value is stored. */


### PR DESCRIPTION
Take with a pinch of salt as am still getting familiar with the project. But it looks like current Trailer has 128 byte length but the three fields are packed into the first 24 bytes. i.e. they'll all be sharing a cache line + the second cache line will be completely empty.

I've just stolen the code from the RingBuffer descriptor as a tentative fix.

Again... pinch of salt but see what you think.

Cheers,

A.
