### PR TITLE
Fixed Int2IntHashMap/Long2LongHashMap.size(). 

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/collections/Int2IntHashMap.java
+++ b/src/main/java/uk/co/real_logic/agrona/collections/Int2IntHashMap.java
@@ -546,6 +546,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
         /*@DoNotSub*/ resizeThreshold = (int)(newCapacity * loadFactor);
         mask = (newCapacity * 2) - 1;
         entries = new int[newCapacity * 2];
+        size = 0;
         Arrays.fill(entries, missingValue);
     }
 }

--- a/src/test/java/uk/co/real_logic/agrona/collections/Int2IntHashMapTest.java
+++ b/src/test/java/uk/co/real_logic/agrona/collections/Int2IntHashMapTest.java
@@ -326,6 +326,18 @@ public class Int2IntHashMapTest
         assertEquals(-5, map.minValue());
     }
 
+    @Test
+    public void sizeShouldReturnNumberOfEntries()
+    {
+        final int count = 100;
+        for (int key = 0; key < count; key++)
+        {
+            map.put(key, 1);
+        }
+
+        assertEquals(count, map.size());
+    }
+
     private void assertEntryIs(final Entry<Integer, Integer> entry, final int expectedKey, final int expectedValue)
     {
         assertEquals(expectedKey, entry.getKey().intValue());


### PR DESCRIPTION
Size field should be reset during rehash() to avoid counting current entries multiple times.