### PR TITLE
ensure BitUtil.align is unit tested/documented re negative inputs

### DIFF
--- a/src/test/java/uk/co/real_logic/agrona/BitUtilTest.java
+++ b/src/test/java/uk/co/real_logic/agrona/BitUtilTest.java
@@ -51,13 +51,34 @@ public class BitUtilTest
         assertThat(valueOf(align(alignment, alignment)), is(valueOf(alignment)));
         assertThat(valueOf(align(alignment + 1, alignment)), is(valueOf(alignment * 2)));
 
-        final int reminder = Integer.MAX_VALUE % alignment;
-        final int maxMultiple = Integer.MAX_VALUE - reminder;
+        final int remainder = Integer.MAX_VALUE % alignment;
+        final int maxMultiple = Integer.MAX_VALUE - remainder;
 
         assertThat(valueOf(align(maxMultiple, alignment)), is(valueOf(maxMultiple)));
         assertThat(valueOf(align(Integer.MAX_VALUE, alignment)), is(valueOf(Integer.MIN_VALUE)));
     }
 
+    @Test
+    public void shouldAlignWhenAlignmentIsPositiveAndValueIsNegative() {
+        final int alignment = BitUtil.CACHE_LINE_LENGTH;
+        assertThat(valueOf(align(-1, alignment)), is(valueOf(0)));
+        assertThat(valueOf(align(-alignment, alignment)), is(valueOf(-alignment)));
+        assertThat(valueOf(align(-alignment - 1, alignment)), is(valueOf(-alignment)));
+    }
+    
+    @Test
+    public void shouldAlignWhenAlignmentIsNegativeAndValueIsPositive() {
+        final int alignment = BitUtil.CACHE_LINE_LENGTH;
+        assertThat(valueOf(align(alignment + 1, -alignment)), is(valueOf(2 * alignment)));//FAILS
+    }
+
+    @Test
+    public void shouldAlignWhenAlignmentIsNegativeAndValueIsNegative() {
+        final int alignment = BitUtil.CACHE_LINE_LENGTH;
+        assertThat(valueOf(align(-alignment + 1, -alignment)), is(valueOf(0)));
+        assertThat(valueOf(align(-alignment - 1, -alignment)), is(valueOf(-alignment)));// FAILS
+    }
+    
     @Test
     public void shouldConvertToHexCorrectly()
     {


### PR DESCRIPTION
Just added tests for `BitUtil.align` for negative values and fixed a spelling error in the unit test.

Also added unit tests to see what would happen for negative `alignment` parameters and got (newly added) unit test failures. 

I'm assuming that the javadoc could be updated to indicate that a positive alignment value is expected. Would you like to throw an `IllegalArgumentException` for a non-positive `alignment` parameter?