### PR TITLE
[Java] Improve javadoc

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/MappedResizeableBuffer.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/MappedResizeableBuffer.java
@@ -41,7 +41,8 @@ import uk.co.real_logic.agrona.MutableDirectBuffer;
 /**
  * Supports regular, byte ordered, and atomic (memory ordered) access to an underlying buffer.
  *
- * This buffer is resizable and based upon an underlying
+ * This buffer is resizable and based upon an underlying FileChannel.
+ * The channel is <b>not</b> closed when the buffer is closed.
  */
 public class MappedResizeableBuffer implements AtomicBuffer, AutoCloseable
 {

--- a/src/test/java/uk/co/real_logic/agrona/concurrent/MappedResizeableBufferTest.java
+++ b/src/test/java/uk/co/real_logic/agrona/concurrent/MappedResizeableBufferTest.java
@@ -27,6 +27,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MappedResizeableBufferTest
 {
@@ -89,6 +90,15 @@ public class MappedResizeableBufferTest
         buffer = new MappedResizeableBuffer(channel, 0, SIZE);
 
         assertEquals(VALUE, buffer.getInt(SIZE - 4));
+    }
+
+    @Test
+    public void shouldNotCloseChannelUponBufferClose() throws Exception {
+        buffer = new MappedResizeableBuffer(channel, 0, SIZE);
+
+        buffer.close();
+
+        assertTrue(channel.isOpen());
     }
 
     private void exchangeDataAt(final long index) throws IOException


### PR DESCRIPTION
While reading the code, I noticed that the doc was cut in the middle of a sentence. 
Here is my proposal to complete it and also add more information about the behavior of the buffer  close().