### PR TITLE
converting address to long in UnsafeBuffer constructor

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
@@ -128,7 +128,7 @@ public class UnsafeBuffer implements AtomicBuffer
      * @param address where the memory begins off-heap
      * @param length  of the buffer from the given address
      */
-    public UnsafeBuffer(final int address, final int length)
+    public UnsafeBuffer(final long address, final int length)
     {
         wrap(address, length);
     }


### PR DESCRIPTION
This is fix for a bug introduced in rollback of long index changes, address should be long.