### PR TITLE
Use long address in UnsafeBuffer ctor

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/UnsafeBuffer.java
@@ -128,7 +128,7 @@ public class UnsafeBuffer implements AtomicBuffer
      * @param address where the memory begins off-heap
      * @param length  of the buffer from the given address
      */
-    public UnsafeBuffer(final int address, final int length)
+    public UnsafeBuffer(final long address, final int length)
     {
         wrap(address, length);
     }


### PR DESCRIPTION
The param seems to have been mistakenly converted to an int, but that would severely limit the use of this constructor, moreover wrap() is taking a long address as parameter.