### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/concurrent/AgentRunner.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/AgentRunner.java
@@ -28,18 +28,6 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class AgentRunner implements Runnable, AutoCloseable
 {
-    /**
-     * Start the given agent runner on a new thread.
-     *
-     * @param runner the agent runner to start
-     */
-    public static void startOnThread(final AgentRunner runner)
-    {
-        final Thread thread = new Thread(runner);
-        thread.setName(runner.agent().roleName());
-        thread.start();
-    }
-
     private static final Thread TOMBSTONE = new Thread();
 
     private volatile boolean running = true;
@@ -72,6 +60,18 @@ public class AgentRunner implements Runnable, AutoCloseable
         this.errorHandler = errorHandler;
         this.errorCounter = errorCounter;
         this.agent = agent;
+    }
+
+    /**
+     * Start the given agent runner on a new thread.
+     *
+     * @param runner the agent runner to start
+     */
+    public static void startOnThread(final AgentRunner runner)
+    {
+        final Thread thread = new Thread(runner);
+        thread.setName(runner.agent().roleName());
+        thread.start();
     }
 
     /**

--- a/src/main/java/uk/co/real_logic/agrona/concurrent/BackoffIdleStrategy.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/BackoffIdleStrategy.java
@@ -43,6 +43,12 @@ abstract class BackoffIdleStrategyData extends BackoffIdleStrategyPrePad
     protected final long minParkPeriodNs;
     protected final long maxParkPeriodNs;
 
+    protected State state;
+
+    protected long spins;
+    protected long yields;
+    protected long parkPeriodNs;
+
     BackoffIdleStrategyData(final long maxSpins, final long maxYields, final long minParkPeriodNs, final long maxParkPeriodNs)
     {
         this.maxSpins = maxSpins;
@@ -50,11 +56,6 @@ abstract class BackoffIdleStrategyData extends BackoffIdleStrategyPrePad
         this.minParkPeriodNs = minParkPeriodNs;
         this.maxParkPeriodNs = maxParkPeriodNs;
     }
-    protected State state;
-
-    protected long spins;
-    protected long yields;
-    protected long parkPeriodNs;
 }
 
 @SuppressWarnings("unused")


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava