### PR TITLE
Avoid boxing in CountersReader.forEach()

### DIFF
--- a/src/main/java/uk/co/real_logic/agrona/collections/IntIntConsumer.java
+++ b/src/main/java/uk/co/real_logic/agrona/collections/IntIntConsumer.java
@@ -23,7 +23,7 @@ public interface
     IntIntConsumer
 {
     /**
-     * Accept a key and value that comes as a tuple of longs.
+     * Accept a key and value that comes as a tuple of ints.
      *
      * @param key   for the tuple.
      * @param value for the tuple.

--- a/src/main/java/uk/co/real_logic/agrona/collections/IntObjConsumer.java
+++ b/src/main/java/uk/co/real_logic/agrona/collections/IntObjConsumer.java
@@ -23,10 +23,8 @@ public interface
 IntObjConsumer<T>
 {
     /**
-     * Accept a key and value that comes as a tuple of longs.
-     *
-     * @param key   for the tuple.
-     * @param value for the tuple.
+     * @param i for the tuple.
+     * @param v for the tuple.
      */
-    void accept(int key, T value);
+    void accept(int i, T v);
 }

--- a/src/main/java/uk/co/real_logic/agrona/collections/IntObjConsumer.java
+++ b/src/main/java/uk/co/real_logic/agrona/collections/IntObjConsumer.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.agrona.collections;
+
+/**
+ * This is an (int,Object) primitive specialisation of a BiConsumer.
+ */
+@FunctionalInterface
+public interface
+IntObjConsumer<T>
+{
+    /**
+     * Accept a key and value that comes as a tuple of longs.
+     *
+     * @param key   for the tuple.
+     * @param value for the tuple.
+     */
+    void accept(int key, T value);
+}

--- a/src/main/java/uk/co/real_logic/agrona/concurrent/CountersReader.java
+++ b/src/main/java/uk/co/real_logic/agrona/concurrent/CountersReader.java
@@ -17,8 +17,7 @@ package uk.co.real_logic.agrona.concurrent;
 
 import uk.co.real_logic.agrona.BitUtil;
 import uk.co.real_logic.agrona.DirectBuffer;
-
-import java.util.function.BiConsumer;
+import uk.co.real_logic.agrona.collections.IntObjConsumer;
 
 import static uk.co.real_logic.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static uk.co.real_logic.agrona.BitUtil.SIZE_OF_INT;
@@ -167,7 +166,7 @@ public class CountersReader
      *
      * @param consumer function to be called for each label.
      */
-    public void forEach(final BiConsumer<Integer, String> consumer)
+    public void forEach(final IntObjConsumer<String> consumer)
     {
         int counterId = 0;
 

--- a/src/test/java/uk/co/real_logic/agrona/concurrent/CountersManagerTest.java
+++ b/src/test/java/uk/co/real_logic/agrona/concurrent/CountersManagerTest.java
@@ -20,11 +20,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import uk.co.real_logic.agrona.DirectBuffer;
+import uk.co.real_logic.agrona.collections.IntObjConsumer;
 import uk.co.real_logic.agrona.concurrent.status.Position;
 import uk.co.real_logic.agrona.concurrent.status.ReadablePosition;
 import uk.co.real_logic.agrona.concurrent.status.UnsafeBufferPosition;
-
-import java.util.function.BiConsumer;
 
 import static java.nio.ByteBuffer.allocateDirect;
 import static org.hamcrest.Matchers.is;
@@ -45,7 +44,7 @@ public class CountersManagerTest
     private CountersReader otherManager = new CountersManager(labelsBuffer, counterBuffer);
 
     @SuppressWarnings("unchecked")
-    private final BiConsumer<Integer, String> consumer = mock(BiConsumer.class);
+    private final IntObjConsumer<String> consumer = mock(IntObjConsumer.class);
     private final CountersReader.MetaData metaData = mock(CountersReader.MetaData.class);
 
     @Test


### PR DESCRIPTION
`CountersReader.forEach()` takes a `java.util.function.BiConsumer` as parameter, and pass it the counterId (int) and label (String). Using a `BiConsumer` causes the counter to be boxed.
This pull requests creates a new functional interterace `IntObjConsumer` in agrona/collections and uses it in `CountersReader.forEach()` to avoid the boxing. This new interface is very similar to `ObjIntConsumer` from the JDK but with parameters order reversed to be backward compatible with current uses of forEach(), but I may remove it and use the JDK's one if it seems overkill to add an almost duplicate interface.

I also fixed a little error in the doc of `IntIntConsumer` that was saying `long` instead of `int`