### PR TITLE
Issue #75: [Java] Fixed IntHashSet.containsAll.

### DIFF
--- a/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/src/main/java/org/agrona/collections/IntHashSet.java
@@ -337,7 +337,7 @@ public final class IntHashSet implements Set<Integer>
      */
     public boolean addAll(final Collection<? extends Integer> coll)
     {
-        return conjunction(coll, this::add);
+        return disjunction(coll, this::add);
     }
 
     /**
@@ -345,7 +345,17 @@ public final class IntHashSet implements Set<Integer>
      */
     public boolean containsAll(final Collection<?> coll)
     {
-        return conjunction(coll, this::contains);
+        Objects.requireNonNull(coll);
+
+        for (final Object t : coll)
+        {
+            if (!contains(t))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -356,19 +366,18 @@ public final class IntHashSet implements Set<Integer>
      */
     public boolean containsAll(final IntHashSet other)
     {
-        boolean containsAll = true;
+        Objects.requireNonNull(other);
 
-        final int missingValue = this.missingValue;
-        for (final int value : values)
+        final int missingValue = other.missingValue;
+        for (final int value : other.values)
         {
-            if (value != missingValue && !other.contains(value))
+            if (value != missingValue && !contains(value))
             {
-                containsAll = false;
-                break;
+                return false;
             }
         }
 
-        return containsAll;
+        return true;
     }
 
     /**
@@ -407,10 +416,10 @@ public final class IntHashSet implements Set<Integer>
      */
     public boolean removeAll(final Collection<?> coll)
     {
-        return conjunction(coll, this::remove);
+        return disjunction(coll, this::remove);
     }
 
-    private static <T> boolean conjunction(final Collection<T> collection, final Predicate<T> predicate)
+    private static <T> boolean disjunction(final Collection<T> collection, final Predicate<T> predicate)
     {
         Objects.requireNonNull(collection);
 

--- a/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -48,7 +48,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsAddedBoxedElement()
+    public void containsAddedElement()
     {
         assertTrue(obj.add(1));
 
@@ -71,6 +71,12 @@ public class IntHashSetTest
 
         assertTrue(obj.contains(Integer.valueOf(1)));
         assertTrue(obj.contains(2));
+    }
+
+    @Test
+    public void doesNotContainMissingValue()
+    {
+        assertFalse(obj.contains(obj.missingValue()));
     }
 
     @Test
@@ -427,7 +433,125 @@ public class IntHashSetTest
         assertFalse(obj.containsAll((Collection<?>) superset));
     }
 
-    private void addTwoElements(final IntHashSet obj)
+    @Test
+    public void addingEmptySetDoesNothing()
+    {
+        addTwoElements(obj);
+
+        assertFalse(obj.addAll(new IntHashSet(100, -1)));
+        assertContainsElements(obj);
+    }
+
+    @Test
+    public void addingSubsetDoesNothing()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet subset = new IntHashSet(100, -1);
+
+        subset.add(1);
+
+        assertFalse(obj.addAll(subset));
+        assertContainsElements(obj);
+    }
+
+    @Test
+    public void addingEqualSetDoesNothing()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet equal = new IntHashSet(100, -1);
+
+        addTwoElements(equal);
+
+        assertFalse(obj.addAll(equal));
+        assertContainsElements(obj);
+    }
+
+    @Test
+    public void containsValuesAddedFromDisjointSet()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet disjoint = new IntHashSet(100, -1);
+
+        disjoint.add(2);
+        disjoint.add(1002);
+
+        assertTrue(obj.addAll(disjoint));
+        assertTrue(obj.contains(1));
+        assertTrue(obj.contains(1001));
+        assertTrue(obj.containsAll(disjoint));
+    }
+
+    @Test
+    public void containsValuesAddedFromIntersectingSet()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet intersecting = new IntHashSet(100, -1);
+
+        intersecting.add(1);
+        intersecting.add(1002);
+
+        assertTrue(obj.addAll(intersecting));
+        assertTrue(obj.contains(1));
+        assertTrue(obj.contains(1001));
+        assertTrue(obj.containsAll(intersecting));
+    }
+
+    @Test
+    public void removingEmptySetDoesNothing()
+    {
+        addTwoElements(obj);
+
+        assertFalse(obj.removeAll(new IntHashSet(100, -1)));
+        assertContainsElements(obj);
+    }
+
+    @Test
+    public void removingDisjointSetDoesNothing()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet disjoint = new IntHashSet(100, -1);
+
+        disjoint.add(2);
+        disjoint.add(1002);
+
+        assertFalse(obj.removeAll(disjoint));
+        assertContainsElements(obj);
+    }
+
+    @Test
+    public void doesNotContainRemovedIntersectingSet()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet intersecting = new IntHashSet(100, -1);
+
+        intersecting.add(1);
+        intersecting.add(1002);
+
+        assertTrue(obj.removeAll(intersecting));
+        assertTrue(obj.contains(1001));
+        assertFalse(obj.containsAll(intersecting));
+    }
+
+    @Test
+    public void isEmptyAfterRemovingEqualSet()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet equal = new IntHashSet(100, -1);
+
+        addTwoElements(equal);
+
+        assertTrue(obj.removeAll(equal));
+        assertTrue(obj.isEmpty());
+    }
+
+    private static void addTwoElements(final IntHashSet obj)
     {
         obj.add(1);
         obj.add(1001);
@@ -460,12 +584,12 @@ public class IntHashSetTest
         assertContainsElements(values);
     }
 
-    private void assertArrayContainingElements(final Integer[] result)
+    private static void assertArrayContainingElements(final Integer[] result)
     {
         assertThat(result, arrayContainingInAnyOrder(1, 1001));
     }
 
-    private void assertContainsElements(final Set<Integer> other)
+    private static void assertContainsElements(final Set<Integer> other)
     {
         assertThat(other, containsInAnyOrder(1, 1001));
     }

--- a/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -17,10 +17,7 @@ package org.agrona.collections;
 
 import org.junit.Test;
 
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -378,6 +375,56 @@ public class IntHashSetTest
         {
             assertTrue(obj.contains(i));
         }
+    }
+
+     @Test
+    public void containsEmptySet()
+    {
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        assertTrue(obj.containsAll(other));
+        assertTrue(obj.containsAll((Collection<?>) other));
+    }
+
+    @Test
+    public void containsSubset()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet subset = new IntHashSet(100, -1);
+
+        subset.add(1);
+
+        assertTrue(obj.containsAll(subset));
+        assertTrue(obj.containsAll((Collection<?>) subset));
+    }
+
+    @Test
+    public void doesNotContainDisjointSet()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        other.add(1);
+        other.add(1002);
+
+        assertFalse(obj.containsAll(other));
+        assertFalse(obj.containsAll((Collection<?>) other));
+    }
+
+    @Test
+    public void doesNotContainSuperset()
+    {
+        addTwoElements(obj);
+
+        final IntHashSet superset = new IntHashSet(100, -1);
+
+        addTwoElements(superset);
+        superset.add(15);
+
+        assertFalse(obj.containsAll(superset));
+        assertFalse(obj.containsAll((Collection<?>) superset));
     }
 
     private void addTwoElements(final IntHashSet obj)


### PR DESCRIPTION
I've fixed the `IntHashSet.containsAll(Collection)` method. When writing tests I've also found that there are some problems with `IntHashSet.containsAll(IntHashSet)`, which I've also fixed. Plus, renamed `conjunction` to `disjunction` according to what it does.

Edit: it might be a good idea to write some tests for `addAll` and `removeAll`. I could push another commit to this pull request. Shall I?