### PR TITLE
New Set implementation for Objects

### DIFF
--- a/src/main/java/org/agrona/collections/ObjHashSet.java
+++ b/src/main/java/org/agrona/collections/ObjHashSet.java
@@ -1,0 +1,524 @@
+/*
+ *  Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.agrona.BitUtil;
+import org.agrona.generation.DoNotSub;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.IntConsumer;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.joining;
+import static org.agrona.collections.CollectionUtil.validateLoadFactor;
+
+/**
+ * Open-addressing with linear-probing expandable hash set. Allocation free in steady state use when expanded.
+ * <p>
+  * Not Threadsafe.
+ * <p>
+ * This HashSet caches its iterator object, so nested iteration is not supported.
+ *
+ * @see ObjIterator
+ * @see Set
+ */
+public final class ObjHashSet<T> implements Set<T>
+{
+    /**
+     * The load factor used when none is specified in the constructor.
+     */
+    public static final float DEFAULT_LOAD_FACTOR = 0.67f;
+
+    /**
+     * The initial capacity used when none is specified in the constructor.
+     */
+    @DoNotSub public static final int DEFAULT_INITIAL_CAPACITY = 8;
+
+    private final float loadFactor;
+    //Using the missingValue variable name rather than null to make the code less obtuse
+    private static final Object missingValue = null;
+    @DoNotSub private int resizeThreshold;
+    @DoNotSub private int size;
+
+    private T[] values;
+    private final ObjIterator<T> iterator;
+    private IntConsumer resizeNotifier;
+
+    public ObjHashSet()
+    {
+        this(DEFAULT_INITIAL_CAPACITY);
+    }
+
+    public ObjHashSet(
+        @DoNotSub final int proposedCapacity)
+    {
+        this(proposedCapacity, DEFAULT_LOAD_FACTOR);
+    }
+
+    public ObjHashSet(
+        @DoNotSub final int initialCapacity,
+        final float loadFactor)
+    {
+        validateLoadFactor(loadFactor);
+
+        this.loadFactor = loadFactor;
+        size = 0;
+        @DoNotSub final int capacity = BitUtil.findNextPositivePowerOfTwo(initialCapacity);
+        resizeThreshold = (int)(capacity * loadFactor); // @DoNotSub
+        values = (T[])new Object[capacity];
+        Arrays.fill(values, missingValue);
+
+        // NB: references values in the constructor, so must be assigned after values
+        iterator = new ObjHashSetIterator(values);
+    }
+
+    public void setReziseNotifier(IntConsumer resizeNotifier){
+        this.resizeNotifier = resizeNotifier;
+    }
+    /**
+     * @param value the value to add
+     * @return true if the collection has changed, false otherwise
+     * @throws NullPointerException if the value is null
+     */
+    public boolean add(final T value)
+    {
+        Objects.requireNonNull(value);
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+        @DoNotSub int index = value.hashCode() & mask;
+
+        while (values[index] != missingValue)
+        {
+            if (values[index].equals(value))
+            {
+                return false;
+            }
+
+            index = next(index, mask);
+        }
+
+        values[index] = value;
+        size++;
+
+        if (size > resizeThreshold)
+        {
+            increaseCapacity();
+            if(resizeNotifier!=null)
+                resizeNotifier.accept(resizeThreshold);
+        }
+
+        return true;
+    }
+
+    private void increaseCapacity()
+    {
+        @DoNotSub final int newCapacity = values.length * 2;
+        if (newCapacity < 0)
+        {
+            throw new IllegalStateException("Max capacity reached at size=" + size);
+        }
+
+        rehash(newCapacity);
+    }
+
+    private void rehash(@DoNotSub final int newCapacity)
+    {
+        @DoNotSub final int capacity = newCapacity;
+        @DoNotSub final int mask = newCapacity - 1;
+        resizeThreshold = (int)(newCapacity * loadFactor); // @DoNotSub
+
+        final T[] tempValues = (T[])new Object[capacity];
+        Arrays.fill(tempValues, missingValue);
+
+        for (final T value : values)
+        {
+            if (value != missingValue)
+            {
+                @DoNotSub int newHash = value.hashCode() & mask;
+                while (tempValues[newHash] != missingValue)
+                {
+                    newHash = ++newHash & mask;
+                }
+
+                tempValues[newHash] = value;
+            }
+        }
+
+        values = tempValues;
+    }
+
+    /**
+     * An int specialised version of {this#remove(Object)}.
+     *
+     * @param value the value to remove
+     * @return true if the value was present, false otherwise
+     */
+    @Override
+    public boolean remove(final Object value)
+    {
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+        @DoNotSub int index = value.hashCode() & mask;
+
+        while (values[index] != missingValue)
+        {
+            if (values[index].equals(value))
+            {
+                values[index] = (T)missingValue;
+                compactChain(index);
+                size--;
+                return true;
+            }
+
+            index = next(index, mask);
+        }
+
+        return false;
+    }
+
+    @DoNotSub private static int next(final int index, final int mask)
+    {
+        return (index + 1) & mask;
+    }
+
+    @DoNotSub void compactChain(int deleteIndex)
+    {
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+
+        @DoNotSub int index = deleteIndex;
+        while (true)
+        {
+            index = next(index, mask);
+            if (values[index] == missingValue)
+            {
+                return;
+            }
+
+            @DoNotSub final int hash = values[index].hashCode() &mask;
+
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index)) ||
+                (hash <= deleteIndex && deleteIndex <= index))
+            {
+                values[deleteIndex] = values[index];
+
+                values[index] = (T)missingValue;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    /**
+     * Compact the backing arrays by rehashing with a capacity just larger than current size
+     * and giving consideration to the load factor.
+     */
+    public void compact()
+    {
+        @DoNotSub final int idealCapacity = (int)Math.round(size() * (1.0 / loadFactor));
+        rehash(BitUtil.findNextPositivePowerOfTwo(idealCapacity));
+    }
+
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean contains(final Object value)
+    {
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+        @DoNotSub int index = value.hashCode()& mask;
+
+        while (values[index] != missingValue)
+        {
+            if (values[index].equals(value))
+            {
+                return true;
+            }
+
+            index = next(index, mask);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @DoNotSub public int size()
+    {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty()
+    {
+        return size == 0;
+    }
+
+    /**
+     * Get the load factor beyond which the set will increase size.
+     *
+     * @return load factor for when the set should increase size.
+     */
+    public float loadFactor()
+    {
+        return loadFactor;
+    }
+
+    /**
+     * Get the total capacity for the set to which the load factor with be a fraction of.
+     *
+     * @return the total capacity for the set.
+     */
+    public int capacity()
+    {
+        return values.length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear()
+    {
+        Arrays.fill(values, missingValue);
+        size = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsAll(final Collection<?> coll)
+    {
+        Objects.requireNonNull(coll);
+
+        for (final Object t : coll)
+        {
+            if (!contains(t))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public boolean addAll(final Collection<? extends T> coll) {
+        return disjunction(coll, this::add);
+    }
+
+    /**
+     * Fast Path set difference for comparison with another ObjHashSet.
+     * <p>
+     * NB: garbage free in the identical case, allocates otherwise.
+     *
+     * @param other the other set to subtract
+     * @return null if identical, otherwise the set of differences
+     */
+    public ObjHashSet difference(final ObjHashSet other)
+    {
+        Objects.requireNonNull(other);
+
+        ObjHashSet difference = null;
+
+        for (final T value : values)
+        {
+            if (value != missingValue && !other.contains(value))
+            {
+                if (difference == null)
+                {
+                    difference = new ObjHashSet(size);
+                }
+
+                difference.add(value);
+            }
+        }
+
+        return difference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean removeAll(final Collection<?> coll)
+    {
+        return disjunction(coll, this::remove);
+    }
+
+    private static <T> boolean disjunction(final Collection<T> coll, final Predicate<T> predicate)
+    {
+        Objects.requireNonNull(coll);
+
+        boolean acc = false;
+        for (final T t : coll)
+        {
+            // Deliberate strict evaluation
+            acc |= predicate.test(t);
+        }
+
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ObjIterator iterator()
+    {
+        iterator.reset();
+
+        return iterator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void copy(final ObjHashSet that)
+    {
+        if (this.values.length != that.values.length)
+        {
+            throw new IllegalArgumentException("Cannot copy object: masks not equal");
+        }
+
+        if (this.missingValue != that.missingValue)
+        {
+            throw new IllegalArgumentException("Cannot copy object: missingValues not equal");
+        }
+
+        System.arraycopy(that.values, 0, this.values, 0, this.values.length);
+        this.size = that.size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString()
+    {
+        return
+            stream()
+            .map((x) -> x.toString())
+            .collect(joining(",", "{", "}"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] into)
+    {
+        Objects.requireNonNull(into, "into");
+
+        final Class<?> componentType = into.getClass().getComponentType();
+
+        @DoNotSub final int size = this.size;
+        final T[] arrayCopy = into.length >= size ? into : (T[])Array.newInstance(componentType, size);
+        copyValues(arrayCopy);
+
+        return arrayCopy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object[] toArray()
+    {
+        final Object[] arrayCopy = new Object[size];
+        copyValues(arrayCopy);
+
+        return arrayCopy;
+    }
+
+    private void copyValues(final Object[] arrayCopy)
+    {
+        final ObjIterator iterator = iterator();
+        for (@DoNotSub int i = 0; iterator.hasNext(); i++)
+        {
+            arrayCopy[i] = iterator.next();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object other)
+    {
+        if (other == this)
+        {
+            return true;
+        }
+
+        if (other instanceof ObjHashSet)
+        {
+            final ObjHashSet otherSet = (ObjHashSet)other;
+
+            return otherSet.size == size
+                && containsAll(otherSet);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @DoNotSub public int hashCode()
+    {
+        return Arrays.hashCode(values);
+    }
+
+    private final class ObjHashSetIterator extends ObjIterator
+    {
+        private ObjHashSetIterator(final T[] values)
+        {
+            super(values);
+        }
+
+        public void remove()
+        {
+            if (isPositionValid)
+            {
+                @DoNotSub final int position = position();
+                values[position] = (T)missingValue;
+                --size;
+
+                compactChain(position);
+
+                isPositionValid = false;
+            }
+            else
+            {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    // --- Unimplemented below here
+
+    public boolean retainAll(final Collection<?> coll)
+    {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/src/main/java/org/agrona/collections/ObjHashSet.java
+++ b/src/main/java/org/agrona/collections/ObjHashSet.java
@@ -31,8 +31,9 @@ import static org.agrona.collections.CollectionUtil.validateLoadFactor;
 
 /**
  * Open-addressing with linear-probing expandable hash set. Allocation free in steady state use when expanded.
+ * Ability to be notified when resizing occurs so that appropriate sizing can be implemented.
  * <p>
-  * Not Threadsafe.
+ * Not Threadsafe.
  * <p>
  * This HashSet caches its iterator object, so nested iteration is not supported.
  *
@@ -89,6 +90,10 @@ public final class ObjHashSet<T> implements Set<T>
         iterator = new ObjHashSetIterator(values);
     }
 
+    /**
+     * Add a Consumer that will be called when the collection is resized.
+     * @param resizeNotifier IntConsumer containing the new resizeThreshold
+     */
     public void setReziseNotifier(IntConsumer resizeNotifier){
         this.resizeNotifier = resizeNotifier;
     }
@@ -165,8 +170,6 @@ public final class ObjHashSet<T> implements Set<T>
     }
 
     /**
-     * An int specialised version of {this#remove(Object)}.
-     *
      * @param value the value to remove
      * @return true if the value was present, false otherwise
      */
@@ -234,8 +237,6 @@ public final class ObjHashSet<T> implements Set<T>
         @DoNotSub final int idealCapacity = (int)Math.round(size() * (1.0 / loadFactor));
         rehash(BitUtil.findNextPositivePowerOfTwo(idealCapacity));
     }
-
-
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/agrona/collections/ObjIterator.java
+++ b/src/main/java/org/agrona/collections/ObjIterator.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.agrona.generation.DoNotSub;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator for a sequence of primitive values.
+ */
+public class ObjIterator<T> implements Iterator<T>
+{
+    private static final Object missingValue = null;
+    @DoNotSub private int positionCounter;
+    @DoNotSub private int stopCounter;
+    protected boolean isPositionValid = false;
+    private T[] values;
+
+    /**
+     * Construct an {@link Iterator} over an array of primitives ints.
+     *
+     * @param values       to iterate over.
+     */
+    public ObjIterator(final T[] values)
+    {
+        reset(values);
+    }
+
+    /**
+     * Reset methods for fixed size collections.
+     */
+    void reset()
+    {
+        reset(values);
+    }
+
+    /**
+     * Reset method for expandable collections.
+     *
+     * @param values to be iterated over
+     */
+    void reset(final T[] values)
+    {
+        this.values = values;
+        @DoNotSub final int length = values.length;
+
+        @DoNotSub int i = length;
+        if (values[length - 1] != missingValue)
+        {
+            i = 0;
+            for (@DoNotSub int size = length; i < size; i++)
+            {
+                if (values[i] == missingValue)
+                {
+                    break;
+                }
+            }
+        }
+
+        stopCounter = i;
+        positionCounter = i + length;
+        isPositionValid = false;
+    }
+
+    @DoNotSub protected int position()
+    {
+        return positionCounter & (values.length - 1);
+    }
+
+    public boolean hasNext()
+    {
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+
+        for (@DoNotSub int i = positionCounter - 1; i >= stopCounter; i--)
+        {
+            @DoNotSub final int index = i & mask;
+            if (values[index] != missingValue)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected void findNext()
+    {
+        final T[] values = this.values;
+        @DoNotSub final int mask = values.length - 1;
+        isPositionValid = false;
+
+        for (@DoNotSub int i = positionCounter - 1; i >= stopCounter; i--)
+        {
+            @DoNotSub final int index = i & mask;
+            if (values[index] != missingValue)
+            {
+                positionCounter = i;
+                isPositionValid = true;
+                return;
+            }
+        }
+
+        throw new NoSuchElementException();
+    }
+
+    public T next()
+    {
+        return nextValue();
+    }
+
+    /**
+     * Strongly typed alternative of {@link Iterator#next()} not to avoid boxing.
+     *
+     * @return the next int value.
+     */
+    public T nextValue()
+    {
+        findNext();
+
+        return values[position()];
+    }
+}

--- a/src/main/java/org/agrona/collections/ObjIterator.java
+++ b/src/main/java/org/agrona/collections/ObjIterator.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * An iterator for a sequence of primitive values.
+ * An iterator for a sequence of values.
  */
 public class ObjIterator<T> implements Iterator<T>
 {
@@ -32,7 +32,7 @@ public class ObjIterator<T> implements Iterator<T>
     private T[] values;
 
     /**
-     * Construct an {@link Iterator} over an array of primitives ints.
+     * Construct an {@link Iterator} over an array of values.
      *
      * @param values       to iterate over.
      */
@@ -125,8 +125,6 @@ public class ObjIterator<T> implements Iterator<T>
     }
 
     /**
-     * Strongly typed alternative of {@link Iterator#next()} not to avoid boxing.
-     *
      * @return the next int value.
      */
     public T nextValue()

--- a/src/test/java/org/agrona/collections/ObjHashSetTest.java
+++ b/src/test/java/org/agrona/collections/ObjHashSetTest.java
@@ -1,0 +1,608 @@
+/*
+ *  Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class ObjHashSetTest
+{
+    private static final int INITIAL_CAPACITY = 100;
+
+    private final ObjHashSet<Integer> testSet = new ObjHashSet(INITIAL_CAPACITY);
+
+    @Test
+    public void initiallyContainsNoElements() throws Exception
+    {
+        for (int i = 0; i < 10_000; i++)
+        {
+            assertFalse(testSet.contains(i));
+        }
+    }
+
+    @Test
+    public void initiallyContainsNoBoxedElements()
+    {
+        for (int i = 0; i < 10_000; i++)
+        {
+            assertFalse(testSet.contains(Integer.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void containsAddedElement()
+    {
+        assertTrue(testSet.add(1));
+
+        assertTrue(testSet.contains(1));
+    }
+
+    @Test
+    public void addingAnElementTwiceDoesNothing()
+    {
+        assertTrue(testSet.add(1));
+
+        assertFalse(testSet.add(1));
+    }
+
+    @Test
+    public void containsAddedBoxedElements()
+    {
+        assertTrue(testSet.add(1));
+        assertTrue(testSet.add(Integer.valueOf(2)));
+
+        assertTrue(testSet.contains(Integer.valueOf(1)));
+        assertTrue(testSet.contains(2));
+    }
+
+    @Test
+    public void doesNotContainMissingValue()
+    {
+        assertFalse(testSet.contains(2048));
+    }
+
+    @Test
+    public void removingAnElementFromAnEmptyListDoesNothing()
+    {
+        assertFalse(testSet.remove(0));
+    }
+
+    @Test
+    public void removingAPresentElementRemovesIt()
+    {
+        assertTrue(testSet.add(1));
+
+        assertTrue(testSet.remove(1));
+
+        assertFalse(testSet.contains(1));
+    }
+
+    @Test
+    public void sizeIsInitiallyZero()
+    {
+        assertEquals(0, testSet.size());
+    }
+
+    @Test
+    public void sizeIncrementsWithNumberOfAddedElements()
+    {
+        addTwoElements(testSet);
+
+        assertEquals(2, testSet.size());
+    }
+
+    @Test
+    public void sizeContainsNumberOfNewElements()
+    {
+        testSet.add(1);
+        testSet.add(1);
+
+        assertEquals(1, testSet.size());
+    }
+
+    @Test
+    public void iteratorsListElements()
+    {
+        addTwoElements(testSet);
+
+        assertIteratorHasElements();
+    }
+
+    @Test
+    public void iteratorsStartFromTheBeginningEveryTime()
+    {
+        iteratorsListElements();
+
+        assertIteratorHasElements();
+    }
+
+    @Test
+    public void iteratorsListElementsWithoutHasNext()
+    {
+        addTwoElements(testSet);
+
+        assertIteratorHasElementsWithoutHasNext();
+    }
+
+    @Test
+    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
+    {
+        iteratorsListElementsWithoutHasNext();
+
+        assertIteratorHasElementsWithoutHasNext();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorsThrowNoSuchElementException()
+    {
+        addTwoElements(testSet);
+
+        exhaustIterator();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
+    {
+        addTwoElements(testSet);
+
+        try
+        {
+            exhaustIterator();
+        }
+        catch (final NoSuchElementException ignore)
+        {
+        }
+
+        exhaustIterator();
+    }
+
+    @Test
+    public void iteratorHasNoElements()
+    {
+        assertFalse(testSet.iterator().hasNext());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorThrowExceptionForEmptySet()
+    {
+        testSet.iterator().next();
+    }
+
+    @Test
+    public void clearRemovesAllElementsOfTheSet()
+    {
+        addTwoElements(testSet);
+
+        testSet.clear();
+
+        assertEquals(0, testSet.size());
+        assertFalse(testSet.contains(1));
+        assertFalse(testSet.contains(1001));
+    }
+
+    @Test
+    public void differenceReturnsNullIfBothSetsEqual()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+        addTwoElements(other);
+
+        assertNull(testSet.difference(other));
+    }
+
+    @Test
+    public void differenceReturnsSetDifference()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+        other.add(1);
+
+        final ObjHashSet<Integer> diff = testSet.difference(other);
+        assertThat(diff, containsInAnyOrder(1001));
+    }
+
+    @Test
+    public void copiesOtherIntHashSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+        other.copy(testSet);
+
+        assertContainsElements(other);
+    }
+
+    @Test
+    public void twoEmptySetsAreEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+        assertEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheSameValuesAreEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+        addTwoElements(other);
+
+        assertEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheDifferentSizesAreNotEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        other.add(1001);
+
+        assertNotEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheDifferentValuesAreNotEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        other.add(2);
+        other.add(1001);
+
+        assertNotEquals(testSet, other);
+    }
+
+    @Test
+    public void twoEmptySetsHaveTheSameHashcode()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+        assertEquals(testSet.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void setsWithTheSameValuesHaveTheSameHashcode()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        addTwoElements(other);
+
+        assertEquals(testSet.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void reducesSizeWhenElementRemoved()
+    {
+        addTwoElements(testSet);
+
+        testSet.remove(1001);
+
+        assertEquals(1, testSet.size());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toArrayThrowsNullPointerExceptionForNullArgument()
+    {
+        testSet.toArray(null);
+    }
+
+    @Test
+    public void toArrayCopiesElementsIntoSufficientlySizedArray()
+    {
+        addTwoElements(testSet);
+
+        final Integer[] result = (Integer[])testSet.toArray(new Integer[testSet.size()]);
+
+        assertArrayContainingElements(result);
+    }
+
+    @Test
+    public void toArrayCopiesElementsIntoNewArray()
+    {
+        addTwoElements(testSet);
+
+        final Integer[] result = (Integer[])testSet.toArray(new Integer[testSet.size()]);
+
+        assertArrayContainingElements(result);
+    }
+
+    @Test
+    public void toArraySupportsEmptyCollection()
+    {
+        final Integer[] result = (Integer[])testSet.toArray(new Integer[testSet.size()]);
+
+        assertArrayEquals(result, new Integer[]{});
+    }
+
+    // Test case from usage bug.
+    @Test
+    public void chainCompactionShouldNotCauseElementsToBeMovedBeforeTheirHash()
+    {
+        final ObjHashSet<Integer> requiredFields = new ObjHashSet(14);
+
+        requiredFields.add(8);
+        requiredFields.add(9);
+        requiredFields.add(35);
+        requiredFields.add(49);
+        requiredFields.add(56);
+
+        assertTrue("Failed to remove 8", requiredFields.remove(8));
+        assertTrue("Failed to remove 9", requiredFields.remove(9));
+
+        assertThat(requiredFields, containsInAnyOrder(35, 49, 56));
+    }
+
+    @Test
+    public void shouldResizeWhenItHitsCapacity()
+    {
+        for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
+        {
+            assertTrue(testSet.add(i));
+        }
+
+        for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
+        {
+            assertTrue(testSet.contains(i));
+        }
+    }
+
+    @Test
+    public void containsEmptySet()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        assertTrue(testSet.containsAll(other));
+        assertTrue(testSet.containsAll((Collection<?>)other));
+    }
+
+    @Test
+    public void containsSubset()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet subset = new ObjHashSet(100);
+
+        subset.add(1);
+
+        assertTrue(testSet.containsAll(subset));
+        assertTrue(testSet.containsAll((Collection<?>)subset));
+    }
+
+    @Test
+    public void doesNotContainDisjointSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+
+        other.add(1);
+        other.add(1002);
+
+        assertFalse(testSet.containsAll(other));
+        assertFalse(testSet.containsAll((Collection<?>)other));
+    }
+
+    @Test
+    public void doesNotContainSuperset()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet superset = new ObjHashSet(100);
+
+        addTwoElements(superset);
+        superset.add(15);
+
+        assertFalse(testSet.containsAll(superset));
+        assertFalse(testSet.containsAll((Collection<?>)superset));
+    }
+
+    @Test
+    public void addingEmptySetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        assertFalse(testSet.addAll(new ObjHashSet(100)));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void addingSubsetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet subset = new ObjHashSet(100);
+
+        subset.add(1);
+
+        assertFalse(testSet.addAll(subset));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void addingEqualSetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet equal = new ObjHashSet(100);
+
+        addTwoElements(equal);
+
+        assertFalse(testSet.addAll(equal));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void containsValuesAddedFromDisjointSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet disjoint = new ObjHashSet(100);
+
+        disjoint.add(2);
+        disjoint.add(1002);
+
+        assertTrue(testSet.addAll(disjoint));
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(1001));
+        assertTrue(testSet.containsAll(disjoint));
+    }
+
+    @Test
+    public void containsValuesAddedFromIntersectingSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet intersecting = new ObjHashSet(100);
+
+        intersecting.add(1);
+        intersecting.add(1002);
+
+        assertTrue(testSet.addAll(intersecting));
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(1001));
+        assertTrue(testSet.containsAll(intersecting));
+    }
+
+    @Test
+    public void removingEmptySetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        assertFalse(testSet.removeAll(new ObjHashSet(100)));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void removingDisjointSetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet disjoint = new ObjHashSet(100);
+
+        disjoint.add(2);
+        disjoint.add(1002);
+
+        assertFalse(testSet.removeAll(disjoint));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void doesNotContainRemovedIntersectingSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet intersecting = new ObjHashSet(100);
+
+        intersecting.add(1);
+        intersecting.add(1002);
+
+        assertTrue(testSet.removeAll(intersecting));
+        assertTrue(testSet.contains(1001));
+        assertFalse(testSet.containsAll(intersecting));
+    }
+
+    @Test
+    public void isEmptyAfterRemovingEqualSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet equal = new ObjHashSet(100);
+
+        addTwoElements(equal);
+
+        assertTrue(testSet.removeAll(equal));
+        assertTrue(testSet.isEmpty());
+    }
+
+    @Test
+    public void removeElementsFromIterator()
+    {
+        addTwoElements(testSet);
+
+        final ObjIterator intIterator = testSet.iterator();
+        while (intIterator.hasNext())
+        {
+            if (intIterator.nextValue().equals(1))
+            {
+                intIterator.remove();
+            }
+        }
+
+        assertThat(testSet, contains(1001));
+        assertThat(testSet, hasSize(1));
+    }
+
+    private static void addTwoElements(final ObjHashSet obj)
+    {
+        obj.add(1);
+        obj.add(1001);
+    }
+
+    private void assertIteratorHasElements()
+    {
+        final Iterator<Integer> iter = testSet.iterator();
+
+        final Set<Integer> values = new HashSet<>();
+
+        assertTrue(iter.hasNext());
+        values.add(iter.next());
+        assertTrue(iter.hasNext());
+        values.add(iter.next());
+        assertFalse(iter.hasNext());
+
+        assertContainsElements(values);
+    }
+
+    private void assertIteratorHasElementsWithoutHasNext()
+    {
+        final Iterator<Integer> iter = testSet.iterator();
+
+        final Set<Integer> values = new HashSet<>();
+
+        values.add(iter.next());
+        values.add(iter.next());
+
+        assertContainsElements(values);
+    }
+
+    private static void assertArrayContainingElements(final Integer[] result)
+    {
+        assertThat(result, arrayContainingInAnyOrder(1, 1001));
+    }
+
+    private static void assertContainsElements(final Set<Integer> other)
+    {
+        assertThat(other, containsInAnyOrder(1, 1001));
+    }
+
+    private void exhaustIterator()
+    {
+        final ObjIterator iterator = testSet.iterator();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+    }
+}

--- a/src/test/java/org/agrona/collections/ObjHashSetTestInteger.java
+++ b/src/test/java/org/agrona/collections/ObjHashSetTestInteger.java
@@ -22,7 +22,7 @@ import java.util.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-public class ObjHashSetTest
+public class ObjHashSetTestInteger
 {
     private static final int INITIAL_CAPACITY = 100;
 

--- a/src/test/java/org/agrona/collections/ObjHashSetTestString.java
+++ b/src/test/java/org/agrona/collections/ObjHashSetTestString.java
@@ -1,0 +1,608 @@
+/*
+ *  Copyright 2014 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class ObjHashSetTestString
+{
+    private static final int INITIAL_CAPACITY = 100;
+
+    private final ObjHashSet<String> testSet = new ObjHashSet(INITIAL_CAPACITY);
+
+    @Test
+    public void initiallyContainsNoElements() throws Exception
+    {
+        for (int i = 0; i < 10_000; i++)
+        {
+            assertFalse(testSet.contains(i));
+        }
+    }
+
+    @Test
+    public void initiallyContainsNoBoxedElements()
+    {
+        for (int i = 0; i < 10_000; i++)
+        {
+            assertFalse(testSet.contains(Integer.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void containsAddedElement()
+    {
+        assertTrue(testSet.add("1"));
+
+        assertTrue(testSet.contains("1"));
+    }
+
+    @Test
+    public void addingAnElementTwiceDoesNothing()
+    {
+        assertTrue(testSet.add("1"));
+
+        assertFalse(testSet.add("1"));
+    }
+
+    @Test
+    public void containsAddedBoxedElements()
+    {
+        assertTrue(testSet.add("1"));
+        assertTrue(testSet.add("2"));
+
+        assertTrue(testSet.contains("1"));
+        assertTrue(testSet.contains("2"));
+    }
+
+    @Test
+    public void doesNotContainMissingValue()
+    {
+        assertFalse(testSet.contains(2048));
+    }
+
+    @Test
+    public void removingAnElementFromAnEmptyListDoesNothing()
+    {
+        assertFalse(testSet.remove(0));
+    }
+
+    @Test
+    public void removingAPresentElementRemovesIt()
+    {
+        assertTrue(testSet.add("1"));
+
+        assertTrue(testSet.remove("1"));
+
+        assertFalse(testSet.contains("1"));
+    }
+
+    @Test
+    public void sizeIsInitiallyZero()
+    {
+        assertEquals(0, testSet.size());
+    }
+
+    @Test
+    public void sizeIncrementsWithNumberOfAddedElements()
+    {
+        addTwoElements(testSet);
+
+        assertEquals(2, testSet.size());
+    }
+
+    @Test
+    public void sizeContainsNumberOfNewElements()
+    {
+        testSet.add("1");
+        testSet.add("1");
+
+        assertEquals(1, testSet.size());
+    }
+
+    @Test
+    public void iteratorsListElements()
+    {
+        addTwoElements(testSet);
+
+        assertIteratorHasElements();
+    }
+
+    @Test
+    public void iteratorsStartFromTheBeginningEveryTime()
+    {
+        iteratorsListElements();
+
+        assertIteratorHasElements();
+    }
+
+    @Test
+    public void iteratorsListElementsWithoutHasNext()
+    {
+        addTwoElements(testSet);
+
+        assertIteratorHasElementsWithoutHasNext();
+    }
+
+    @Test
+    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
+    {
+        iteratorsListElementsWithoutHasNext();
+
+        assertIteratorHasElementsWithoutHasNext();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorsThrowNoSuchElementException()
+    {
+        addTwoElements(testSet);
+
+        exhaustIterator();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
+    {
+        addTwoElements(testSet);
+
+        try
+        {
+            exhaustIterator();
+        }
+        catch (final NoSuchElementException ignore)
+        {
+        }
+
+        exhaustIterator();
+    }
+
+    @Test
+    public void iteratorHasNoElements()
+    {
+        assertFalse(testSet.iterator().hasNext());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void iteratorThrowExceptionForEmptySet()
+    {
+        testSet.iterator().next();
+    }
+
+    @Test
+    public void clearRemovesAllElementsOfTheSet()
+    {
+        addTwoElements(testSet);
+
+        testSet.clear();
+
+        assertEquals(0, testSet.size());
+        assertFalse(testSet.contains(1));
+        assertFalse(testSet.contains(1001));
+    }
+
+    @Test
+    public void differenceReturnsNullIfBothSetsEqual()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+        addTwoElements(other);
+
+        assertNull(testSet.difference(other));
+    }
+
+    @Test
+    public void differenceReturnsSetDifference()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> other = new ObjHashSet(100);
+        other.add("1");
+
+        final ObjHashSet<Integer> diff = testSet.difference(other);
+        assertThat(diff, containsInAnyOrder("1001"));
+    }
+
+    @Test
+    public void copiesOtherIntHashSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet other = new ObjHashSet(100);
+        other.copy(testSet);
+
+        assertContainsElements(other);
+    }
+
+    @Test
+    public void twoEmptySetsAreEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+        assertEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheSameValuesAreEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+        addTwoElements(other);
+
+        assertEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheDifferentSizesAreNotEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        other.add(1001);
+
+        assertNotEquals(testSet, other);
+    }
+
+    @Test
+    public void setsWithTheDifferentValuesAreNotEqual()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        other.add(2);
+        other.add(1001);
+
+        assertNotEquals(testSet, other);
+    }
+
+    @Test
+    public void twoEmptySetsHaveTheSameHashcode()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+        assertEquals(testSet.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void setsWithTheSameValuesHaveTheSameHashcode()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        addTwoElements(testSet);
+
+        addTwoElements(other);
+
+        assertEquals(testSet.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void reducesSizeWhenElementRemoved()
+    {
+        addTwoElements(testSet);
+
+        testSet.remove("1001");
+
+        assertEquals(1, testSet.size());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toArrayThrowsNullPointerExceptionForNullArgument()
+    {
+        testSet.toArray(null);
+    }
+
+    @Test
+    public void toArrayCopiesElementsIntoSufficientlySizedArray()
+    {
+        addTwoElements(testSet);
+
+        final String[] result = (String[])testSet.toArray(new String[testSet.size()]);
+
+        assertArrayContainingElements(result);
+    }
+
+    @Test
+    public void toArrayCopiesElementsIntoNewArray()
+    {
+        addTwoElements(testSet);
+
+        final String[] result = (String[])testSet.toArray(new String[testSet.size()]);
+
+        assertArrayContainingElements(result);
+    }
+
+    @Test
+    public void toArraySupportsEmptyCollection()
+    {
+        final String[] result = (String[])testSet.toArray(new String[testSet.size()]);
+
+        assertArrayEquals(result, new Integer[]{});
+    }
+
+    // Test case from usage bug.
+    @Test
+    public void chainCompactionShouldNotCauseElementsToBeMovedBeforeTheirHash()
+    {
+        final ObjHashSet<String> requiredFields = new ObjHashSet(14);
+
+        requiredFields.add("8");
+        requiredFields.add("9");
+        requiredFields.add("35");
+        requiredFields.add("49");
+        requiredFields.add("56");
+
+        assertTrue("Failed to remove 8", requiredFields.remove("8"));
+        assertTrue("Failed to remove 9", requiredFields.remove("9"));
+
+        assertThat(requiredFields, containsInAnyOrder("35", "49", "56"));
+    }
+
+    @Test
+    public void shouldResizeWhenItHitsCapacity()
+    {
+        for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
+        {
+            assertTrue(testSet.add(String.valueOf(i)));
+        }
+
+        for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
+        {
+            assertTrue(testSet.contains(String.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void containsEmptySet()
+    {
+        final ObjHashSet other = new ObjHashSet(100);
+
+        assertTrue(testSet.containsAll(other));
+        assertTrue(testSet.containsAll((Collection<?>)other));
+    }
+
+    @Test
+    public void containsSubset()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> subset = new ObjHashSet(100);
+
+        subset.add("1");
+
+        assertTrue(testSet.containsAll(subset));
+        assertTrue(testSet.containsAll((Collection<?>)subset));
+    }
+
+    @Test
+    public void doesNotContainDisjointSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> other = new ObjHashSet(100);
+
+        other.add("1");
+        other.add("1002");
+
+        assertFalse(testSet.containsAll(other));
+        assertFalse(testSet.containsAll((Collection<?>)other));
+    }
+
+    @Test
+    public void doesNotContainSuperset()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> superset = new ObjHashSet(100);
+
+        addTwoElements(superset);
+        superset.add("15");
+
+        assertFalse(testSet.containsAll(superset));
+        assertFalse(testSet.containsAll((Collection<?>)superset));
+    }
+
+    @Test
+    public void addingEmptySetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        assertFalse(testSet.addAll(new ObjHashSet(100)));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void addingSubsetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> subset = new ObjHashSet(100);
+
+        subset.add("1");
+
+        assertFalse(testSet.addAll(subset));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void addingEqualSetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> equal = new ObjHashSet(100);
+
+        addTwoElements(equal);
+
+        assertFalse(testSet.addAll(equal));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void containsValuesAddedFromDisjointSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> disjoint = new ObjHashSet(100);
+
+        disjoint.add("2");
+        disjoint.add("1002");
+
+        assertTrue(testSet.addAll(disjoint));
+        assertTrue(testSet.contains("1"));
+        assertTrue(testSet.contains("1001"));
+        assertTrue(testSet.containsAll(disjoint));
+    }
+
+    @Test
+    public void containsValuesAddedFromIntersectingSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> intersecting = new ObjHashSet(100);
+
+        intersecting.add("1");
+        intersecting.add("1002");
+
+        assertTrue(testSet.addAll(intersecting));
+        assertTrue(testSet.contains("1"));
+        assertTrue(testSet.contains("1001"));
+        assertTrue(testSet.containsAll(intersecting));
+    }
+
+    @Test
+    public void removingEmptySetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        assertFalse(testSet.removeAll(new ObjHashSet(100)));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void removingDisjointSetDoesNothing()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> disjoint = new ObjHashSet(100);
+
+        disjoint.add("2");
+        disjoint.add("1002");
+
+        assertFalse(testSet.removeAll(disjoint));
+        assertContainsElements(testSet);
+    }
+
+    @Test
+    public void doesNotContainRemovedIntersectingSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> intersecting = new ObjHashSet(100);
+
+        intersecting.add("1");
+        intersecting.add("1002");
+
+        assertTrue(testSet.removeAll(intersecting));
+        assertTrue(testSet.contains("1001"));
+        assertFalse(testSet.containsAll(intersecting));
+    }
+
+    @Test
+    public void isEmptyAfterRemovingEqualSet()
+    {
+        addTwoElements(testSet);
+
+        final ObjHashSet<String> equal = new ObjHashSet(100);
+
+        addTwoElements(equal);
+
+        assertTrue(testSet.removeAll(equal));
+        assertTrue(testSet.isEmpty());
+    }
+
+    @Test
+    public void removeElementsFromIterator()
+    {
+        addTwoElements(testSet);
+
+        final ObjIterator<String> intIterator = testSet.iterator();
+        while (intIterator.hasNext())
+        {
+            if (intIterator.nextValue().equals("1"))
+            {
+                intIterator.remove();
+            }
+        }
+
+        assertThat(testSet, contains("1001"));
+        assertThat(testSet, hasSize(1));
+    }
+
+    private static void addTwoElements(final ObjHashSet<String> obj)
+    {
+        obj.add("1");
+        obj.add("1001");
+    }
+
+    private void assertIteratorHasElements()
+    {
+        final Iterator<String> iter = testSet.iterator();
+
+        final Set<String> values = new HashSet<>();
+
+        assertTrue(iter.hasNext());
+        values.add(iter.next());
+        assertTrue(iter.hasNext());
+        values.add(iter.next());
+        assertFalse(iter.hasNext());
+
+        assertContainsElements(values);
+    }
+
+    private void assertIteratorHasElementsWithoutHasNext()
+    {
+        final Iterator<String> iter = testSet.iterator();
+
+        final Set<String> values = new HashSet<>();
+
+        values.add(iter.next());
+        values.add(iter.next());
+
+        assertContainsElements(values);
+    }
+
+    private static void assertArrayContainingElements(final String[] result)
+    {
+        assertThat(result, arrayContainingInAnyOrder("1", "1001"));
+    }
+
+    private static void assertContainsElements(final Set<String> other)
+    {
+        assertThat(other, containsInAnyOrder("1", "1001"));
+    }
+
+    private void exhaustIterator()
+    {
+        final ObjIterator iterator = testSet.iterator();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+    }
+}


### PR DESCRIPTION
This is a new `Set` implementation for `Object`s.  It is based on the `IntHashSet` but takes `Object`s rather than primitives.

Like `IntHashSet` (unlike `HashSet` based on `HashMap`) it is suitable for environments where allocation is not an option.

One thing I have added is a ability to be notified when the collection is resized.  The idea is that a warning could be implemented during testing allowing appropriate capacity to be set in the constructor so that when deployed for real there should be no need for resizing.

I have added 2 test classes, again based on the tests written for `IntHashSet`.

Please review and if you think it will enhance the library please add.

Daniel