### PR TITLE
Added Gradle OSGi plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'checkstyle'
 apply plugin: 'eclipse'
+apply plugin: 'osgi'
 
 defaultTasks 'clean', 'build', 'install'
 


### PR DESCRIPTION
This ensures that OSGi compatible meta data is generated and added to
the jar's manifest. So the artifact can be used as OSGi bundle in an
OSGi container.

This is analogous to the pull request I created for the Aeron project. As Aeron depends on Agrona, Agrona should support OSGi, too.