### PR TITLE
[Java] Fixed size message Broadcast Buffer + tests

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastBufferDescriptor.java
+++ b/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastBufferDescriptor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.BitUtil;
+
+/**
+ * Layout of the broadcast buffer. The buffer consists of a ring of fixed size messages that is a power of 2 in size
+ * multiplied for the configured record size obtained by {@link RecordDescriptor#calculateRecordSize(int)}.
+ * This is followed by a trailer section containing state information about the ring.
+ */
+public class BroadcastBufferDescriptor
+{
+    /**
+     * Offset within the trailer for where the latest sequence value is stored.
+     */
+    public static final int LATEST_COUNTER_OFFSET;
+
+    /**
+     * Offset within the trailer for where the record size value is stored.
+     */
+    public static final int RECORD_SIZE_OFFSET;
+
+    /**
+     * Total size of the trailer
+     */
+    public static final int TRAILER_LENGTH;
+
+    static
+    {
+        int offset = 0;
+        LATEST_COUNTER_OFFSET = offset;
+        offset += (BitUtil.CACHE_LINE_LENGTH * 2);
+        RECORD_SIZE_OFFSET = offset;
+        TRAILER_LENGTH = offset + BitUtil.CACHE_LINE_LENGTH * 2;
+    }
+
+    /**
+     * Check the buffer capacity is the correct size.
+     *
+     * @param maxMessageSize the maximum encoded message size
+     * @param capacity       to be checked.
+     * @throws IllegalStateException if the buffer capacity is not a power of 2
+     *                               multiple of {@link RecordDescriptor#calculateRecordSize(int)} of the given {@code maxMessageSize}.
+     */
+    public static void checkCapacity(final int maxMessageSize, final int capacity)
+    {
+        final int recordSize = RecordDescriptor.calculateRecordSize(maxMessageSize);
+        if (capacity % recordSize != 0)
+        {
+            final String msg = "Capacity must be a positive power of 2 multiple of " + recordSize +
+                " bytes + TRAILER_LENGTH: capacity=" + capacity;
+            throw new IllegalStateException(msg);
+        }
+        final int records = capacity / recordSize;
+        if (!BitUtil.isPowerOfTwo(records))
+        {
+            final String msg = "Capacity must be a positive power of 2 multiple of " + recordSize +
+                " bytes + TRAILER_LENGTH: capacity=" + capacity;
+            throw new IllegalStateException(msg);
+        }
+    }
+
+    /**
+     * Calculate the buffer capacity (excluding the {@link #TRAILER_LENGTH}).
+     *
+     * @param maxMessageSize the maximum encoded message size
+     * @param messages       the capacity in number of messages of the buffer
+     * @return the required capacity of the buffer
+     */
+    public static int calculateCapacity(final int maxMessageSize, final int messages)
+    {
+        return BitUtil.findNextPositivePowerOfTwo(messages) * RecordDescriptor.calculateRecordSize(maxMessageSize);
+    }
+
+
+}

--- a/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastReceiver.java
+++ b/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastReceiver.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.agrona.UnsafeAccess.UNSAFE;
+import static org.agrona.concurrent.broadcast.fixed.BroadcastBufferDescriptor.*;
+import static org.agrona.concurrent.broadcast.fixed.RecordDescriptor.*;
+
+/**
+ * Receive transmissions broadcast from a {@link BroadcastTransmitter} via an underlying buffer. Receivers can join
+ * a transmission stream at any point by consuming the latest transmission at the point of joining and forward.
+ * <p>
+ * If a Receiver cannot keep up with the transmission stream then loss will be experienced. Loss is not an
+ * error condition.
+ * <p>
+ * <b>Note:</b> Each Receiver is not threadsafe but there can be zero or many receivers to a transmission stream.
+ */
+public final class BroadcastReceiver
+{
+
+    public enum ReceiveReturnType
+    {
+        LOSS,
+        ANY_AVAILABLE,
+        NOT_AVAILABLE
+    }
+
+    private long cursor = 0;
+    private long nextRecord = 0;
+    private int recordOffset = 0;
+
+    private final int capacity;
+    private final int mask;
+    private final AtomicBuffer buffer;
+    private long lost = 0;
+    private final AtomicLong lostTransmissions = new AtomicLong();
+    private final int recordSize;
+    private final int latestCounterIndex;
+
+    /**
+     * Construct a new broadcast receiver based on an underlying {@link AtomicBuffer}.
+     * The underlying buffer must a power of 2 multiple of the recordSize
+     * written on {@link BroadcastBufferDescriptor#RECORD_SIZE_OFFSET} of the buffer.
+     *
+     * @param buffer via which transmissions will be exchanged.
+     * @throws IllegalStateException if the buffer capacity is not a power of 2 multiple of the recordSize
+     *                               read on {@link BroadcastBufferDescriptor#RECORD_SIZE_OFFSET} of the buffer
+     */
+    public BroadcastReceiver(final AtomicBuffer buffer)
+    {
+        this.buffer = buffer;
+        this.capacity = buffer.capacity() - TRAILER_LENGTH;
+        this.recordSize = buffer.getIntVolatile(this.capacity + RECORD_SIZE_OFFSET);
+        checkRecordSize(recordSize);
+        checkCapacity(calculateAvailableMessageLength(recordSize), capacity);
+        buffer.verifyAlignment();
+        final int transmissions = capacity / recordSize;
+        this.mask = transmissions - 1;
+        this.latestCounterIndex = this.capacity + LATEST_COUNTER_OFFSET;
+    }
+
+    /**
+     * @return The max size in bytes of a transmission (including any message header).
+     */
+    public int recordSize()
+    {
+        return recordSize;
+    }
+
+    /**
+     * Get the capacity of the underlying broadcast buffer.
+     *
+     * @return the capacity of the underlying broadcast buffer.
+     */
+    public int capacity()
+    {
+        return capacity;
+    }
+
+    /**
+     * The number of transmissions lost by this receiver.<p>
+     * This method's accuracy is subject to concurrent modifications happening, but it is safe to be
+     * called by any threads.
+     *
+     * @return the number of transmissions lost by this receiver
+     */
+    public long lostTransmissions()
+    {
+        return this.lostTransmissions.get();
+    }
+
+    /**
+     * Type of the message received.
+     *
+     * @return typeId of the message received.
+     */
+    public int typeId()
+    {
+        return buffer.getInt(typeOffset(recordOffset));
+    }
+
+    /**
+     * The offset for the beginning of the next transmission in the transmission stream.
+     *
+     * @return offset for the beginning of the next transmission in the transmission stream.
+     */
+    public int offset()
+    {
+        return msgOffset(recordOffset);
+    }
+
+    /**
+     * The length of the next transmission in the transmission stream.
+     *
+     * @return length of the next transmission in the transmission stream.
+     */
+    public int length()
+    {
+        return buffer.getInt(lengthOffset(recordOffset));
+    }
+
+    /**
+     * The underlying buffer containing the broadcast transmission stream.
+     *
+     * @return the underlying buffer containing the broadcast transmission stream.
+     */
+    public MutableDirectBuffer buffer()
+    {
+        return buffer;
+    }
+
+    /**
+     * Non-blocking receive of next transmission from the transmission stream.
+     * <p>
+     * If loss has occurred then {@link #lostTransmissions()} will be incremented.
+     *
+     * @return {@link ReceiveReturnType#ANY_AVAILABLE} if a transmission is available with {@link #offset()}, {@link #length()} and {@link #typeId()}
+     * set for the next transmission to be consumed. If no transmission is available {@link ReceiveReturnType#NOT_AVAILABLE} or {@link ReceiveReturnType#LOSS} if loss is experienced.
+     */
+    public ReceiveReturnType receiveNext()
+    {
+        final AtomicBuffer buffer = this.buffer;
+        final long cursor = this.nextRecord;
+        final int recordOffset = calculatedRecordOffset(cursor, mask, recordSize);
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+        final long sequence = buffer.getLongVolatile(sequenceIndicatorOffset);
+        final long expectedSequence = cursor + 1;
+        if (sequence == expectedSequence)
+        {
+            this.recordOffset = recordOffset;
+            this.cursor = cursor;
+            this.nextRecord = expectedSequence;
+            return ReceiveReturnType.ANY_AVAILABLE;
+        }
+        else
+        {
+            if (sequence > expectedSequence)
+            {
+                chase(cursor, sequence);
+                return ReceiveReturnType.LOSS;
+            }
+            return ReceiveReturnType.NOT_AVAILABLE;
+        }
+    }
+
+    /**
+     * It allows this receiver to keep up with the transmission by moving right after the last transmitted transmission.
+     * <p>
+     * To continue receive any new transmission is necessary to use {@link #receiveNext()}:
+     * this method will not initialize {@link #offset()} with any valid value.
+     *
+     * @return the number of transmissions lost during this operation
+     */
+    public long keepUpWithTrasmitter()
+    {
+        final long sequenceToChase = Math.max(0, buffer.getLongVolatile(latestCounterIndex));
+        final long lostWhileChasing = sequenceToChase - this.nextRecord;
+        if (lostWhileChasing == 0)
+        {
+            return 0;
+        }
+        this.nextRecord = sequenceToChase;
+        this.lost += lostWhileChasing;
+        this.lostTransmissions.lazySet(this.lost);
+        return lostWhileChasing;
+    }
+
+    /**
+     * It tries to chase the transmitter using just the already read sequence.
+     */
+    private void chase(final long cursor, final long sequence)
+    {
+        //if the sequence is claimed -> chasing the previous is ok
+        //if the sequence is committed -> chasing the current is ok
+        final long previousSequence = sequence - 1;
+        //this is a partial view of the real lost giving just using the value of the sequence
+        final long estimatedLost = previousSequence - cursor;
+        this.lost += estimatedLost;
+        this.lostTransmissions.lazySet(this.lost);
+        this.nextRecord = previousSequence;
+    }
+
+    /**
+     * Validate that the current received record is still valid and has not been overwritten.
+     * <p>
+     * If the receiver is not consuming transmissions fast enough to keep up with the transmitter then loss
+     * can be experienced resulting in transmissions being overwritten thus making them no longer valid.
+     *
+     * @return true if still valid otherwise false.
+     */
+    public boolean validate()
+    {
+        UNSAFE.loadFence();
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+        final long sequence = buffer.getLongVolatile(sequenceIndicatorOffset);
+        final long expectedCommittedSequence = cursor + 1;
+        if (sequence == expectedCommittedSequence)
+        {
+            return true;
+        }
+        else
+        {
+            chase(cursor, sequence);
+            return false;
+        }
+    }
+}

--- a/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastTransmitter.java
+++ b/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/BroadcastTransmitter.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.nio.ByteBuffer;
+
+import static org.agrona.UnsafeAccess.UNSAFE;
+import static org.agrona.concurrent.broadcast.fixed.BroadcastBufferDescriptor.*;
+import static org.agrona.concurrent.broadcast.fixed.RecordDescriptor.*;
+
+/**
+ * Transmit messages via an underlying broadcast buffer to zero or more {@link BroadcastReceiver}s.
+ * <p>
+ * <b>Note:</b> This class is not threadsafe. Only one transmitter is allowed per broadcast buffer.
+ */
+public final class BroadcastTransmitter
+{
+
+    public static final class Transmission extends UnsafeBuffer implements AutoCloseable
+    {
+        private static final byte[] EMPTY_BYTES = new byte[0];
+        private final long transmissionBufferAddress;
+        private final byte[] transmissionBufferBytes;
+        private final long latestCounterAddress;
+        private long nextTail;
+        private int sequenceIndicatorOffset;
+
+        private Transmission(final AtomicBuffer buffer, final int latestCounterIndex)
+        {
+            //it is the only initialization allowed
+            super(EMPTY_BYTES);
+            this.transmissionBufferAddress = buffer.addressOffset();
+            this.transmissionBufferBytes = buffer.byteArray();
+            this.latestCounterAddress = this.transmissionBufferAddress + latestCounterIndex;
+        }
+
+        private void commit()
+        {
+            if (addressOffset() != -1)
+            {
+                final byte[] bufferArray = this.transmissionBufferBytes;
+                final long bufferAddress = this.transmissionBufferAddress;
+                final int sequenceIndicatorOffset = this.sequenceIndicatorOffset;
+                final long nextTail = this.nextTail;
+                final long latestCounterAddress = this.latestCounterAddress;
+                UNSAFE.putOrderedLong(bufferArray, bufferAddress + sequenceIndicatorOffset, nextTail);
+                UNSAFE.putOrderedLong(bufferArray, latestCounterAddress, nextTail);
+                super.wrap(-1, 0);
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            commit();
+        }
+
+        private void unsafeWrap(final DirectBuffer buffer, final int offset, final int length)
+        {
+            super.wrap(buffer, offset, length);
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final byte[] buffer)
+        {
+            if (buffer != EMPTY_BYTES)
+            {
+                throw new UnsupportedOperationException();
+            }
+            else
+            {
+                super.wrap(EMPTY_BYTES);
+            }
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final byte[] buffer, final int offset, final int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final ByteBuffer buffer)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final ByteBuffer buffer, final int offset, final int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final DirectBuffer buffer)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final DirectBuffer buffer, final int offset, final int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void wrap(final long address, final int length)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private final Transmission transmission;
+    private final AtomicBuffer buffer;
+    private final int capacity;
+    private final int mask;
+    private final int recordSize;
+    private final int maxMsgLength;
+    private final int latestCounterIndex;
+
+    /**
+     * Construct a new fixed size message broadcast transmitter based on an underlying {@link AtomicBuffer}.
+     * The underlying buffer must be a power of 2 multiple of {@link RecordDescriptor#calculateRecordSize(int)} of the given {@code requiredMsgLength} in size plus sufficient space
+     * for the {@link BroadcastBufferDescriptor#TRAILER_LENGTH}.
+     *
+     * @param buffer            via which messages will be exchanged.
+     * @param requiredMsgLength of each transmitted message
+     * @throws IllegalStateException if the buffer capacity is not a power of 2
+     *                               multiple of {@link RecordDescriptor#calculateRecordSize(int)} of the given {@code maxMessageSize}.
+     */
+    public BroadcastTransmitter(final AtomicBuffer buffer, final int requiredMsgLength)
+    {
+        this.buffer = buffer;
+        this.capacity = buffer.capacity() - TRAILER_LENGTH;
+        checkCapacity(requiredMsgLength, capacity);
+        buffer.verifyAlignment();
+        this.maxMsgLength = calculateMaxMessageLength(requiredMsgLength);
+        this.recordSize = calculateRecordSize(requiredMsgLength);
+        final int messages = capacity / recordSize;
+        this.mask = messages - 1;
+        this.latestCounterIndex = capacity + LATEST_COUNTER_OFFSET;
+        final int recordSizeOffset = capacity + RECORD_SIZE_OFFSET;
+        this.buffer.putIntOrdered(recordSizeOffset, this.recordSize);
+        this.transmission = new Transmission(this.buffer, this.latestCounterIndex);
+    }
+
+    public MutableDirectBuffer buffer()
+    {
+        return this.buffer;
+    }
+
+    /**
+     * Get the capacity of the underlying broadcast buffer.
+     *
+     * @return the capacity of the underlying broadcast buffer.
+     */
+    public int capacity()
+    {
+        return capacity;
+    }
+
+    /**
+     * Get the maximum message length that can be transmitted for a buffer.
+     *
+     * @return the maximum message length that can be transmitted for a buffer.
+     */
+    public int maxMsgLength()
+    {
+        return maxMsgLength;
+    }
+
+    /**
+     * Transmit a message to {@link BroadcastReceiver}s via the broadcast buffer.
+     *
+     * @param msgTypeId type of the message to be transmitted.
+     * @param length    in bytes of the encoded message.
+     * @return the claimed transmission
+     * @throws IllegalArgumentException of the msgTypeId is not valid,
+     *                                  or if the message length is greater than {@link #maxMsgLength()}.
+     */
+    public Transmission transmit(
+        final int msgTypeId,
+        final int length)
+    {
+        checkTypeId(msgTypeId);
+        checkMessageLength(length);
+
+        final AtomicBuffer buffer = this.buffer;
+        final int latestCounterIndex = this.latestCounterIndex;
+        final int mask = this.mask;
+        final int recordSize = this.recordSize;
+
+        final long currentTail = buffer.getLong(latestCounterIndex);
+        final int recordOffset = calculatedRecordOffset(currentTail, mask, recordSize);
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+        buffer.putLong(sequenceIndicatorOffset, currentTail);
+        UNSAFE.storeFence();
+        buffer.putInt(lengthOffset(recordOffset), length);
+        buffer.putInt(typeOffset(recordOffset), msgTypeId);
+        final int msgOffset = msgOffset(recordOffset);
+        final long nextTail = currentTail + 1;
+        transmission.unsafeWrap(buffer, msgOffset, length);
+        transmission.sequenceIndicatorOffset = sequenceIndicatorOffset;
+        transmission.nextTail = nextTail;
+        return transmission;
+    }
+
+    /**
+     * Transmit a message to {@link BroadcastReceiver}s via the broadcast buffer.
+     *
+     * @param msgTypeId type of the message to be transmitted.
+     * @param srcBuffer containing the encoded message to be transmitted.
+     * @param srcIndex  srcIndex in the source buffer at which the encoded message begins.
+     * @param length    in bytes of the encoded message.
+     * @throws IllegalArgumentException of the msgTypeId is not valid,
+     *                                  or if the message length is greater than {@link #maxMsgLength()}.
+     */
+    public void transmit(final int msgTypeId, final DirectBuffer srcBuffer, final int srcIndex, final int length)
+    {
+        checkTypeId(msgTypeId);
+        checkMessageLength(length);
+
+        final AtomicBuffer buffer = this.buffer;
+        final int latestCounterIndex = this.latestCounterIndex;
+        final int mask = this.mask;
+        final int recordSize = this.recordSize;
+
+        final long currentTail = buffer.getLong(latestCounterIndex);
+        final int recordOffset = calculatedRecordOffset(currentTail, mask, recordSize);
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+        buffer.putLong(sequenceIndicatorOffset, currentTail);
+        UNSAFE.storeFence();
+        buffer.putInt(lengthOffset(recordOffset), length);
+        buffer.putInt(typeOffset(recordOffset), msgTypeId);
+        buffer.putBytes(msgOffset(recordOffset), srcBuffer, srcIndex, length);
+        final long nextTail = currentTail + 1;
+        buffer.putLongOrdered(sequenceIndicatorOffset, nextTail);
+        buffer.putLongOrdered(latestCounterIndex, nextTail);
+    }
+
+    private void checkMessageLength(final int length)
+    {
+        if (length > maxMsgLength)
+        {
+            throw new IllegalArgumentException(
+                "Encoded message exceeds maxMsgLength of " + maxMsgLength + ", length=" + length);
+        }
+    }
+}

--- a/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/CopyBroadcastReceiver.java
+++ b/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/CopyBroadcastReceiver.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.BitUtil;
+import org.agrona.BufferUtil;
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Receiver that copies messages that have been broadcast to enable a simpler API for the client.
+ */
+public final class CopyBroadcastReceiver
+{
+    private final BroadcastReceiver receiver;
+    private final UnsafeBuffer scratchBuffer;
+    private final boolean failWhileSlow;
+
+    /**
+     * Wrap a {@link BroadcastReceiver} to simplify the API for receiving messages.
+     *
+     * @param failWhileSlow if {@code true} fails throwing {@link IllegalStateException} if not able to
+     *                      keep-up with the transmitter, {@code false} otherwise
+     * @param receiver      to be wrapped.
+     */
+    public CopyBroadcastReceiver(final BroadcastReceiver receiver, final boolean failWhileSlow)
+    {
+        this.receiver = receiver;
+        final int maxTransmissionLength = RecordDescriptor.calculateAvailableMessageLength(receiver.recordSize());
+        this.scratchBuffer = new UnsafeBuffer(
+            BufferUtil.allocateDirectAligned(maxTransmissionLength, BitUtil.CACHE_LINE_LENGTH * 2));
+        // If we're reconnecting to a broadcast buffer then we need to
+        // scan ourselves up to date, otherwise we risk "falling behind"
+        // the buffer due to the time taken to catchup.
+        receiver.keepUpWithTrasmitter();
+        this.failWhileSlow = failWhileSlow;
+    }
+
+    /**
+     * Wrap a {@link BroadcastReceiver} to simplify the API for receiving messages.
+     * <p>
+     * It fails throwing {@link IllegalStateException} if not able to keep-up with the transmitter.
+     *
+     * @param receiver to be wrapped.
+     */
+    public CopyBroadcastReceiver(final BroadcastReceiver receiver)
+    {
+        this(receiver, true);
+    }
+
+    /**
+     * Receive as many messages as are available from the broadcast buffer.
+     *
+     * @param handler to be called for each message received.
+     * @param limit   the number of messages will be read in a single invocation.
+     * @return the number of messages that have been received.
+     */
+    public int receive(final MessageHandler handler, final int limit)
+    {
+        final UnsafeBuffer scratchBuffer = this.scratchBuffer;
+        final BroadcastReceiver receiver = this.receiver;
+        final boolean failWhileSlow = this.failWhileSlow;
+        for (int i = 0; i < limit; i++)
+        {
+            int received;
+            while ((received = receive(receiver, failWhileSlow, scratchBuffer, handler)) == 0)
+            {
+
+            }
+            if (received < 0)
+            {
+                return i;
+            }
+        }
+        return limit;
+    }
+
+    private static int receive(
+        final BroadcastReceiver receiver,
+        final boolean failWhileSlow,
+        final UnsafeBuffer scratchBuffer,
+        final MessageHandler handler)
+    {
+        switch (receiver.receiveNext())
+        {
+            case LOSS:
+                if (failWhileSlow)
+                {
+                    throw new IllegalStateException("Unable to keep up with broadcast buffer");
+                }
+                return 0;
+            case ANY_AVAILABLE:
+                final int length = receiver.length();
+                final int msgTypeId = receiver.typeId();
+                scratchBuffer.putBytes(0, receiver.buffer(), receiver.offset(), length);
+                if (!receiver.validate())
+                {
+                    if (failWhileSlow)
+                    {
+                        throw new IllegalStateException("Unable to keep up with broadcast buffer");
+                    }
+                    return 0;
+                }
+                else
+                {
+                    handler.onMessage(msgTypeId, scratchBuffer, 0, length);
+                    return 1;
+                }
+            case NOT_AVAILABLE:
+                return -1;
+            default:
+                throw new AssertionError();
+        }
+    }
+}

--- a/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/RecordDescriptor.java
+++ b/agrona/src/main/java/org/agrona/concurrent/broadcast/fixed/RecordDescriptor.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.BitUtil;
+
+/**
+ * Description of the structure for a record in the broadcast buffer.
+ * All messages are stored in records with the following format.
+ * <pre>
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                         Sequence                              |
+ *  |                         Indicator                             |
+ *  +-+-------------------------------------------------------------+
+ *  |R|                        Length                               |
+ *  +-+-------------------------------------------------------------+
+ *  |                           Type                                |
+ *  +---------------------------------------------------------------+
+ *  |                      Encoded Message                         ...
+ * ...                                                              |
+ *  +---------------------------------------------------------------+
+ * </pre>
+ * <p>
+ * (R) bits are reserved.
+ */
+public class RecordDescriptor
+{
+    /**
+     * Offset within the record at which the sequence indicator field begins.
+     */
+    public static final int SEQUENCE_INDICATOR_OFFSET = 0;
+
+    /**
+     * Offset within the record at which the record length field begins.
+     */
+    public static final int LENGTH_OFFSET = SEQUENCE_INDICATOR_OFFSET + BitUtil.SIZE_OF_LONG;
+
+    /**
+     * Offset within the record at which the message type field begins.
+     */
+    public static final int TYPE_OFFSET = LENGTH_OFFSET + BitUtil.SIZE_OF_INT;
+
+    /**
+     * Length of the record header in bytes.
+     */
+    public static final int HEADER_LENGTH = BitUtil.SIZE_OF_LONG + BitUtil.SIZE_OF_INT * 2;
+
+    /**
+     * Alignment as a multiple of bytes for each record.
+     */
+    public static final int RECORD_ALIGNMENT = BitUtil.SIZE_OF_LONG;
+
+    /**
+     * Calculate the avaialble message length for the given valid recordSize (ie {@link #checkRecordSize(int)}).
+     *
+     * @param recordSize of the message record.
+     * @return the required record length
+     */
+    public static int calculateAvailableMessageLength(final int recordSize)
+    {
+        return recordSize - HEADER_LENGTH;
+    }
+
+    /**
+     * Check recordSize is a valid.
+     *
+     * @param recordSize to be checked.
+     * @throws IllegalStateException if the recordSize is not sufficient to hold {@link #HEADER_LENGTH}
+     *                               or is not {@link #RECORD_ALIGNMENT}-aligned.
+     */
+    public static void checkRecordSize(final int recordSize)
+    {
+        final int availableEncodedMessageLength = recordSize - HEADER_LENGTH;
+        if (availableEncodedMessageLength < 0)
+        {
+            throw new IllegalStateException("The given recordSize has insufficient space to hold the " +
+                "HEADER of a record: recordSize=" + recordSize);
+        }
+        if (!BitUtil.isAligned(recordSize, RECORD_ALIGNMENT))
+        {
+            throw new IllegalStateException(
+                "The given recordSize is not " + RECORD_ALIGNMENT + "-aligned: recordSize=" + recordSize);
+        }
+    }
+
+    /**
+     * Calculate the real maximum supported message length for a record of given encoded message length.
+     *
+     * @param encodedMessageSize of the message record.
+     * @return the required record length
+     */
+    public static int calculateMaxMessageLength(final int encodedMessageSize)
+    {
+        final int recordSize = calculateRecordSize(encodedMessageSize);
+        final int availableEncodedMessageLength = recordSize - HEADER_LENGTH;
+        return availableEncodedMessageLength;
+    }
+
+    /**
+     * The buffer offset at which the sequence indicator field begins.
+     *
+     * @param recordOffset at which the frame begins.
+     * @return the offset at which the sequence indicator field begins.
+     */
+    public static int sequenceIndicatorOffset(final int recordOffset)
+    {
+        return recordOffset + SEQUENCE_INDICATOR_OFFSET;
+    }
+
+    /**
+     * The buffer offset at which the message length field begins.
+     *
+     * @param recordOffset at which the frame begins.
+     * @return the offset at which the message length field begins.
+     */
+    public static int lengthOffset(final int recordOffset)
+    {
+        return recordOffset + LENGTH_OFFSET;
+    }
+
+    /**
+     * The buffer offset at which the message type field begins.
+     *
+     * @param recordOffset at which the frame begins.
+     * @return the offset at which the message type field begins.
+     */
+    public static int typeOffset(final int recordOffset)
+    {
+        return recordOffset + TYPE_OFFSET;
+    }
+
+    /**
+     * The buffer offset at which the encoded message begins.
+     *
+     * @param recordOffset at which the frame begins.
+     * @return the offset at which the encoded message begins.
+     */
+    public static int msgOffset(final int recordOffset)
+    {
+        return recordOffset + HEADER_LENGTH;
+    }
+
+    /**
+     * Check that and message id is in the valid range.
+     *
+     * @param msgTypeId to be checked.
+     * @throws IllegalArgumentException if the id is not in the valid range.
+     */
+    public static void checkTypeId(final int msgTypeId)
+    {
+        if (msgTypeId < 1)
+        {
+            final String msg = "Type id must be greater than zero, msgTypeId=" + msgTypeId;
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    /**
+     * Calculate the required record length to hold {@code encodedMessageSize} message bytes.
+     *
+     * @param encodedMessageSize of the message record.
+     * @return the required record length
+     */
+    public static int calculateRecordSize(final int encodedMessageSize)
+    {
+        return BitUtil.align(HEADER_LENGTH + encodedMessageSize, RECORD_ALIGNMENT);
+    }
+
+    /**
+     * Calculate the starting offset of a record on a given {@code sequence}.
+     *
+     * @param sequence   of the record inside the buffer.
+     * @param mask       of the real capacity in number of messages of the buffer.
+     * @param recordSize the record size as obtained by {@link #calculateRecordSize(int)}.
+     * @return the offset of a record on a given {@code sequence}
+     */
+    public static int calculatedRecordOffset(final long sequence, final int mask, final int recordSize)
+    {
+        return (int)(sequence & mask) * recordSize;
+    }
+}

--- a/agrona/src/test/java/org/agrona/concurrent/broadcast/fixed/BroadcastReceiverTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/broadcast/fixed/BroadcastReceiverTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.broadcast.fixed.BroadcastReceiver.ReceiveReturnType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.agrona.concurrent.broadcast.fixed.RecordDescriptor.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class BroadcastReceiverTest
+{
+    private static final int MSG_TYPE_ID = 7;
+    private static final int MSG_CAPACITY = 1024;
+    private static final int MAX_MESSAGE_SIZE = 8;
+    private static final int CAPACITY = BroadcastBufferDescriptor.calculateCapacity(MAX_MESSAGE_SIZE, MSG_CAPACITY);
+    private static final int TOTAL_BUFFER_LENGTH = CAPACITY + BroadcastBufferDescriptor.TRAILER_LENGTH;
+    private static final int LATEST_COUNTER_INDEX = CAPACITY + BroadcastBufferDescriptor.LATEST_COUNTER_OFFSET;
+
+    private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
+    private BroadcastReceiver broadcastReceiver;
+
+    @Before
+    public void setUp()
+    {
+        when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
+        //mimic an already configured transmitter on it
+        when(buffer.getIntVolatile(CAPACITY + BroadcastBufferDescriptor.RECORD_SIZE_OFFSET)).thenReturn(
+            calculateRecordSize(MAX_MESSAGE_SIZE));
+        broadcastReceiver = new BroadcastReceiver(buffer);
+    }
+
+    @Test
+    public void shouldCalculateCapacityForBuffer()
+    {
+        assertThat(broadcastReceiver.capacity(), is(CAPACITY));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
+    {
+        final int capacity = 777;
+        final int totalBufferLength = capacity + BroadcastBufferDescriptor.TRAILER_LENGTH;
+
+        when(buffer.capacity()).thenReturn(totalBufferLength);
+
+        new BroadcastReceiver(buffer);
+    }
+
+    @Test
+    public void shouldNotBeLossesBeforeReception()
+    {
+        assertThat(broadcastReceiver.lostTransmissions(), is(0L));
+    }
+
+    @Test
+    public void shouldNotReceiveFromEmptyBuffer()
+    {
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.NOT_AVAILABLE));
+    }
+
+
+    @Test
+    public void shouldReceiveFirstMessageFromBuffer()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long sequenceIndicator = 1;
+        final int recordOffset = 0;
+        final int sequenceIndicatorOffset = 0;
+
+        when(buffer.getLongVolatile(sequenceIndicatorOffset)).thenReturn(sequenceIndicator);
+        when(buffer.getInt(lengthOffset(recordOffset))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffset))).thenReturn(MSG_TYPE_ID);
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffset)));
+        assertThat(broadcastReceiver.length(), is(length));
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffset));
+
+        assertTrue(broadcastReceiver.validate());
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+
+    }
+
+    @Test
+    public void shouldReceiveTwoMessagesFromBuffer()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final int recordSize = calculateRecordSize(MAX_MESSAGE_SIZE);
+        final long sequenceIndicatorOne = 1;
+        final long sequenceIndicatorTwo = 2;
+        final int recordOffsetOne = 0;
+        final int recordOffsetTwo = recordSize;
+        final int sequenceIndicatorOffsetOne = 0;
+        final int sequenceIndicatorOffsetTwo = recordOffsetTwo;
+
+        when(buffer.getLongVolatile(sequenceIndicatorOffsetOne)).thenReturn(sequenceIndicatorOne);
+        when(buffer.getInt(lengthOffset(recordOffsetOne))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffsetOne))).thenReturn(MSG_TYPE_ID);
+        when(buffer.getLongVolatile(sequenceIndicatorOffsetTwo)).thenReturn(sequenceIndicatorTwo);
+        when(buffer.getInt(lengthOffset(recordOffsetTwo))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffsetTwo))).thenReturn(MSG_TYPE_ID);
+
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffsetOne)));
+        assertThat(broadcastReceiver.length(), is(length));
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffsetOne);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffsetOne));
+
+        assertTrue(broadcastReceiver.validate());
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffsetOne);
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffsetTwo)));
+        assertThat(broadcastReceiver.length(), is(length));
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffsetTwo);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffsetTwo));
+
+        assertTrue(broadcastReceiver.validate());
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffsetTwo);
+    }
+
+    @Test
+    public void shouldLateJoinTransmission()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long tail = MSG_CAPACITY * 3L;
+        final long sequenceIndicator = tail + 1;
+        final int recordOffset = 0;
+        final int sequenceIndicatorOffset = 0;
+
+        when(buffer.getLongVolatile(sequenceIndicatorOffset)).thenReturn(sequenceIndicator);
+        when(buffer.getInt(lengthOffset(recordOffset))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffset))).thenReturn(MSG_TYPE_ID);
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.LOSS));
+        assertThat(broadcastReceiver.lostTransmissions(), is(MSG_CAPACITY * 3L));
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffset)));
+        assertThat(broadcastReceiver.length(), is(length));
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffset));
+        assertTrue(broadcastReceiver.validate());
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+    }
+
+    @Test
+    public void shouldKeepUpWithTransmission()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long tail = MSG_CAPACITY * 3L;
+        final int recordOffset = 0;
+        final int lostSequenceIndicatorOffset = calculateRecordSize(MAX_MESSAGE_SIZE);
+        final long lostSequenceIndicator = ((tail + 1) - MSG_CAPACITY) + 1;
+
+        when(buffer.getLongVolatile(lostSequenceIndicatorOffset)).thenReturn(lostSequenceIndicator);
+        when(buffer.getLongVolatile(LATEST_COUNTER_INDEX)).thenReturn(tail + 1);
+        when(buffer.getInt(lengthOffset(recordOffset))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffset))).thenReturn(MSG_TYPE_ID);
+
+        assertThat(broadcastReceiver.keepUpWithTrasmitter(), is((MSG_CAPACITY * 3L) + 1L));
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(LATEST_COUNTER_INDEX);
+        assertThat(broadcastReceiver.lostTransmissions(), is((MSG_CAPACITY * 3L) + 1L));
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.NOT_AVAILABLE));
+        inOrder.verify(buffer).getLongVolatile(lostSequenceIndicatorOffset);
+    }
+
+    @Test
+    public void shouldDealWithRecordBecomingInvalidDueToInitiatedOverwrite()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long sequenceIndicator = 1;
+        final int recordOffset = 0;
+        final int sequenceIndicatorOffset = 0;
+
+        when(buffer.getLongVolatile(sequenceIndicatorOffset))
+            .thenReturn(sequenceIndicator)
+            .thenReturn(sequenceIndicator + MSG_CAPACITY - 1);
+        when(buffer.getInt(lengthOffset(recordOffset))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffset))).thenReturn(MSG_TYPE_ID);
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffset)));
+        assertThat(broadcastReceiver.length(), is(length));
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffset));
+
+        assertFalse(broadcastReceiver.validate());
+        assertThat(broadcastReceiver.lostTransmissions(), is((long)MSG_CAPACITY - 1));
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+    }
+
+    @Test
+    public void shouldDealWithRecordBecomingInvalidDueToCompleteOverwrite()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long sequenceIndicator = 1;
+        final int recordOffset = 0;
+        final int sequenceIndicatorOffset = 0;
+
+        when(buffer.getLongVolatile(sequenceIndicatorOffset))
+            .thenReturn(sequenceIndicator)
+            .thenReturn(sequenceIndicator + MSG_CAPACITY);
+        when(buffer.getInt(lengthOffset(recordOffset))).thenReturn(length);
+        when(buffer.getInt(typeOffset(recordOffset))).thenReturn(MSG_TYPE_ID);
+
+        assertThat(broadcastReceiver.receiveNext(), is(ReceiveReturnType.ANY_AVAILABLE));
+        assertThat(broadcastReceiver.typeId(), is(MSG_TYPE_ID));
+        assertThat(broadcastReceiver.buffer(), is(buffer));
+        assertThat(broadcastReceiver.offset(), is(msgOffset(recordOffset)));
+        assertThat(broadcastReceiver.length(), is(length));
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+        inOrder.verify(buffer).getInt(lengthOffset(recordOffset));
+
+        assertFalse(broadcastReceiver.validate());
+        assertThat(broadcastReceiver.lostTransmissions(), is((long)MSG_CAPACITY));
+
+        inOrder.verify(buffer).getLongVolatile(sequenceIndicatorOffset);
+    }
+}

--- a/agrona/src/test/java/org/agrona/concurrent/broadcast/fixed/BroadcastTransmitterTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/broadcast/fixed/BroadcastTransmitterTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2014-2017 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.broadcast.fixed;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.agrona.BitUtil.align;
+import static org.agrona.concurrent.broadcast.fixed.RecordDescriptor.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class BroadcastTransmitterTest
+{
+    private static final int MSG_TYPE_ID = 7;
+    private static final int MSG_CAPACITY = 1024;
+    private static final int MAX_MESSAGE_SIZE = 8;
+    private static final int CAPACITY = BroadcastBufferDescriptor.calculateCapacity(MAX_MESSAGE_SIZE, MSG_CAPACITY);
+    private static final int TOTAL_BUFFER_LENGTH = CAPACITY + BroadcastBufferDescriptor.TRAILER_LENGTH;
+    private static final int LATEST_COUNTER_INDEX = CAPACITY + BroadcastBufferDescriptor.LATEST_COUNTER_OFFSET;
+
+    private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
+    private BroadcastTransmitter broadcastTransmitter;
+
+    @Before
+    public void setUp()
+    {
+        when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
+
+        broadcastTransmitter = new BroadcastTransmitter(buffer, MAX_MESSAGE_SIZE);
+    }
+
+    @Test
+    public void shouldCalculateCapacityForBuffer()
+    {
+        assertThat(broadcastTransmitter.capacity(), is(CAPACITY));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
+    {
+        final int totalBufferLength = TOTAL_BUFFER_LENGTH + 1;
+
+        when(buffer.capacity()).thenReturn(totalBufferLength);
+
+        new BroadcastTransmitter(buffer, MAX_MESSAGE_SIZE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenMaxMessageLengthExceeded()
+    {
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
+
+        broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, 0, broadcastTransmitter.maxMsgLength() + 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenMessageTypeIdInvalid()
+    {
+        final int invalidMsgId = -1;
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
+
+        broadcastTransmitter.transmit(invalidMsgId, srcBuffer, 0, 32);
+    }
+
+    @Test
+    public void shouldTransmitIntoEmptyBuffer()
+    {
+        final long tail = 0L;
+        assert tail < MSG_CAPACITY;
+        final long nextTail = 1L;
+        final int recordOffset = (int)tail;
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
+        final int srcIndex = 0;
+
+        broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, srcIndex, length);
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLong(LATEST_COUNTER_INDEX);
+        inOrder.verify(buffer).putLong(sequenceIndicatorOffset, tail);
+        inOrder.verify(buffer).putInt(lengthOffset(recordOffset), length);
+        inOrder.verify(buffer).putInt(typeOffset(recordOffset), MSG_TYPE_ID);
+        inOrder.verify(buffer).putBytes(msgOffset(recordOffset), srcBuffer, srcIndex, length);
+        inOrder.verify(buffer).putLongOrdered(sequenceIndicatorOffset, nextTail);
+        inOrder.verify(buffer).putLongOrdered(LATEST_COUNTER_INDEX, nextTail);
+    }
+
+    @Test
+    public void shouldTransmitIntoUsedBuffer()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final long tail = 3;
+        assert tail < MSG_CAPACITY;
+        final long nextTail = 4;
+        final int recordLength = length + HEADER_LENGTH;
+        final int recordLengthAligned = align(recordLength, RECORD_ALIGNMENT);
+        final int recordOffset = (int)tail * recordLengthAligned;
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+
+        when(buffer.getLong(LATEST_COUNTER_INDEX)).thenReturn(tail);
+
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
+        final int srcIndex = 0;
+
+        broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, srcIndex, length);
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLong(LATEST_COUNTER_INDEX);
+        inOrder.verify(buffer).putLong(sequenceIndicatorOffset, tail);
+        inOrder.verify(buffer).putInt(lengthOffset(recordOffset), length);
+        inOrder.verify(buffer).putInt(typeOffset(recordOffset), MSG_TYPE_ID);
+        inOrder.verify(buffer).putBytes(msgOffset(recordOffset), srcBuffer, srcIndex, length);
+        inOrder.verify(buffer).putLongOrdered(sequenceIndicatorOffset, nextTail);
+        inOrder.verify(buffer).putLongOrdered(LATEST_COUNTER_INDEX, nextTail);
+    }
+
+
+    @Test
+    public void shouldTransmitIntoEndOfBuffer()
+    {
+        final int length = 8;
+        assert length <= MAX_MESSAGE_SIZE;
+        final int recordLength = length + HEADER_LENGTH;
+        final int recordLengthAligned = align(recordLength, RECORD_ALIGNMENT);
+        final long tail = MSG_CAPACITY - 1;
+        assert tail < MSG_CAPACITY;
+        final long nextTail = tail + 1;
+        final int recordOffset = (int)tail * recordLengthAligned;
+        final int sequenceIndicatorOffset = sequenceIndicatorOffset(recordOffset);
+
+
+        when(buffer.getLong(LATEST_COUNTER_INDEX)).thenReturn(tail);
+
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
+        final int srcIndex = 0;
+
+        broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, srcIndex, length);
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLong(LATEST_COUNTER_INDEX);
+        inOrder.verify(buffer).putLong(sequenceIndicatorOffset, tail);
+        inOrder.verify(buffer).putInt(lengthOffset(recordOffset), length);
+        inOrder.verify(buffer).putInt(typeOffset(recordOffset), MSG_TYPE_ID);
+        inOrder.verify(buffer).putBytes(msgOffset(recordOffset), srcBuffer, srcIndex, length);
+        inOrder.verify(buffer).putLongOrdered(sequenceIndicatorOffset, nextTail);
+        inOrder.verify(buffer).putLongOrdered(LATEST_COUNTER_INDEX, nextTail);
+    }
+}


### PR DESCRIPTION
This is a new broadcast buffer implementation. 

It is different from the one already present in this library because although it allows variable sized transmissions it needs to know at configuration time the maximum allowed transmission size.
Thanks this restriction it allows precise counting of transmissions and losses on the receiver(s) side.

Most of the original semantic on the receiver is preserved and enhanced to allow different receive strategies, like extended `receiveNext` outcomes (`LOSS, ANY_AVAILABLE, NOT_AVAILABLE`) and explicit fast-forward methods (ie `keepUpWithTrasmitter`).
While on the transmitter side has been added a zero-copy transmission method in addition to the one
using copy.

The related `CopyBroadcastReceiver` has been changed as well to accomodate the enhancements of the receiver side.

Implementation-wise it is using a mechanics similar to the Fast Flow queues (aka using message indicators) with all the well-known performance benefits of them (I've some measurements using JMH to share if needed).

I have added 2 test classes covering most of the same cases of the original broadcast buffer and based 
on tests already written for it.

Please review and If it will pass I hope it will be a good companion for the other awesome data structures of the library.
