### PR TITLE
[Java] Use current size for array copy in IntArrayList

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -209,7 +209,7 @@ public final class IntArrayList extends AbstractList<Integer> implements List<In
 
         if (index < size)
         {
-            System.arraycopy(elements, index, elements, index + 1, requiredSize - index);
+            System.arraycopy(elements, index, elements, index + 1, size - index);
         }
 
         elements[index] = element;

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -78,6 +78,20 @@ public class IntArrayListTest
     }
 
     @Test
+    public void shouldAddValueAtIndexWithNearlyFullCapacity()
+    {
+        final int count = IntArrayList.INITIAL_CAPACITY - 1;
+        final int value = count + 1;
+        IntStream.range(0, count).forEachOrdered(list::addInt);
+
+        list.addInt(0, value);
+
+        assertThat(list.size(), is(count + 1));
+        assertThat(list.getInt(0), is(value));
+        assertThat(list.getInt(count), is(count - 1));
+    }
+
+    @Test
     public void shouldSetIntValue()
     {
         list.addInt(7);


### PR DESCRIPTION
This fixes a bug in `IntArrayList#addInt(index, element)` if the current capacity will be reached after the insert. The `System.arraycopy` used the new size instead of the current one to calculate the length of the copy. This will lead to an `ArrayIndexOutOfBoundsException` as it tries to copy the last element of the array to outside of the array bounds. 