### PR TITLE
Use Java's least common denominator for random access lists

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/ArrayListUtil.java
+++ b/agrona/src/main/java/org/agrona/collections/ArrayListUtil.java
@@ -15,7 +15,7 @@
  */
 package org.agrona.collections;
 
-import java.util.ArrayList;
+import java.util.AbstractList;
 
 /**
  * Utility functions for working with {@link ArrayList}s.
@@ -31,7 +31,7 @@ public class ArrayListUtil
      * @param <T>   element type.
      * @throws IndexOutOfBoundsException if index is out of bounds.
      */
-    public static <T> void fastUnorderedRemove(final ArrayList<T> list, final int index)
+    public static <T> void fastUnorderedRemove(final AbstractList<T> list, final int index)
     {
         final int lastIndex = list.size() - 1;
         if (index != lastIndex)
@@ -54,7 +54,7 @@ public class ArrayListUtil
      * @param <T>       element type.
      * @throws IndexOutOfBoundsException if index or lastIndex are out of bounds.
      */
-    public static <T> void fastUnorderedRemove(final ArrayList<T> list, final int index, final int lastIndex)
+    public static <T> void fastUnorderedRemove(final AbstractList<T> list, final int index, final int lastIndex)
     {
         if (index != lastIndex)
         {
@@ -75,7 +75,7 @@ public class ArrayListUtil
      * @param <T>  element type.
      * @return true if found and removed, false otherwise.
      */
-    public static <T> boolean fastUnorderedRemove(final ArrayList<T> list, final T e)
+    public static <T> boolean fastUnorderedRemove(final AbstractList<T> list, final T e)
     {
         for (int i = 0, size = list.size(); i < size; i++)
         {


### PR DESCRIPTION
Hi,

Could you accept this minor change so that we can do unordered removals using AbstractList instead of ArrayList? Seems a pity/inconsistent to not be able to use this on org.agrona.collections.IntArrayList and org.agrona.collections.LongArrayList.

An alternative would be to have the latter extend ArrayList instead of AbstactList.

This would of course cause boxing in the "list.set(index, list.remove(lastIndex));" line so maybe it's even better to just add a "removeUnordered" in IntArrayList / LongArrayList themselves?