### PR TITLE
Add unordered remove to primitive collection

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -320,6 +320,36 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     }
 
     /**
+     * Removes element at index, but instead of copying all elements to the
+     * left, moves into the same slot the last element. This avoids the copy
+     * costs, but spoils the list order. If index is the last element it is just
+     * removed.
+     *
+     * @param index
+     *            of the element to be removed.
+     * @return the existing value at this index.
+     * @throws IndexOutOfBoundsException
+     *             if index is out of bounds.
+     */
+    public int fastUnorderedRemove(
+        @DoNotSub final int index)
+    {
+        checkIndex(index);
+
+        final int value = elements[index];
+
+        @DoNotSub final int moveCount = size - index - 1;
+        if (moveCount > 0)
+        {
+            elements[index] = elements[size - 1];
+        }
+
+        size--;
+
+        return value;
+    }
+
+    /**
      * Remove the first instance of a value if found in the list.
      *
      * @param value to be removed.

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -139,6 +139,18 @@ public class IntArrayListTest
     }
 
     @Test
+    public void shouldFastRemoveUnorderedAtIndex()
+    {
+        final int count = 20;
+        IntStream.range(0, count).forEachOrdered(list::addInt);
+
+        assertThat(list.fastUnorderedRemove(10), is(10));
+
+        assertThat(list.size(), is(count - 1));
+        assertThat(list.getInt(10), is(19));
+    }
+
+    @Test
     public void shouldForEachOrderedInt()
     {
         final List<Integer> expected = new ArrayList<>();


### PR DESCRIPTION
Add fast unordered remove to primitive int collections (and longs through primitive expander).

Basically removes an element faster by overwriting with the last element (breaks order). This is instead of #134 because that approach is not allocation-free and the point of that change was to allow this in the primitive collections.

