### PR TITLE
Adds ReferenceHelper class

### DIFF
--- a/agrona/src/main/java/org/agrona/ReferenceHelper.java
+++ b/agrona/src/main/java/org/agrona/ReferenceHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Gil Tene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.agrona;
+
+import java.lang.ref.Reference;
+
+/**
+ * ReferenceHelper provides two key helper method for commonly used idioms on
+ * Reference types: isCleared(), and isReferringTo(Reference ref, Object o).
+ *
+ * Both of these idioms are obviously trivially implementable using Reference.get().
+ * However, such explicit implementations produce a temporary strong reference to
+ * the referent, forcing a "strengthening" of the referent when performed during
+ * concurrent marking phases on most concurrent collectors (such as G1, C4, ZGC,
+ * Shenandoah, etc.). By capturing the non-reference-escaping semantic definitions
+ * of these idioms, JDKs may validly intrisify their implementations to perform
+ * the required logic without strengthening the referent.
+ *
+ * Various uses of Reference subclasses can use these method idioms when performing
+ * the common operations needed to maintain various data structures such and weakly
+ * keyed maps, lists, etc., without those operations explicitly force-strengthening
+ * referents. When run on JDKs that intrisify these implementations, or on future
+ * JDKs that would probide similar functionality (and to which this class will adapt
+ * in a portable way), such strengthening will be avoided.
+ *
+ * e.g. the JDK's own WeakIdentitiHashMap implementation could, when using these
+ * two methods, have it's get() and set() methods work without requiring the
+ * force-strengthening of unrelated keys and without forcing unrelated entries
+ * and values to stay alive.
+ *
+ * <p>
+ * Since JDKs may choose to "intrinsify" the implementation of the methods in
+ * this class, no assumptions, beyoind those provided in the documentation below,
+ * should be made about their actual implementation.
+ * </p>
+ *
+ */
+public class ReferenceHelper
+{
+    /**
+     * Indicate whether a Reference has been cleared
+     *
+     * @param ref The Reference to be tested
+     * @return True if ref is cleared. False otherwise.
+     */
+    static boolean isCleared(final Reference ref)
+    {
+        return ref.get() == null;
+    }
+
+    /**
+     * Indicate whether a Reference refers to a given object
+     *
+     * @param ref The Reference to be tested
+     * @param o The object to which the Reference may or may not be referring
+     * @param <T> the class of the referent
+     * @return True if the Reference's referent is o. False otherwise.
+     */
+    static <T> boolean isReferringTo(final Reference<T> ref, final T o)
+    {
+        return ref.get() == o;
+    }
+}

--- a/agrona/src/test/java/org/agrona/ReferenceHelperTest.java
+++ b/agrona/src/test/java/org/agrona/ReferenceHelperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Gil Tene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import org.junit.Test;
+
+import java.lang.ref.WeakReference;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ReferenceHelperTest
+{
+
+    @Test
+    public void validateIsCleared()
+    {
+        BigInteger big = new BigInteger("42");
+        final WeakReference<BigInteger> ref = new WeakReference<>(big);
+        assertFalse(ReferenceHelper.isCleared(ref));
+        big = null;
+        System.gc();
+        assertTrue(ReferenceHelper.isCleared(ref));
+    }
+
+    @Test
+    public void validateIsReferringto()
+    {
+        final Long longObject1 = 42L;
+        final Long longObject2 = 43L; // Need different value to make sure it is a different instance...
+        final WeakReference<Long> ref = new WeakReference<>(longObject1);
+        assertTrue(ReferenceHelper.isReferringTo(ref, longObject1));
+        assertFalse(ReferenceHelper.isReferringTo(ref, longObject2));
+    }
+
+}
+


### PR DESCRIPTION
I'd like to use org.agrona as a stable home for ReferenceHelper. The JavaDoc explains its purpose to some degree, but let me elaborate here:

There is currently a deficiency in the Java Reference class API (which I would like to suggest fixes to over time via a JEP): Two common operation idioms that are used in most WeakReference-based data structured can currently only be performed by using a Reference.get(), which explicitly creates a strong reference to the referent and can prevent its collection on concurrent collectors. The two operations are isCleared() (usually done by evaluating (ref.get() == null) and isReferingTo (usually done by evaluating (ref.get() == obj)). Examples of these operations can be seen in e.g. [WeakIdentityHashMap](https://github.com/unofficial-openjdk/openjdk/blob/jdk/jdk10/src/java.management/share/classes/com/sun/jmx/mbeanserver/WeakIdentityHashMap.java#L125) and [ThreadLocal.ThreadLocalMap](https://github.com/unofficial-openjdk/openjdk/blob/5434c70f3ed0718b22acbc2c80c205e6b7ac5fcd/src/java.base/share/classes/java/lang/ThreadLocal.java#L436). Both of these are examples of how the forced use of Reference.get() to perform a non-reference-escaping operation leads most concurrent collectors (G1, C4, ZGC, Shenandoah) to keep such tables massively populated with weakly-keyed items that would have properly died if it were not for this strengthening during concurrent marking. While both of these examples are in-JDK implementations, similar data structures outside the JDK exist, which are exposed to the same issues. ReferenceHelper introduces two methods (one for each idiom) that do not expose the underlying referent, thereby allowing intrinsic implementations that would not force-strengthen the referent when called.

My aim with ReferenceHelper in agrona is three-fold:

1. Provide a stable, well-documented API that can be intrinsified by JDKs, such that (when the API is used on an intrisifying JDK) unnecessary strengthening is avoided.

2. Make the case for adding Reference.isCleared() and Reference.isReferingTo() to future OpenJDK versions, by supplying working implementation examples of common data structure, using org.agrona.ReferenceHelper APIs in the same way that the proposed APIs would be used.

3. Provide a cross-JDK-version compatible API (similar to what  org.agrona.hints.ThreadHints.onSpinWait() does), such that data structures written to this new API will work on both older and newer JDKs, but would be able to benefit from the  better (not explicitly stregthening) behavior of future JDK versions or of inrisifying JDKs of current versions.