### PR TITLE
Allow null values

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2NullableObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2NullableObjectHashMap.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2018 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.agrona.generation.DoNotSub;
+
+/**
+ * Variation of {@link Int2ObjectHashMap} that allows {@code null} values.
+ *
+ * @param <V> type of values stored in the {@link java.util.Map}
+ */
+public class Int2NullableObjectHashMap<V> extends Int2ObjectHashMap<V>
+{
+    public Int2NullableObjectHashMap()
+    {
+    }
+
+    public Int2NullableObjectHashMap(
+        @DoNotSub final int initialCapacity,
+        final float loadFactor)
+    {
+        super(initialCapacity, loadFactor);
+    }
+
+    /**
+     * Construct a new map allowing a configuration for initial capacity and load factor.
+     * @param initialCapacity       for the backing array
+     * @param loadFactor            limit for resizing on puts
+     * @param shouldAvoidAllocation should allocation be avoided by caching iterators and map entries.
+     */
+    public Int2NullableObjectHashMap(
+        @DoNotSub final int initialCapacity,
+        final float loadFactor,
+        final boolean shouldAvoidAllocation)
+    {
+        super(initialCapacity, loadFactor, shouldAvoidAllocation);
+    }
+
+    /**
+     * Copy construct a new map from an existing one.
+     *
+     * @param mapToCopy for construction.
+     */
+    public Int2NullableObjectHashMap(final Int2ObjectHashMap<V> mapToCopy)
+    {
+        super(mapToCopy);
+    }
+
+    @Override
+    protected Object mapNullValue(final Object value)
+    {
+        return value == null ? NullReference.INSTANCE : value;
+    }
+
+    @Override
+    protected V unmapNullValue(final Object value)
+    {
+        return value == NullReference.INSTANCE ? null : (V)value;
+    }
+}

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -186,11 +186,12 @@ public class Int2ObjectHashMap<V>
     public boolean containsValue(final Object value)
     {
         boolean found = false;
-        if (null != value)
+        final Object val = mapNullValue(value);
+        if (null != val)
         {
             for (final Object v : values)
             {
-                if (value.equals(v))
+                if (val.equals(v))
                 {
                     found = true;
                     break;
@@ -215,8 +216,13 @@ public class Int2ObjectHashMap<V>
      * @param key for indexing the {@link Map}
      * @return the value if found otherwise null
      */
-    @SuppressWarnings("unchecked")
     public V get(final int key)
+    {
+        return unmapNullValue(getMapped(key));
+    }
+
+    @SuppressWarnings("unchecked")
+    protected V getMapped(final int key)
     {
         @DoNotSub final int mask = values.length - 1;
         @DoNotSub int index = Hashing.hash(key, mask);
@@ -247,7 +253,7 @@ public class Int2ObjectHashMap<V>
      */
     public V computeIfAbsent(final int key, final IntFunction<? extends V> mappingFunction)
     {
-        V value = get(key);
+        V value = getMapped(key);
         if (value == null)
         {
             value = mappingFunction.apply(key);
@@ -255,6 +261,10 @@ public class Int2ObjectHashMap<V>
             {
                 put(key, value);
             }
+        }
+        else
+        {
+            value = unmapNullValue(value);
         }
 
         return value;
@@ -278,7 +288,8 @@ public class Int2ObjectHashMap<V>
     @SuppressWarnings("unchecked")
     public V put(final int key, final V value)
     {
-        requireNonNull(value, "Value cannot be null");
+        final V val = (V)mapNullValue(value);
+        requireNonNull(val, "Value cannot be null");
 
         V oldValue = null;
         @DoNotSub final int mask = values.length - 1;
@@ -301,14 +312,14 @@ public class Int2ObjectHashMap<V>
             keys[index] = key;
         }
 
-        values[index] = value;
+        values[index] = val;
 
         if (size > resizeThreshold)
         {
             increaseCapacity();
         }
 
-        return oldValue;
+        return unmapNullValue(oldValue);
     }
 
     /**
@@ -346,7 +357,7 @@ public class Int2ObjectHashMap<V>
             index = ++index & mask;
         }
 
-        return (V)value;
+        return unmapNullValue(value);
     }
 
     /**
@@ -438,7 +449,7 @@ public class Int2ObjectHashMap<V>
         while (true)
         {
             entryIterator.next();
-            sb.append(entryIterator.getIntKey()).append('=').append(entryIterator.getValue());
+            sb.append(entryIterator.getIntKey()).append('=').append(unmapNullValue(entryIterator.getValue()));
             if (!entryIterator.hasNext())
             {
                 return sb.append('}').toString();
@@ -475,7 +486,7 @@ public class Int2ObjectHashMap<V>
             if (null != thisValue)
             {
                 final Object thatValue = that.get(keys[i]);
-                if (!thisValue.equals(thatValue))
+                if (!thisValue.equals(mapNullValue(thatValue)))
                 {
                     return false;
                 }
@@ -502,6 +513,16 @@ public class Int2ObjectHashMap<V>
         }
 
         return result;
+    }
+
+    protected Object mapNullValue(final Object value)
+    {
+        return value;
+    }
+
+    protected V unmapNullValue(final Object value)
+    {
+        return (V)value;
     }
 
     /**
@@ -534,7 +555,7 @@ public class Int2ObjectHashMap<V>
     public boolean replace(final int key, final V oldValue, final V newValue)
     {
         final Object curValue = get(key);
-        if (curValue == null || !Objects.equals(curValue, oldValue))
+        if (curValue == null || !Objects.equals(unmapNullValue(curValue), oldValue))
         {
             return false;
         }
@@ -735,8 +756,9 @@ public class Int2ObjectHashMap<V>
         public boolean contains(final Object o)
         {
             final Entry entry = (Entry)o;
-            final V value = get(entry.getKey());
-            return value != null && value.equals(entry.getValue());
+            final int key = ((Integer)entry.getKey()).intValue();
+            final V value = getMapped(key);
+            return value != null && value.equals(mapNullValue(entry.getValue()));
         }
     }
 
@@ -843,7 +865,7 @@ public class Int2ObjectHashMap<V>
         {
             findNext();
 
-            return (V)values[position()];
+            return unmapNullValue(values[position()]);
         }
     }
 
@@ -902,7 +924,7 @@ public class Int2ObjectHashMap<V>
 
                 @DoNotSub public int hashCode()
                 {
-                    return Integer.hashCode(getIntKey()) ^ v.hashCode();
+                    return Integer.hashCode(getIntKey()) ^ (v != null ? v.hashCode() : 0);
                 }
 
                 @DoNotSub public boolean equals(final Object o)
@@ -914,8 +936,8 @@ public class Int2ObjectHashMap<V>
 
                     final Map.Entry e = (Entry)o;
 
-                    return (e.getKey() != null && e.getValue() != null) &&
-                        (e.getKey().equals(k) && e.getValue().equals(v));
+                    return (e.getKey() != null && e.getKey().equals(k)) &&
+                        ((e.getValue() == null && v == null) || e.getValue().equals(v));
                 }
 
                 public String toString()
@@ -937,12 +959,13 @@ public class Int2ObjectHashMap<V>
 
         public V getValue()
         {
-            return (V)values[position()];
+            return unmapNullValue(values[position()]);
         }
 
         public V setValue(final V value)
         {
-            requireNonNull(value);
+            final V val = (V)mapNullValue(value);
+            requireNonNull(val, "Value cannot be null");
 
             if (!this.isPositionValid)
             {
@@ -951,7 +974,7 @@ public class Int2ObjectHashMap<V>
 
             @DoNotSub final int pos = position();
             final Object oldValue = values[pos];
-            values[pos] = value;
+            values[pos] = val;
 
             return (V)oldValue;
         }

--- a/agrona/src/main/java/org/agrona/collections/NullReference.java
+++ b/agrona/src/main/java/org/agrona/collections/NullReference.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2018 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+public final class NullReference
+{
+    public static final NullReference INSTANCE = new NullReference();
+
+    public int hashCode()
+    {
+        return 0;
+    }
+
+    public boolean equals(final Object obj)
+    {
+        return obj == this;
+    }
+}

--- a/agrona/src/main/java/org/agrona/collections/Object2NullableObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2NullableObjectHashMap.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2018 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * Variation of {@link Object2ObjectHashMap} that allows {@code null} values.
+ */
+public class Object2NullableObjectHashMap<K, V> extends Object2ObjectHashMap<K, V>
+{
+    public Object2NullableObjectHashMap()
+    {
+    }
+
+    public Object2NullableObjectHashMap(
+        final int initialCapacity,
+        final float loadFactor)
+    {
+        super(initialCapacity, loadFactor);
+    }
+
+    /**
+     * @param initialCapacity       for the map to override {@link #MIN_CAPACITY}
+     * @param loadFactor            for the map to override {@link Hashing#DEFAULT_LOAD_FACTOR}.
+     * @param shouldAvoidAllocation should allocation be avoided by caching iterators and map entries.
+     */
+    public Object2NullableObjectHashMap(
+        final int initialCapacity,
+        final float loadFactor,
+        final boolean shouldAvoidAllocation)
+    {
+        super(initialCapacity, loadFactor, shouldAvoidAllocation);
+    }
+
+    @Override
+    protected Object mapNullValue(final Object value)
+    {
+        return value == null ? NullReference.INSTANCE : value;
+    }
+
+    @Override
+    protected V unmapNullValue(final Object value)
+    {
+        return value == NullReference.INSTANCE ? null : (V)value;
+    }
+}

--- a/agrona/src/main/java/org/agrona/generation/PrimitiveExpander.java
+++ b/agrona/src/main/java/org/agrona/generation/PrimitiveExpander.java
@@ -45,6 +45,7 @@ public final class PrimitiveExpander
         expandPrimitiveSpecialisedClass(COLLECTIONS, "IntLruCache");
         expandPrimitiveSpecialisedClass(COLLECTIONS, "Int2ObjectCache");
         expandPrimitiveSpecialisedClass(COLLECTIONS, "Int2ObjectHashMap");
+        expandPrimitiveSpecialisedClass(COLLECTIONS, "Int2NullableObjectHashMap");
         expandPrimitiveSpecialisedClass(COLLECTIONS, "Object2IntHashMap");
     }
 

--- a/agrona/src/test/java/org/agrona/collections/ConformanceTestsSuite.java
+++ b/agrona/src/test/java/org/agrona/collections/ConformanceTestsSuite.java
@@ -7,9 +7,11 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     Int2ObjectHashMapConformanceTest.class, Int2IntHashMapConformanceTest.class,
+    Int2NullableObjectHashMapConformanceTest.class,
     Long2ObjectHashMapConformanceTest.class, Long2LongHashMapConformanceTest.class,
+    Long2NullableObjectHashMapConformanceTest.class,
     Object2IntHashMapConformanceTest.class, Object2LongHashMapConformanceTest.class,
-    Object2ObjectHashMapConformanceTest.class})
+    Object2ObjectHashMapConformanceTest.class, Object2NullableObjectHashMapConformanceTest.class})
 public class ConformanceTestsSuite
 {
     // This is required so that the suites are picked up by gradle

--- a/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
@@ -78,7 +78,6 @@ public class Int2NullableObjectHashMapConformanceTest
         }.withFeatures(
             MapFeature.GENERAL_PURPOSE,
             MapFeature.ALLOWS_NULL_VALUES,
-            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
             CollectionSize.ANY,
             CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
             .named(name)

--- a/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
@@ -1,0 +1,87 @@
+package org.agrona.collections;
+
+import com.google.common.collect.testing.Helpers;
+import com.google.common.collect.testing.MapTestSuiteBuilder;
+import com.google.common.collect.testing.SampleElements;
+import com.google.common.collect.testing.TestMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import junit.framework.TestSuite;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class Int2NullableObjectHashMapConformanceTest
+{
+    // Generated suite to test conformity to the java.util.Set interface
+    public static TestSuite suite()
+    {
+        return mapTestSuite(new TestMapGenerator<Integer, Integer>()
+        {
+            public Integer[] createKeyArray(final int length)
+            {
+                return new Integer[length];
+            }
+
+            public Integer[] createValueArray(final int length)
+            {
+                return new Integer[length];
+            }
+
+            public SampleElements<Map.Entry<Integer, Integer>> samples()
+            {
+                return new SampleElements<>(
+                    Helpers.mapEntry(1, 123),
+                    Helpers.mapEntry(2, 234),
+                    Helpers.mapEntry(3, 345),
+                    Helpers.mapEntry(345, 6),
+                    Helpers.mapEntry(777, 666));
+            }
+
+            public Map<Integer, Integer> create(final Object... entries)
+            {
+                final Int2NullableObjectHashMap<Integer> map = new Int2NullableObjectHashMap<Integer>(
+                    entries.length * 2, Hashing.DEFAULT_LOAD_FACTOR, false);
+
+                for (final Object o : entries)
+                {
+                    @SuppressWarnings("unchecked")
+                    final Map.Entry<Integer, Integer> e = (Map.Entry<Integer, Integer>)o;
+                    map.put(e.getKey(), e.getValue());
+                }
+
+                return map;
+            }
+
+            @SuppressWarnings("unchecked")
+            public Map.Entry<Integer, Integer>[] createArray(final int length)
+            {
+                return new Map.Entry[length];
+            }
+
+            public Iterable<Map.Entry<Integer, Integer>> order(final List<Map.Entry<Integer, Integer>> insertionOrder)
+            {
+                return insertionOrder;
+            }
+        }, Int2NullableObjectHashMap.class.getSimpleName());
+    }
+
+    private static <T> TestSuite mapTestSuite(final TestMapGenerator<T, T> testMapGenerator, final String name)
+    {
+        return new MapTestSuiteBuilder<T, T>()
+        {
+            {
+                usingGenerator(testMapGenerator);
+            }
+        }.withFeatures(
+            MapFeature.GENERAL_PURPOSE,
+            MapFeature.ALLOWS_NULL_VALUES,
+            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
+            CollectionSize.ANY,
+            CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
+            .named(name)
+            .createTestSuite();
+    }
+}

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
@@ -374,6 +376,55 @@ public class Int2ObjectHashMapTest
 
         final Int2ObjectHashMap<String> mapCopy = new Int2ObjectHashMap<>(intToObjectMap);
         assertThat(mapCopy, is(intToObjectMap));
+    }
+
+    @Test
+    public void shouldAllowNullValuesWithNullMapping()
+    {
+        final Int2ObjectHashMap<String> map = new Int2ObjectHashMap<String>()
+        {
+            private final Object nullRef = new Object();
+
+            @Override
+            protected Object mapNullValue(final Object value)
+            {
+                return value == null ? nullRef : value;
+            }
+
+            @Override
+            protected String unmapNullValue(final Object value)
+            {
+                return value == nullRef ? null : (String)value;
+            }
+        };
+
+        map.put(0, null);
+        map.put(1, "one");
+
+        assertThat(map.get(0), nullValue());
+        assertThat(map.get(1), is("one"));
+        assertThat(map.get(-1), nullValue());
+
+        assertThat(map.containsKey(0), is(true));
+        assertThat(map.containsKey(1), is(true));
+        assertThat(map.containsKey(-1), is(false));
+
+        assertThat(map.values(), containsInAnyOrder(null, "one"));
+        assertThat(map.keySet(), containsInAnyOrder(0, 1));
+
+        assertThat(map.size(), is(2));
+
+        map.remove(0);
+
+        assertThat(map.get(0), nullValue());
+        assertThat(map.get(1), is("one"));
+        assertThat(map.get(-1), nullValue());
+
+        assertThat(map.containsKey(0), is(false));
+        assertThat(map.containsKey(1), is(true));
+        assertThat(map.containsKey(-1), is(false));
+
+        assertThat(map.size(), is(1));
     }
 }
 

--- a/agrona/src/test/java/org/agrona/collections/Long2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Long2NullableObjectHashMapConformanceTest.java
@@ -1,0 +1,100 @@
+package org.agrona.collections;
+
+import com.google.common.collect.testing.Helpers;
+import com.google.common.collect.testing.MapTestSuiteBuilder;
+import com.google.common.collect.testing.SampleElements;
+import com.google.common.collect.testing.TestMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import junit.framework.TestSuite;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class Long2NullableObjectHashMapConformanceTest
+{
+    // Generated suite to test conformity to the java.util.Set interface
+    public static TestSuite suite()
+    {
+        return mapTestSuite(new TestMapGenerator<Long, Long>()
+        {
+            public Long[] createKeyArray(final int length)
+            {
+                return new Long[length];
+            }
+
+            public Long[] createValueArray(final int length)
+            {
+                return new Long[length];
+            }
+
+            public SampleElements<Map.Entry<Long, Long>> samples()
+            {
+                return new SampleElements<>(
+                    Helpers.mapEntry(1L, 123L),
+                    Helpers.mapEntry(2L, 234L),
+                    Helpers.mapEntry(3L, 345L),
+                    Helpers.mapEntry(345L, 6L),
+                    Helpers.mapEntry(777L, 666L));
+            }
+
+            public Map<Long, Long> create(final Object... entries)
+            {
+                final Long2NullableObjectHashMap<Long> map = new Long2NullableObjectHashMap<Long>(
+                    entries.length * 2, Hashing.DEFAULT_LOAD_FACTOR, false)
+                {
+                    private final Object nullRef = new Object();
+
+                    protected Object mapNullValue(final Object value)
+                    {
+                        return value == null ? nullRef : value;
+                    }
+
+                    protected Long unmapNullValue(final Object value)
+                    {
+                        return value == nullRef ? null : (Long)value;
+                    }
+                };
+
+                for (final Object o : entries)
+                {
+                    @SuppressWarnings("unchecked")
+                    final Map.Entry<Long, Long> e = (Map.Entry<Long, Long>)o;
+                    map.put(e.getKey(), e.getValue());
+                }
+
+                return map;
+            }
+
+            @SuppressWarnings("unchecked")
+            public Map.Entry<Long, Long>[] createArray(final int length)
+            {
+                return new Map.Entry[length];
+            }
+
+            public Iterable<Map.Entry<Long, Long>> order(final List<Map.Entry<Long, Long>> insertionOrder)
+            {
+                return insertionOrder;
+            }
+        }, Long2NullableObjectHashMap.class.getSimpleName());
+    }
+
+    private static <T> TestSuite mapTestSuite(final TestMapGenerator<T, T> testMapGenerator, final String name)
+    {
+        return new MapTestSuiteBuilder<T, T>()
+        {
+            {
+                usingGenerator(testMapGenerator);
+            }
+        }.withFeatures(
+            MapFeature.GENERAL_PURPOSE,
+            MapFeature.ALLOWS_NULL_VALUES,
+            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
+            CollectionSize.ANY,
+            CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
+            .named(name)
+            .createTestSuite();
+    }
+}

--- a/agrona/src/test/java/org/agrona/collections/Long2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Long2NullableObjectHashMapConformanceTest.java
@@ -43,20 +43,7 @@ public class Long2NullableObjectHashMapConformanceTest
             public Map<Long, Long> create(final Object... entries)
             {
                 final Long2NullableObjectHashMap<Long> map = new Long2NullableObjectHashMap<Long>(
-                    entries.length * 2, Hashing.DEFAULT_LOAD_FACTOR, false)
-                {
-                    private final Object nullRef = new Object();
-
-                    protected Object mapNullValue(final Object value)
-                    {
-                        return value == null ? nullRef : value;
-                    }
-
-                    protected Long unmapNullValue(final Object value)
-                    {
-                        return value == nullRef ? null : (Long)value;
-                    }
-                };
+                    entries.length * 2, Hashing.DEFAULT_LOAD_FACTOR, false);
 
                 for (final Object o : entries)
                 {
@@ -91,7 +78,6 @@ public class Long2NullableObjectHashMapConformanceTest
         }.withFeatures(
             MapFeature.GENERAL_PURPOSE,
             MapFeature.ALLOWS_NULL_VALUES,
-            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
             CollectionSize.ANY,
             CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
             .named(name)

--- a/agrona/src/test/java/org/agrona/collections/Object2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2NullableObjectHashMapConformanceTest.java
@@ -1,0 +1,87 @@
+package org.agrona.collections;
+
+import com.google.common.collect.testing.Helpers;
+import com.google.common.collect.testing.MapTestSuiteBuilder;
+import com.google.common.collect.testing.SampleElements;
+import com.google.common.collect.testing.TestMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import junit.framework.TestSuite;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class Object2NullableObjectHashMapConformanceTest
+{
+    // Generated suite to test conformity to the java.util.Set interface
+    public static TestSuite suite()
+    {
+        return mapTestSuite(new TestMapGenerator<Long, Long>()
+        {
+            public Long[] createKeyArray(final int length)
+            {
+                return new Long[length];
+            }
+
+            public Long[] createValueArray(final int length)
+            {
+                return new Long[length];
+            }
+
+            public SampleElements<Map.Entry<Long, Long>> samples()
+            {
+                return new SampleElements<>(
+                    Helpers.mapEntry(1L, 123L),
+                    Helpers.mapEntry(2L, 234L),
+                    Helpers.mapEntry(3L, 345L),
+                    Helpers.mapEntry(345L, 6L),
+                    Helpers.mapEntry(777L, 666L));
+            }
+
+            public Map<Long, Long> create(final Object... entries)
+            {
+                final Object2NullableObjectHashMap<Long, Long> map = new Object2NullableObjectHashMap<>(
+                    entries.length * 2, Hashing.DEFAULT_LOAD_FACTOR, false);
+
+                for (final Object o : entries)
+                {
+                    @SuppressWarnings("unchecked")
+                    final Map.Entry<Long, Long> e = (Map.Entry<Long, Long>)o;
+                    map.put(e.getKey(), e.getValue());
+                }
+
+                return map;
+            }
+
+            @SuppressWarnings("unchecked")
+            public Map.Entry<Long, Long>[] createArray(final int length)
+            {
+                return new Map.Entry[length];
+            }
+
+            public Iterable<Map.Entry<Long, Long>> order(final List<Map.Entry<Long, Long>> insertionOrder)
+            {
+                return insertionOrder;
+            }
+        }, Object2NullableObjectHashMap.class.getSimpleName());
+    }
+
+    private static <T> TestSuite mapTestSuite(final TestMapGenerator<T, T> testMapGenerator, final String name)
+    {
+        return new MapTestSuiteBuilder<T, T>()
+        {
+            {
+                usingGenerator(testMapGenerator);
+            }
+        }.withFeatures(
+            MapFeature.GENERAL_PURPOSE,
+            MapFeature.ALLOWS_NULL_VALUES,
+            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
+            CollectionSize.ANY,
+            CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
+            .named(name)
+            .createTestSuite();
+    }
+}

--- a/agrona/src/test/java/org/agrona/collections/Object2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2NullableObjectHashMapConformanceTest.java
@@ -78,7 +78,6 @@ public class Object2NullableObjectHashMapConformanceTest
         }.withFeatures(
             MapFeature.GENERAL_PURPOSE,
             MapFeature.ALLOWS_NULL_VALUES,
-            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
             CollectionSize.ANY,
             CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
             .named(name)


### PR DESCRIPTION
This is a variation of #153, that adds the nullability of values to `Object2ObjectHashMap`, `Int2ObjectHashMap` + `Long2ObjectHashMap`. It's basically identical to the other PR, except that the nullability of the map values is optional via `xyz2NullableObjectHashMap`. `BiInt2ObjectHashMap` although allows `null` values.

Note: this PR does _not_ include the fix for `Object2ObjectHashMap.AbstractIterator.remove()`, because it's not implicitly required for this variant of #153.