### PR TITLE
Added a copyMemory method o ExpandableDirectByteBuffer.java

### DIFF
--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -140,6 +140,17 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         }
     }
 
+    public void copyMemory(final int index, final long fromAddress,
+                           final int length)
+    {
+        lengthCheck(length);
+        ensureCapacity(index, length);
+
+        final long indexOffset = address + index;
+
+        UNSAFE.copyMemory(fromAddress, indexOffset, length);
+    }
+
     public int capacity()
     {
         return capacity;

--- a/agrona/src/test/java/org/agrona/CopyMemoryTest.java
+++ b/agrona/src/test/java/org/agrona/CopyMemoryTest.java
@@ -1,0 +1,19 @@
+package org.agrona;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CopyMemoryTest {
+    @Test
+    public void shouldCopyMemory(){
+        long valueOfLong = 34567;
+        long addressOfLong = UnsafeAccess.UNSAFE.allocateMemory(8);
+        UnsafeAccess.UNSAFE.putLong(addressOfLong, valueOfLong);
+
+        final ExpandableDirectByteBuffer buffer
+                = new ExpandableDirectByteBuffer(128);
+        buffer.copyMemory(23,addressOfLong,8);
+        long aLong = buffer.getLong(23);
+        Assert.assertEquals(valueOfLong, aLong);
+    }
+}


### PR DESCRIPTION
This is a utility method added to ExpandableDirectByteBuffer which would have been super useful for me in the project I've been working on recently. Ideally it would have been added to the interface MutableDirectBuffer only there are a number of implementations that are not relevant for this method (I didn't want to throw UnsupportedOperationException too often) so I added directly to the implementation for which it was intended.  

Would welcome feedback on this decision and if you think it is a useful addition and if so if it could be added to an interface or if it is acceptable to be added to this specific implementation.