### PR TITLE
[Java] Correctly load system properties in SystemUtil

### DIFF
--- a/agrona/src/main/java/org/agrona/SystemUtil.java
+++ b/agrona/src/main/java/org/agrona/SystemUtil.java
@@ -151,7 +151,8 @@ public class SystemUtil
      */
     public static void loadPropertiesFile(final String filenameOrUrl)
     {
-        final Properties properties = new Properties(System.getProperties());
+        final Properties properties = new Properties();
+        System.getProperties().forEach(properties::put);
 
         final URL resource = ClassLoader.getSystemClassLoader().getResource(filenameOrUrl);
         if (null != resource)

--- a/agrona/src/test/resources/TestFileA.properties
+++ b/agrona/src/test/resources/TestFileA.properties
@@ -1,0 +1,1 @@
+TestFileA.foo=AAA

--- a/agrona/src/test/resources/TestFileB.properties
+++ b/agrona/src/test/resources/TestFileB.properties
@@ -1,0 +1,1 @@
+TestFileB.foo=BBB


### PR DESCRIPTION
This PR changes the behaviour for SystemUtil.loadPropertiesFile so that system properties are correctly loaded. 

I've also added a couple of tests 
 - one which documents the behaviour for loadProperties 
 - another which documents how properties are merged between systemprops and props from a file. 