### PR TITLE
Ability to disable array content printout on UnsafeBuffer#toString().

### DIFF
--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -38,6 +38,10 @@ import static org.agrona.AsciiEncoding.*;
  */
 public class ExpandableArrayBuffer implements MutableDirectBuffer
 {
+
+    private static final boolean SHOULD_PRINT_ARRAY_CONTENT =
+        !Boolean.getBoolean(DISABLE_ARRAY_CONTENT_PRINTOUT_PROP_NAME);
+
     /**
      * Maximum length to which the underlying buffer can grow. Some JVMs set bits in the last few bytes.
      */
@@ -1107,7 +1111,7 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
     public String toString()
     {
         return "ExpandableArrayBuffer{" +
-            "byteArray=" + Arrays.toString(byteArray) +
+            "byteArray=" + (SHOULD_PRINT_ARRAY_CONTENT ? Arrays.toString(byteArray) : byteArray) +
             '}';
     }
 }

--- a/agrona/src/main/java/org/agrona/MutableDirectBuffer.java
+++ b/agrona/src/main/java/org/agrona/MutableDirectBuffer.java
@@ -26,6 +26,12 @@ import java.nio.ByteOrder;
  */
 public interface MutableDirectBuffer extends DirectBuffer
 {
+
+    /**
+     * Don't print the content of the array while calling toString() on buffer instance.
+     */
+    String DISABLE_ARRAY_CONTENT_PRINTOUT_PROP_NAME = "agrona.disable.array.printout";
+
     /**
      * Is this buffer expandable to accommodate putting data into it beyond the current capacity?
      *

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -55,6 +55,8 @@ public class UnsafeBuffer implements AtomicBuffer
 
     public static final String DISABLE_BOUNDS_CHECKS_PROP_NAME = "agrona.disable.bounds.checks";
     public static final boolean SHOULD_BOUNDS_CHECK = !Boolean.getBoolean(DISABLE_BOUNDS_CHECKS_PROP_NAME);
+    public static final boolean SHOULD_PRINT_ARRAY_CONTENT =
+        !Boolean.getBoolean(DISABLE_ARRAY_CONTENT_PRINTOUT_PROP_NAME);
 
     private long addressOffset;
     private int capacity;
@@ -1752,7 +1754,8 @@ public class UnsafeBuffer implements AtomicBuffer
         return "UnsafeBuffer{" +
             "addressOffset=" + addressOffset +
             ", capacity=" + capacity +
-            ", byteArray=" + Arrays.toString(byteArray) +
+            ", byteArray=" + (SHOULD_PRINT_ARRAY_CONTENT ?
+                Arrays.toString(byteArray) : byteArray) +
             ", byteBuffer=" + byteBuffer +
             '}';
     }

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -22,6 +22,8 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -30,8 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 @RunWith(Theories.class)
 public class UnsafeBufferTest
@@ -234,6 +235,25 @@ public class UnsafeBufferTest
     private void putAscii(final UnsafeBuffer buffer, final String value)
     {
         buffer.putBytes(INDEX, value.getBytes(US_ASCII));
+    }
+
+    @Test
+    public void shouldSkipArrayContentPrintout() throws Exception
+    {
+        final Field settingField = UnsafeBuffer.class.getDeclaredField("SHOULD_PRINT_ARRAY_CONTENT");
+        settingField.setAccessible(true);
+        final Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(settingField, settingField.getModifiers() & ~Modifier.FINAL);
+
+        final byte[] backingArray = new byte[10];
+        final UnsafeBuffer unsafeBuffer = new UnsafeBuffer(backingArray);
+
+        settingField.set(null, true);
+        assertTrue(unsafeBuffer.toString().contains(Arrays.toString(backingArray)));
+
+        settingField.set(null, false);
+        assertFalse(unsafeBuffer.toString().contains(Arrays.toString(backingArray)));
     }
 
     @DataPoints


### PR DESCRIPTION
I was a bit baffled for a few moments why IDEA didn't want to skip over a method in debug mode. It turns out the debugger calls toString() on objects quite profusely.

UnsafeBuffer#toString() if it is backed by an array will print the content of the array. For large arrays this doesn't quite work out.

I added a property so it is possible to disable the printout while maintaining backward compatibility. If it is not an issue, maybe better to just go without printing the content altogether?

Also added for ExpandableArrayBuffer.