### PR TITLE
AsciiEncoding::GetDigit to throw a AsciiNumberFormatException.

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -80,13 +80,13 @@ public class AsciiEncoding
      * @param index within the string the value is encoded.
      * @param value of the encoding in ASCII.
      * @return the digit value of the encoded ASCII.
-     * @throws NumberFormatException if the value is not a digit.
+     * @throws AsciiNumberFormatException if the value is not a digit.
      */
     public static int getDigit(final int index, final byte value)
     {
         if (value < 0x30 || value > 0x39)
         {
-            throw new NumberFormatException("'" + ((char)value) + "' is not a valid digit @ " + index);
+            throw new AsciiNumberFormatException("'" + ((char)value) + "' is not a valid digit @ " + index);
         }
 
         return value - 0x30;
@@ -98,13 +98,13 @@ public class AsciiEncoding
      * @param index within the string the value is encoded.
      * @param value of the encoding in ASCII.
      * @return the digit value of the encoded ASCII.
-     * @throws NumberFormatException if the value is not a digit.
+     * @throws AsciiNumberFormatException if the value is not a digit.
      */
     public static int getDigit(final int index, final char value)
     {
         if (value < 0x30 || value > 0x39)
         {
-            throw new NumberFormatException("'" + value + "' is not a valid digit @ " + index);
+            throw new AsciiNumberFormatException("'" + value + "' is not a valid digit @ " + index);
         }
 
         return value - 0x30;

--- a/agrona/src/main/java/org/agrona/AsciiNumberFormatException.java
+++ b/agrona/src/main/java/org/agrona/AsciiNumberFormatException.java
@@ -2,8 +2,8 @@ package org.agrona;
 
 public class AsciiNumberFormatException extends NumberFormatException
 {
-    public AsciiNumberFormatException(final String s)
+    public AsciiNumberFormatException(final String message)
     {
-        super(s);
+        super(message);
     }
 }

--- a/agrona/src/main/java/org/agrona/AsciiNumberFormatException.java
+++ b/agrona/src/main/java/org/agrona/AsciiNumberFormatException.java
@@ -1,0 +1,9 @@
+package org.agrona;
+
+public class AsciiNumberFormatException extends NumberFormatException
+{
+    public AsciiNumberFormatException(final String s)
+    {
+        super(s);
+    }
+}

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -18,7 +18,7 @@ package org.agrona;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class AsciiEncodingTest
 {
@@ -40,5 +40,17 @@ public class AsciiEncodingTest
         assertThat(AsciiEncoding.parseLongAscii("7", 0, 1), is(7L));
         assertThat(AsciiEncoding.parseLongAscii("-7", 0, 2), is(-7L));
         assertThat(AsciiEncoding.parseLongAscii("3333", 1, 2), is(33L));
+    }
+
+    @Test(expected = AsciiNumberFormatException.class)
+    public void shouldThrowExceptionWhenDecodingCharNonAsciiValue()
+    {
+        AsciiEncoding.getDigit(0, 'a');
+    }
+
+    @Test(expected = AsciiNumberFormatException.class)
+    public void shouldThrowExceptionWhenDecodingByteNonAsciiValue()
+    {
+        AsciiEncoding.getDigit(0, (byte)'a');
     }
 }


### PR DESCRIPTION
Allows users to specifically handle errors occurring when a non-ascii digit is attempted to be parsed. Extends NumberFormatException for backwards compatibility
