### PR TITLE
Close all methods

### DIFF
--- a/agrona/src/main/java/org/agrona/CloseHelper.java
+++ b/agrona/src/main/java/org/agrona/CloseHelper.java
@@ -15,6 +15,10 @@
  */
 package org.agrona;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class CloseHelper
 {
     /**
@@ -55,5 +59,55 @@ public class CloseHelper
         {
             LangUtil.rethrowUnchecked(e);
         }
+    }
+
+    /**
+     * Close all closeables in closeables. If any of them throw then throw that exception.
+     * If multiple closeables throw an exception when being closed, then throw an exception that contains
+     * all of them as suppressed exceptions.
+     *
+     * @param closeables to be closed.
+     */
+    public static void closeAll(final List<? extends AutoCloseable> closeables)
+    {
+        if (closeables == null)
+        {
+            return;
+        }
+
+        final List<Exception> exceptions = new ArrayList<>();
+        for (final AutoCloseable closeable : closeables)
+        {
+            if (closeable != null)
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (final Exception ex)
+                {
+                    exceptions.add(ex);
+                }
+            }
+        }
+
+        if (!exceptions.isEmpty())
+        {
+            final Exception exception = exceptions.remove(0);
+            exceptions.forEach(exception::addSuppressed);
+            LangUtil.rethrowUnchecked(exception);
+        }
+    }
+
+    /**
+     * Close all closeables in closeables. If any of them throw then throw that exception.
+     * If multiple closeables throw an exception when being closed, then throw an exception that contains
+     * all of them as suppressed exceptions.
+     *
+     * @param closeables to be closed.
+     */
+    public static void closeAll(final AutoCloseable... closeables)
+    {
+        closeAll(Arrays.asList(closeables));
     }
 }

--- a/agrona/src/main/java/org/agrona/CloseHelper.java
+++ b/agrona/src/main/java/org/agrona/CloseHelper.java
@@ -75,7 +75,7 @@ public class CloseHelper
             return;
         }
 
-        final List<Exception> exceptions = new ArrayList<>();
+        List<Exception> exceptions = null;
         for (final AutoCloseable closeable : closeables)
         {
             if (closeable != null)
@@ -86,12 +86,16 @@ public class CloseHelper
                 }
                 catch (final Exception ex)
                 {
+                    if (exceptions == null)
+                    {
+                        exceptions = new ArrayList<>();
+                    }
                     exceptions.add(ex);
                 }
             }
         }
 
-        if (!exceptions.isEmpty())
+        if (exceptions != null)
         {
             final Exception exception = exceptions.remove(0);
             exceptions.forEach(exception::addSuppressed);


### PR DESCRIPTION
A common situation is that you want to cleanup multiple of closeable objects. The existing close helper methods aren't very useful as they either suppress the exception or fail to guarantee that everything was closed. Here's a pair of utility methods from Artio that take a list or var-args array of closeables, guarantee they're all closed and don't suppress an exception if there is one. Pull requesting as I've had requests from other people for using this kind of method in non-artio projects and it agrona makes sense as a location.