### PR TITLE
added a way to use a closure to write to a ring buffer

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBuffer.java
@@ -45,6 +45,20 @@ public interface RingBuffer
     boolean write(int msgTypeId, DirectBuffer srcBuffer, int srcIndex, int length);
 
     /**
+     * Non-blocking write of a message to an underlying ring-buffer. Instead of a the buffer writing a
+     * {@link DirectBuffer} to the underlying ring-buffer, this method calls a {@link WriteHandler}.
+     * This way you don't have to serialize or copy data until there is enough space in the buffer.
+     *
+     * @param msgTypeId type of the message encoding.
+     * @param length of the encoded message in bytes.
+     * @param writerHandler a write handler that is called when there is the requested space.
+     * @param t The object to write to the ring-buffer.
+     * @param <T> The type of Object to write to the ring-buffer.
+     * @return true if written to the ring-buffer, or false if insufficient space exists.
+     */
+    <T> boolean write(int msgTypeId, int length, WriteHandler<T> writerHandler, T t);
+
+    /**
      * Read as many messages as are available to the end of the ring buffer.
      * <p>
      * If the ring buffer wraps or encounters a type of record, such a a padding record, then an implementation

--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/WriteHandler.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/WriteHandler.java
@@ -1,0 +1,17 @@
+package org.agrona.concurrent.ringbuffer;
+
+import org.agrona.MutableDirectBuffer;
+
+@FunctionalInterface
+public interface WriteHandler<T>
+{
+    /**
+     * This is called by a {@link RingBuffer}'s write method when there is sufficient length.
+     *
+     * @param buffer ring-buffer's underlying {@link MutableDirectBuffer} to write to.
+     * @param offset the current offset to write to the buffer. If you don't write to this offset and
+     *     the requested length you will corrupt the ring-buffer.
+     * @param t The object to write to the buffer.
+     */
+    void handle(MutableDirectBuffer buffer, int offset, T t);
+}


### PR DESCRIPTION
Hi,

I've been using your a fork of  your RingBuffer for shared memory IPC  - I wrote an RSocket transport using it. RSocket-java uses Netty's ByteBufs, and  the ByteBufs can actually be backed by multiple NIO ByteBuffers. I wanted a way to write the to the RingBuffer without copying to an intermediate buffer so I added a write method that takes a closure. Here's an example of how I'm using it.

```
ByteBuf frame = queue.peek();
int length = frame.readableBytes();
if (ringBuffer.write(1, length, this::handleWrite, frame)) {
    queue.poll();
    ReferenceCountUtil.safeRelease(frame);
} 

...

// Write straight to the ring-buffer MutableDirectBuffer
private void handleWrite(MutableDirectBuffer buffer, int offset, ByteBuf byteBuf) {
    final ByteBuffer[] byteBuffers = byteBuf.nioBuffers();
    for (int i = 0, l = byteBuffers.length; i < l; i++) {
      ByteBuffer b = byteBuffers[i];
      if (b == null) {
        continue;
      }
      int remaining = b.remaining();
      buffer.putBytes(offset, b, remaining);
      offset += remaining;
    }
  }
```

Maybe other people will find this useful? Seems to work fairly well so far.

Thanks,
Robert
