### PR TITLE
AsciiEncoding.parseLongAscii() throw instead of returning zero for "-"

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -116,6 +116,8 @@ public class AsciiEncoding
      * @param cs     to parse.
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
+     * @throws AsciiNumberFormatException if <code>cs</code> is not an int value
+     * @throws IndexOutOfBoundsException if <code>cs</code> is empty
      * @return the parsed value.
      */
     public static int parseIntAscii(final CharSequence cs, final int index, final int length)
@@ -124,7 +126,7 @@ public class AsciiEncoding
         final int first = cs.charAt(index);
         int i = index;
 
-        if (first == MINUS_SIGN)
+        if (first == MINUS_SIGN && length > 1)
         {
             i++;
         }
@@ -149,6 +151,8 @@ public class AsciiEncoding
      * @param cs     to parse.
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
+     * @throws AsciiNumberFormatException if <code>cs</code> is not a long value
+     * @throws IndexOutOfBoundsException if <code>cs</code> is empty
      * @return the parsed value.
      */
     public static long parseLongAscii(final CharSequence cs, final int index, final int length)
@@ -157,7 +161,7 @@ public class AsciiEncoding
         final int first = cs.charAt(index);
         int i = index;
 
-        if (first == MINUS_SIGN)
+        if (first == MINUS_SIGN && length > 1)
         {
             i++;
         }

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -43,14 +43,44 @@ public class AsciiEncodingTest
     }
 
     @Test(expected = AsciiNumberFormatException.class)
-    public void shouldThrowExceptionWhenDecodingCharNonAsciiValue()
+    public void shouldThrowExceptionWhenDecodingCharNonNumericValue()
     {
         AsciiEncoding.getDigit(0, 'a');
     }
 
     @Test(expected = AsciiNumberFormatException.class)
-    public void shouldThrowExceptionWhenDecodingByteNonAsciiValue()
+    public void shouldThrowExceptionWhenDecodingByteNonNumericValue()
     {
         AsciiEncoding.getDigit(0, (byte)'a');
+    }
+
+    @Test(expected = AsciiNumberFormatException.class)
+    public void shouldThrowExceptionWhenParsingLongContainingLoneMinusSign()
+    {
+        AsciiEncoding.parseLongAscii("-", 0, 1);
+    }
+
+    @Test(expected = AsciiNumberFormatException.class)
+    public void shouldThrowExceptionWhenParsingIntegerContainingLoneMinusSign()
+    {
+        AsciiEncoding.parseIntAscii("-", 0, 1);
+    }
+
+    @Test(expected = AsciiNumberFormatException.class)
+    public void shouldThrowExceptionWhenParsingLongContainingLonePlusSign()
+    {
+        AsciiEncoding.parseLongAscii("+", 0, 1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldThrowExceptionWhenParsingEmptyLong()
+    {
+        AsciiEncoding.parseLongAscii("", 0, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldThrowExceptionWhenParsingEmptyInteger()
+    {
+        AsciiEncoding.parseIntAscii("", 0, 0);
     }
 }


### PR DESCRIPTION
Modify AsciiEncoding.parseIntAscii() and AsciiEncoding.parseLongAscii() to behave like java.lang.Integer.parseInt() and java.lang.Long.parseLong() respectively when it comes to handling lone signs.