### PR TITLE
[Java] minor bug in CollectionUtil.validatePositivePowerOfTwo()

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/CollectionUtil.java
+++ b/agrona/src/main/java/org/agrona/collections/CollectionUtil.java
@@ -94,9 +94,9 @@ public class CollectionUtil
      */
     public static void validatePositivePowerOfTwo(final int value)
     {
-        if (value > 0 && 1 == (value & (value - 1)))
+        if (value > 0 && 0 != (value & (value - 1)))
         {
-            throw new IllegalStateException("value must be a positive power of two");
+            throw new IllegalArgumentException("value must be a positive power of two");
         }
     }
 

--- a/agrona/src/test/java/org/agrona/collections/CollectionUtilTest.java
+++ b/agrona/src/test/java/org/agrona/collections/CollectionUtilTest.java
@@ -79,4 +79,31 @@ public class CollectionUtilTest
 
         assertThat(result, is(0));
     }
+
+    @Test
+    public void validatePositivePowerOfTwo_passed()
+    {
+        CollectionUtil.validatePositivePowerOfTwo(0);
+        CollectionUtil.validatePositivePowerOfTwo(1);
+        CollectionUtil.validatePositivePowerOfTwo(2);
+        CollectionUtil.validatePositivePowerOfTwo(64);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validatePositivePowerOfTwo_failed_3()
+    {
+        CollectionUtil.validatePositivePowerOfTwo(3);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validatePositivePowerOfTwo_failed_15()
+    {
+        CollectionUtil.validatePositivePowerOfTwo(15);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validatePositivePowerOfTwo_failed_33()
+    {
+        CollectionUtil.validatePositivePowerOfTwo(33);
+    }
 }


### PR DESCRIPTION
The ` CollectionUtil#validatePositivePowerOfTwo` code is a bit incorrect; also changed the exception thrown to the `IllegalArgumentException`