### PR TITLE
Fix bug in ExpandableRingBuffer

### DIFF
--- a/agrona/src/main/java/org/agrona/ExpandableRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableRingBuffer.java
@@ -386,15 +386,19 @@ public class ExpandableRingBuffer
         else if (tailOffset >= headOffset)
         {
             final int toEndRemaining = capacity - tailOffset;
-            if (alignedLength > toEndRemaining && alignedLength <= (totalRemaining - toEndRemaining))
+
+            if (alignedLength > toEndRemaining)
             {
-                buffer.putInt(tailOffset + MESSAGE_LENGTH_OFFSET, toEndRemaining);
-                buffer.putInt(tailOffset + MESSAGE_TYPE_OFFSET, MESSAGE_TYPE_PADDING);
-                tail += toEndRemaining;
-            }
-            else
-            {
-                resize(alignedLength);
+                if (alignedLength <= (totalRemaining - toEndRemaining))
+                {
+                    buffer.putInt(tailOffset + MESSAGE_LENGTH_OFFSET, toEndRemaining);
+                    buffer.putInt(tailOffset + MESSAGE_TYPE_OFFSET, MESSAGE_TYPE_PADDING);
+                    tail += toEndRemaining;
+                }
+                else
+                {
+                    resize(alignedLength);
+                }
             }
         }
 

--- a/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
@@ -17,6 +17,7 @@ package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -179,6 +180,26 @@ public class ExpandableRingBufferTest
         final InOrder inOrder = Mockito.inOrder(mockConsumer);
         inOrder.verify(mockConsumer).onMessage(any(MutableDirectBuffer.class), anyInt(), eq(MSG_LENGTH_ONE), anyInt());
         inOrder.verify(mockConsumer).onMessage(any(MutableDirectBuffer.class), anyInt(), eq(MSG_LENGTH_TWO), anyInt());
+    }
+
+    @Test
+    @Ignore
+    public void shouldAppendMessagesWithinCapacityWithoutExpanding()
+    {
+        final int initialCapacity = 1024;
+        final int maxCapacity = 2048;
+
+        final ExpandableRingBuffer ringBuffer = new ExpandableRingBuffer(initialCapacity, maxCapacity, false);
+
+        final ExpandableRingBuffer.MessageConsumer mockConsumer = mock(ExpandableRingBuffer.MessageConsumer.class);
+        when(mockConsumer.onMessage(any(), anyInt(), anyInt(), anyInt())).thenReturn(Boolean.TRUE);
+
+        assertThat(ringBuffer.capacity(), is(initialCapacity));
+
+        final int messageLength = 32;
+        ringBuffer.append(TEST_MSG, 0, messageLength);
+
+        assertThat(ringBuffer.capacity(), is(initialCapacity));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
@@ -17,7 +17,6 @@ package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -183,7 +182,6 @@ public class ExpandableRingBufferTest
     }
 
     @Test
-    @Ignore
     public void shouldAppendMessagesWithinCapacityWithoutExpanding()
     {
         final int initialCapacity = 1024;


### PR DESCRIPTION
The buffer increases capacity even when there is available space at the end of the buffer.