### PR TITLE
CRC-32

### DIFF
--- a/agrona-benchmarks/src/main/java/org/agrona/CrcUtilBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/CrcUtilBenchmark.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class CrcUtilBenchmark
+{
+    @Param({ "32", "64", "128", "256", "1024", "2048", "4096", "8192" })
+    private int length;
+
+    private int offset = 32;
+    private long address;
+    private ByteBuffer directByteBuffer;
+    private ByteBuffer heapByteBuffer;
+    private CRC32 crc32;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        directByteBuffer = BufferUtil.allocateDirectAligned(length + offset, 64);
+        heapByteBuffer = ByteBuffer.allocate(length + offset + 64);
+        address = BufferUtil.address(directByteBuffer);
+        directByteBuffer.position(offset);
+        heapByteBuffer.position(offset);
+        for (int i = 0; i < length; i++)
+        {
+            directByteBuffer.put((byte)i);
+            heapByteBuffer.put((byte)i);
+        }
+        directByteBuffer.flip().position(offset);
+        heapByteBuffer.flip().position(offset);
+        crc32 = new CRC32();
+    }
+
+    @Benchmark
+    public int publicApiHeapByteBuffer()
+    {
+        return callPublicApi(heapByteBuffer);
+    }
+
+    @Benchmark
+    public int publicApiDirectByteBuffer()
+    {
+        return callPublicApi(directByteBuffer);
+    }
+
+    @Benchmark
+    public int crcUtil()
+    {
+        return CrcUtil.crc32DirectByteBuffer(0, address, offset, length);
+    }
+
+    private int callPublicApi(final ByteBuffer byteBuffer)
+    {
+        final int limit = byteBuffer.limit();
+        final int position = byteBuffer.position();
+        crc32.reset();
+        crc32.update(byteBuffer);
+        final int checksum = (int)crc32.getValue();
+        byteBuffer.limit(limit).position(position);
+        return checksum;
+    }
+}

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -20,7 +20,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 /**
  * Helper for dealing with ASCII encoding of numbers.
  */
-public class AsciiEncoding
+public final class AsciiEncoding
 {
     public static final byte ZERO = '0';
     private static final int[] INT_ROUNDS =
@@ -39,6 +39,10 @@ public class AsciiEncoding
     public static final byte[] MIN_INTEGER_VALUE = String.valueOf(Integer.MIN_VALUE).getBytes(US_ASCII);
     public static final byte[] MIN_LONG_VALUE = String.valueOf(Long.MIN_VALUE).getBytes(US_ASCII);
     public static final byte MINUS_SIGN = (byte)'-';
+
+    private AsciiEncoding()
+    {
+    }
 
     /**
      * Get the end offset of an ASCII encoded value.

--- a/agrona/src/main/java/org/agrona/BitUtil.java
+++ b/agrona/src/main/java/org/agrona/BitUtil.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 /**
  * Miscellaneous useful functions for dealing with low level bits and bytes.
  */
-public class BitUtil
+public final class BitUtil
 {
     /**
      * Size of a byte in bytes
@@ -105,6 +105,10 @@ public class BitUtil
     }
 
     private static final int LAST_DIGIT_MASK = 0b1;
+
+    private BitUtil()
+    {
+    }
 
     /**
      * Fast method of finding the next power of 2 greater than or equal to the supplied value.

--- a/agrona/src/main/java/org/agrona/BufferUtil.java
+++ b/agrona/src/main/java/org/agrona/BufferUtil.java
@@ -24,7 +24,7 @@ import static org.agrona.UnsafeAccess.UNSAFE;
 /**
  * Common functions for buffer implementations.
  */
-public class BufferUtil
+public final class BufferUtil
 {
     public static final byte[] NULL_BYTES = "null".getBytes(StandardCharsets.UTF_8);
     public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
@@ -49,6 +49,10 @@ public class BufferUtil
         {
             throw new RuntimeException(ex);
         }
+    }
+
+    private BufferUtil()
+    {
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/CloseHelper.java
+++ b/agrona/src/main/java/org/agrona/CloseHelper.java
@@ -21,8 +21,12 @@ import java.util.List;
 /**
  * Utility functions to help with using {@link java.lang.AutoCloseable} resources.
  */
-public class CloseHelper
+public final class CloseHelper
 {
+    private CloseHelper()
+    {
+    }
+
     /**
      * Quietly close a {@link java.lang.AutoCloseable} dealing with nulls and exceptions.
      *

--- a/agrona/src/main/java/org/agrona/CrcUtil.java
+++ b/agrona/src/main/java/org/agrona/CrcUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.zip.CRC32;
+
+public final class CrcUtil
+{
+
+    private static final MethodHandle METHOD_HANDLE;
+
+    static
+    {
+        try
+        {
+            final Method method = CRC32.class
+                .getDeclaredMethod("updateByteBuffer", int.class, long.class, int.class, int.class);
+            method.setAccessible(true); // Make sure we can call that
+            METHOD_HANDLE = MethodHandles.lookup().unreflect(method);
+        }
+        catch (final NoSuchMethodException | IllegalAccessException e)
+        {
+            throw new Error("Failed to resolved CRC methods", e);
+        }
+    }
+
+    private CrcUtil()
+    {
+    }
+
+    /**
+     * Compute CRC-32 checksum on a contents of a direct ByteBuffer.
+     * <p>
+     * <em>WARNING: Executing this method non-direct ByteBuffer address may segfault the VM!</em>
+     *
+     * @param crc     current CRC-32 checksum.
+     * @param address at which the underlying ByteBuffer storage begins.
+     * @param offset  within the ByteBuffer.
+     * @param length  of the data from which CRC-32 checksum should be computed.
+     * @return CRC-32 checksum.
+     */
+    public static int crc32DirectByteBuffer(final int crc, final long address, final int offset, final int length)
+    {
+        try
+        {
+            return (int)METHOD_HANDLE.invokeExact(crc, address, offset, length);
+        }
+        catch (final Throwable throwable)
+        {
+            LangUtil.rethrowUnchecked(throwable);
+            return -1; // unreachable
+        }
+    }
+}

--- a/agrona/src/main/java/org/agrona/IoUtil.java
+++ b/agrona/src/main/java/org/agrona/IoUtil.java
@@ -36,7 +36,7 @@ import static java.nio.file.StandardOpenOption.WRITE;
 /**
  * Collection of IO utilities for dealing with files, especially mapping and un-mapping.
  */
-public class IoUtil
+public final class IoUtil
 {
     /**
      * Size in bytes of a file page.
@@ -79,6 +79,10 @@ public class IoUtil
 
             return method;
         }
+    }
+
+    private IoUtil()
+    {
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/LangUtil.java
+++ b/agrona/src/main/java/org/agrona/LangUtil.java
@@ -18,8 +18,12 @@ package org.agrona;
 /**
  * Grouping of language level utilities to make programming in Java more convenient.
  */
-public class LangUtil
+public final class LangUtil
 {
+    private LangUtil()
+    {
+    }
+
     /**
      * Rethrow an {@link java.lang.Throwable} preserving the stack trace but making it unchecked.
      *

--- a/agrona/src/main/java/org/agrona/PrintBufferUtil.java
+++ b/agrona/src/main/java/org/agrona/PrintBufferUtil.java
@@ -21,7 +21,7 @@ package org.agrona;
  *
  * This is code adapted from <a href="https://netty.io/">the Netty project</a> adopted to support {@link DirectBuffer}.
  */
-public class PrintBufferUtil
+public final class PrintBufferUtil
 {
     private static final String NEWLINE = System.lineSeparator();
     private static final String EMPTY_STRING = "";
@@ -46,6 +46,10 @@ public class PrintBufferUtil
         {
             BYTE2HEX_PAD[i] = Integer.toHexString(i);
         }
+    }
+
+    private PrintBufferUtil()
+    {
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/References.java
+++ b/agrona/src/main/java/org/agrona/References.java
@@ -46,8 +46,12 @@ import java.lang.ref.Reference;
  * this class, no assumptions, beyond those provided in the documentation below,
  * should be made about their actual implementation.
  */
-public class References
+public final class References
 {
+    private References()
+    {
+    }
+
     /**
      * Indicate whether a {@link Reference} has been cleared.
      *

--- a/agrona/src/main/java/org/agrona/SemanticVersion.java
+++ b/agrona/src/main/java/org/agrona/SemanticVersion.java
@@ -18,8 +18,12 @@ package org.agrona;
 /**
  * Store and extract a semantic version in a 4 byte integer.
  */
-public class SemanticVersion
+public final class SemanticVersion
 {
+    private SemanticVersion()
+    {
+    }
+
     /**
      * Compose a 4-byte integer with major, minor, and patch version stored in the least significant 3 bytes.
      * The sum of the components must be greater than zero.

--- a/agrona/src/main/java/org/agrona/Strings.java
+++ b/agrona/src/main/java/org/agrona/Strings.java
@@ -18,8 +18,12 @@ package org.agrona;
 /**
  * Utility functions for using Strings.
  */
-public class Strings
+public final class Strings
 {
+    private Strings()
+    {
+    }
+
     /**
      * Is a string null or empty?
      *

--- a/agrona/src/main/java/org/agrona/SystemUtil.java
+++ b/agrona/src/main/java/org/agrona/SystemUtil.java
@@ -31,7 +31,7 @@ import static java.lang.System.getProperty;
 /**
  * Utilities for inspecting the system.
  */
-public class SystemUtil
+public final class SystemUtil
 {
     /**
      * PID value if a process id could not be determined. This value should be equal to a kernel only process
@@ -71,6 +71,10 @@ public class SystemUtil
         }
 
         PID = pid;
+    }
+
+    private SystemUtil()
+    {
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/UnsafeAccess.java
+++ b/agrona/src/main/java/org/agrona/UnsafeAccess.java
@@ -24,7 +24,7 @@ import java.security.PrivilegedExceptionAction;
 /**
  * Obtain access the the {@link Unsafe} class for direct memory operations.
  */
-public class UnsafeAccess
+public final class UnsafeAccess
 {
     public static final Unsafe UNSAFE;
     public static final int ARRAY_BYTE_BASE_OFFSET;
@@ -52,5 +52,9 @@ public class UnsafeAccess
 
         UNSAFE = unsafe;
         ARRAY_BYTE_BASE_OFFSET = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+    }
+
+    private UnsafeAccess()
+    {
     }
 }

--- a/agrona/src/main/java/org/agrona/Verify.java
+++ b/agrona/src/main/java/org/agrona/Verify.java
@@ -20,8 +20,12 @@ import java.util.Map;
 /**
  * Various verification checks to be applied in code.
  */
-public class Verify
+public final class Verify
 {
+    private Verify()
+    {
+    }
+
     /**
      * Verify that a reference is not null.
      *

--- a/agrona/src/main/java/org/agrona/collections/ArrayListUtil.java
+++ b/agrona/src/main/java/org/agrona/collections/ArrayListUtil.java
@@ -20,8 +20,12 @@ import java.util.ArrayList;
 /**
  * Utility functions for working with {@link ArrayList}s.
  */
-public class ArrayListUtil
+public final class ArrayListUtil
 {
+    private ArrayListUtil()
+    {
+    }
+
     /**
      * Removes element at index, but instead of copying all elements to the left, moves into the same slot the last
      * element. This avoids the copy costs, but spoils the list order. If index is the last element it is just removed.

--- a/agrona/src/main/java/org/agrona/collections/ArrayUtil.java
+++ b/agrona/src/main/java/org/agrona/collections/ArrayUtil.java
@@ -56,6 +56,10 @@ public final class ArrayUtil
      */
     public static final int MAX_CAPACITY = Integer.MAX_VALUE - 8;
 
+    private ArrayUtil()
+    {
+    }
+
     /**
      * Add an element to an array resulting in a new array.
      *

--- a/agrona/src/main/java/org/agrona/collections/CollectionUtil.java
+++ b/agrona/src/main/java/org/agrona/collections/CollectionUtil.java
@@ -26,8 +26,12 @@ import java.util.function.ToIntFunction;
 /**
  * Utility functions for collection objects.
  */
-public class CollectionUtil
+public final class CollectionUtil
 {
+    private CollectionUtil()
+    {
+    }
+
     /**
      * A getOrDefault that doesn't create garbage if its suppler is non-capturing.
      *

--- a/agrona/src/main/java/org/agrona/collections/Hashing.java
+++ b/agrona/src/main/java/org/agrona/collections/Hashing.java
@@ -18,12 +18,16 @@ package org.agrona.collections;
 /**
  * Hashing functions for applying to integers.
  */
-public class Hashing
+public final class Hashing
 {
     /**
      * Default load factor to be used in open addressing hashed data structures.
      */
     public static final float DEFAULT_LOAD_FACTOR = 0.55f;
+
+    private Hashing()
+    {
+    }
 
     /**
      * Generate a hash for an int value. This is a no op.

--- a/agrona/src/main/java/org/agrona/generation/CompilerUtil.java
+++ b/agrona/src/main/java/org/agrona/generation/CompilerUtil.java
@@ -32,12 +32,16 @@ import static java.util.stream.Collectors.toList;
 /**
  * Utilities for compiling Java source files at runtime.
  */
-public class CompilerUtil
+public final class CompilerUtil
 {
     /**
      * Temporary directory for files.
      */
     private static final String TEMP_DIR_NAME = SystemUtil.tmpDirName();
+
+    private CompilerUtil()
+    {
+    }
 
     /**
      * Compile a {@link Map} of source files in-memory resulting in a {@link Class} which is named.

--- a/agrona/src/test/java/org/agrona/CrcUtilTest.java
+++ b/agrona/src/test/java/org/agrona/CrcUtilTest.java
@@ -1,0 +1,53 @@
+package org.agrona;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.ByteBuffer;
+import java.util.zip.CRC32;
+
+import static org.agrona.BufferUtil.address;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.agrona.CrcUtil.crc32DirectByteBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class CrcUtilTest
+{
+
+    @Test
+    void crc32DirectByteBufferShouldComputeCorrectCrc32Checksum()
+    {
+        final CRC32 crc32 = new CRC32();
+        final byte[] data = new byte[23];
+        for (int i = 0; i < data.length; i++)
+        {
+            data[i] = (byte)i;
+            crc32.update(i);
+        }
+        final int checksum1 = (int)crc32.getValue();
+        crc32.update(new byte[10]);
+        final int checksum2 = (int)crc32.getValue();
+
+        final ByteBuffer buffer = allocateDirectAligned(100, 64);
+        buffer.position(5);
+        buffer.put(data);
+        final long address = address(buffer);
+
+        assertEquals(checksum1, crc32DirectByteBuffer(0, address, 5, 23));
+        assertEquals(checksum2, crc32DirectByteBuffer(checksum1, address, 28, 10));
+        assertNotEquals(checksum2, crc32DirectByteBuffer(0, address, 28, 10));
+        assertEquals(checksum1, crc32DirectByteBuffer(0, address, 5, 23));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "-1,10", "33, 5", "0,-10", "0,100" })
+    void crc32DirectByteBufferProducesGarbageWhenWrongOffsetOrLengthSpecified(final int offset, final int length)
+    {
+        final ByteBuffer buffer = allocateDirectAligned(32, 32);
+        final long address = address(buffer);
+
+        assertNotEquals(0, crc32DirectByteBuffer(0, address, offset, length));
+    }
+}

--- a/agrona/src/test/java/org/agrona/concurrent/AgentInvokerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/AgentInvokerTest.java
@@ -146,6 +146,7 @@ public class AgentInvokerTest
         when(mockAgent.doWork()).thenThrow(new ClosedByInterruptException());
 
         assertExceptionNotReported();
+        assertTrue(Thread.interrupted()); // by throwing ClosedByInterruptException
     }
 
     @Test
@@ -167,6 +168,7 @@ public class AgentInvokerTest
             });
 
         assertExceptionNotReported();
+        assertTrue(Thread.interrupted()); // by throwing ClosedByInterruptException
     }
 
     private void assertExceptionNotReported()

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ def checkstyleVersion = '8.27'
 def hamcrestVersion = '2.2'
 def mockitoVersion = '3.2.4'
 def junitVersion = '4.12'
+def jmhVersion = '1.22'
 
 def agronaGroup = 'org.agrona'
 def agronaVersion = '1.1.1-SNAPSHOT'
@@ -409,8 +410,75 @@ project(':agrona-agent') {
     }
 }
 
+project(':agrona-benchmarks') {
+    apply plugin: 'com.github.johnrengelman.shadow'
+
+    dependencies {
+        compile "org.openjdk.jmh:jmh-core:${jmhVersion}"
+        annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}"
+        compile project(':agrona')
+    }
+
+    shadowJar {
+        mustRunAfter jar
+        archiveFileName = 'agrona-benchmarks.jar'
+        archiveClassifier = 'benchmarks'
+        manifest.attributes('Main-Class': 'org.openjdk.jmh.Main')
+    }
+
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment {
+                    MavenDeployment deployment -> signing.signPom(deployment)
+                }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                pom.project(projectPom)
+            }
+        }
+    }
+
+    task sourcesJar(type: Jar) {
+        archiveClassifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        archiveClassifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
+    }
+
+    signing {
+        required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.shadow
+    }
+}
+
 task uploadToMavenCentral {
-    dependsOn 'agrona:uploadArchives', 'agrona-agent:uploadArchives', 'agrona-agent:uploadShadow'
+    dependsOn 'agrona:uploadArchives',
+            'agrona-agent:uploadArchives',
+            'agrona-agent:uploadShadow',
+            'agrona-benchmarks:uploadArchives'
+}
+
+task runJavaBenchmarks(type: Exec) {
+    commandLine 'java',
+            '-jar', 'agrona-benchmarks/build/libs/agrona-benchmarks.jar',
+            '-jvmArgs', '-Dagrona.disable.bounds.checks=true -XX:+UseParallelOldGC',
+            '-w', '1s', '-r', '1s','-wi', '3', '-i', '5', '-tu', 'ns', '-f', '5'
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -481,7 +481,7 @@ task uploadToMavenCentral {
             'agrona-benchmarks:uploadArchives'
 }
 
-task runJavaBenchmarks(type: Exec) {
+task runJavaBenchmarks(type: Exec, dependsOn: 'agrona-benchmarks:shadowJar') {
     commandLine 'java',
             '-jar', 'agrona-benchmarks/build/libs/agrona-benchmarks.jar',
             '-jvmArgs', '-Dagrona.disable.bounds.checks=true -XX:+UseParallelOldGC',

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def byteBuddyVersion = '1.10.5'
 def checkstyleVersion = '8.27'
 def hamcrestVersion = '2.2'
 def mockitoVersion = '3.2.4'
-def junitVersion = '4.12'
+def junitVersion = '5.5.2'
 def jmhVersion = '1.22'
 
 def agronaGroup = 'org.agrona'
@@ -138,8 +138,13 @@ subprojects {
         checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
 
         testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
-        testImplementation "org.mockito:mockito-core:${mockitoVersion}"
-        testImplementation "junit:junit:${junitVersion}"
+        testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+        testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
+        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+        // Compatibility with JUnit 4
+        testCompileOnly "junit:junit:4.12"
+        testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
     }
 
     checkstyle.toolVersion = "${checkstyleVersion}"
@@ -178,6 +183,8 @@ subprojects {
             jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED')
             jvmArgs('--add-exports', 'jdk.unsupported/sun.misc=ALL-UNNAMED')
         }
+
+        useJUnitPlatform()
 
         testLogging {
             showStandardStreams = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':agrona', ':agrona-agent'
+include ':agrona', ':agrona-agent', 'agrona-benchmarks'


### PR DESCRIPTION
This PR adds `CrcUtil` class that allows computing CRC-32 checksum from a direct ByteBuffer's content without modifying any of the ByteBuffer state.