### PR TITLE
Switch to CRC-32C when on JDK 9+

### DIFF
--- a/agrona-benchmarks/src/main/java/org/agrona/Crc32Benchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/Crc32Benchmark.java
@@ -26,45 +26,41 @@ import java.util.zip.CRC32;
 @State(Scope.Benchmark)
 public class Crc32Benchmark
 {
-    @Param({ "32", "128", "256", "1376", "2048", "4096" })
+    @Param({ "8", "32", "128", "256", "1376", "2048", "4096" })
     private int length;
 
     private int offset = 32;
     private long address;
     private ByteBuffer directByteBuffer;
-    private ByteBuffer heapByteBuffer;
-    private CRC32 crc32;
 
     @Setup(Level.Trial)
     public void setup()
     {
         directByteBuffer = BufferUtil.allocateDirectAligned(length + offset, 64);
-        heapByteBuffer = ByteBuffer.allocate(length + offset + 64);
         address = BufferUtil.address(directByteBuffer);
         directByteBuffer.position(offset);
-        heapByteBuffer.position(offset);
 
         for (int i = 0; i < length; i++)
         {
             directByteBuffer.put((byte)i);
-            heapByteBuffer.put((byte)i);
         }
 
         directByteBuffer.flip().position(offset);
-        heapByteBuffer.flip().position(offset);
-        crc32 = new CRC32();
     }
 
     @Benchmark
-    public int publicApiHeapByteBuffer()
+    public int publicApi()
     {
-        return callPublicApi(heapByteBuffer);
-    }
+        final ByteBuffer buffer = this.directByteBuffer;
+        final int limit = buffer.limit();
+        final int position = buffer.position();
 
-    @Benchmark
-    public int publicApiDirectByteBuffer()
-    {
-        return callPublicApi(directByteBuffer);
+        final CRC32 crc32 = new CRC32();
+        crc32.update(buffer);
+        final int checksum = (int)crc32.getValue();
+        buffer.limit(limit).position(position);
+
+        return checksum;
     }
 
     @Benchmark
@@ -73,16 +69,4 @@ public class Crc32Benchmark
         return Checksums.crc32(0, address, offset, length);
     }
 
-    private int callPublicApi(final ByteBuffer byteBuffer)
-    {
-        final int limit = byteBuffer.limit();
-        final int position = byteBuffer.position();
-
-        crc32.reset();
-        crc32.update(byteBuffer);
-        final int checksum = (int)crc32.getValue();
-        byteBuffer.limit(limit).position(position);
-
-        return checksum;
-    }
 }


### PR DESCRIPTION
Currently `Checksums#crc32` always delegates to the `java.util.zip.CRC32`class from the JDK to compute actual checksum. This PR switches to the `java.util.zip.CRC32C` class added in JDK 9, because it offers a better performance.

Here are the benchmark results after the switch on different JDK versions:
```
-- JDK 8 [OpenJDK Runtime Environment (Zulu 8.42.0.23-CA-macosx) (build 1.8.0_232-b18)]
Benchmark                   (length)  Mode  Cnt    Score   Error  Units
Crc32Benchmark.crc32Native         8  avgt   25   10.469 ± 0.218  ns/op
Crc32Benchmark.crc32Native        32  avgt   25   14.744 ± 0.121  ns/op
Crc32Benchmark.crc32Native       128  avgt   25   19.667 ± 0.294  ns/op
Crc32Benchmark.crc32Native       256  avgt   25   23.427 ± 0.298  ns/op
Crc32Benchmark.crc32Native      1376  avgt   25   70.459 ± 0.512  ns/op
Crc32Benchmark.crc32Native      2048  avgt   25   93.551 ± 0.892  ns/op
Crc32Benchmark.crc32Native      4096  avgt   25  177.540 ± 6.714  ns/op
Crc32Benchmark.publicApi           8  avgt   25   12.847 ± 0.076  ns/op
Crc32Benchmark.publicApi          32  avgt   25   18.234 ± 1.457  ns/op
Crc32Benchmark.publicApi         128  avgt   25   22.746 ± 0.935  ns/op
Crc32Benchmark.publicApi         256  avgt   25   26.231 ± 0.243  ns/op
Crc32Benchmark.publicApi        1376  avgt   25   68.553 ± 0.802  ns/op
Crc32Benchmark.publicApi        2048  avgt   25   89.620 ± 0.357  ns/op
Crc32Benchmark.publicApi        4096  avgt   25  165.313 ± 0.835  ns/op

-- JDK 11 [OpenJDK Runtime Environment Zulu11.35+15-CA (build 11.0.5+10-LTS)]
Benchmark                   (length)  Mode  Cnt    Score   Error  Units
Crc32Benchmark.crc32Native         8  avgt   25    5.193 ± 0.084  ns/op
Crc32Benchmark.crc32Native        32  avgt   25    7.052 ± 0.081  ns/op
Crc32Benchmark.crc32Native       128  avgt   25   24.317 ± 0.380  ns/op
Crc32Benchmark.crc32Native       256  avgt   25   32.326 ± 0.416  ns/op
Crc32Benchmark.crc32Native      1376  avgt   25   53.498 ± 0.746  ns/op
Crc32Benchmark.crc32Native      2048  avgt   25   82.195 ± 3.682  ns/op
Crc32Benchmark.crc32Native      4096  avgt   25  142.558 ± 3.179  ns/op
Crc32Benchmark.publicApi           8  avgt   25   12.520 ± 0.235  ns/op
Crc32Benchmark.publicApi          32  avgt   25   16.088 ± 0.148  ns/op
Crc32Benchmark.publicApi         128  avgt   25   21.694 ± 0.814  ns/op
Crc32Benchmark.publicApi         256  avgt   25   24.933 ± 0.845  ns/op
Crc32Benchmark.publicApi        1376  avgt   25   66.377 ± 0.801  ns/op
Crc32Benchmark.publicApi        2048  avgt   25   87.008 ± 0.479  ns/op
Crc32Benchmark.publicApi        4096  avgt   25  161.073 ± 4.395  ns/op

-- JDK 13 [OpenJDK Runtime Environment Zulu13.28+11-CA (build 13.0.1+10-MTS)]
Benchmark                   (length)  Mode  Cnt    Score   Error  Units
Crc32Benchmark.crc32Native         8  avgt   25    5.186 ± 0.139  ns/op
Crc32Benchmark.crc32Native        32  avgt   25    7.148 ± 0.175  ns/op
Crc32Benchmark.crc32Native       128  avgt   25   26.088 ± 0.387  ns/op
Crc32Benchmark.crc32Native       256  avgt   25   34.758 ± 1.191  ns/op
Crc32Benchmark.crc32Native      1376  avgt   25   54.686 ± 1.231  ns/op
Crc32Benchmark.crc32Native      2048  avgt   25   82.077 ± 1.328  ns/op
Crc32Benchmark.crc32Native      4096  avgt   25  144.444 ± 3.305  ns/op
Crc32Benchmark.publicApi           8  avgt   25   12.541 ± 0.093  ns/op
Crc32Benchmark.publicApi          32  avgt   25   17.402 ± 0.935  ns/op
Crc32Benchmark.publicApi         128  avgt   25   21.878 ± 0.322  ns/op
Crc32Benchmark.publicApi         256  avgt   25   25.697 ± 0.420  ns/op
Crc32Benchmark.publicApi        1376  avgt   25   69.057 ± 0.884  ns/op
Crc32Benchmark.publicApi        2048  avgt   25   91.627 ± 1.244  ns/op
Crc32Benchmark.publicApi        4096  avgt   25  168.918 ± 3.055  ns/op
```