### PR TITLE
[Java] JUnit 5 migration

### DIFF
--- a/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
+++ b/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
@@ -15,35 +15,25 @@
  */
 package org.agrona.agent;
 
-import static java.nio.ByteOrder.BIG_ENDIAN;
-import static org.agrona.BitUtil.SIZE_OF_BYTE;
-import static org.agrona.BitUtil.SIZE_OF_CHAR;
-import static org.agrona.BitUtil.SIZE_OF_DOUBLE;
-import static org.agrona.BitUtil.SIZE_OF_FLOAT;
-import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.agrona.BitUtil.SIZE_OF_LONG;
-import static org.agrona.BitUtil.SIZE_OF_SHORT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.nio.ByteBuffer;
-import java.util.function.IntConsumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import net.bytebuddy.agent.ByteBuddyAgent;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.UnsafeAccess;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import net.bytebuddy.agent.ByteBuddyAgent;
+import java.nio.ByteBuffer;
+import java.util.function.IntConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static org.agrona.BitUtil.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BufferAlignmentAgentTest
 {
@@ -52,13 +42,13 @@ public class BufferAlignmentAgentTest
     private static final int HEAP_BUFFER_ALIGNMENT_OFFSET = UnsafeAccess.ARRAY_BYTE_BASE_OFFSET % 8;
     private static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("-?\\d+");
 
-    @BeforeClass
+    @BeforeAll
     public static void installAgent()
     {
         BufferAlignmentAgent.agentmain("", ByteBuddyAgent.install());
     }
 
-    @AfterClass
+    @AfterAll
     public static void removeAgent()
     {
         BufferAlignmentAgent.removeTransformer();
@@ -339,8 +329,8 @@ public class BufferAlignmentAgentTest
             assertTrue(matcher.find());
             final int offsetFound = Integer.parseInt(matcher.group());
 
-            assertEquals("BufferAlignmentException reported wrong index", index, indexFound);
-            assertNotEquals("BufferAlignmentException reported wrong offset", 0, offsetFound);
+            assertEquals(index, indexFound, "BufferAlignmentException reported wrong index");
+            assertNotEquals(0, offsetFound, "BufferAlignmentException reported wrong offset");
 
             return;
         }

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -15,10 +15,11 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AsciiEncodingTest
 {
@@ -42,45 +43,45 @@ public class AsciiEncodingTest
         assertThat(AsciiEncoding.parseLongAscii("3333", 1, 2), is(33L));
     }
 
-    @Test(expected = AsciiNumberFormatException.class)
+    @Test
     public void shouldThrowExceptionWhenDecodingCharNonNumericValue()
     {
-        AsciiEncoding.getDigit(0, 'a');
+        assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.getDigit(0, 'a'));
     }
 
-    @Test(expected = AsciiNumberFormatException.class)
+    @Test
     public void shouldThrowExceptionWhenDecodingByteNonNumericValue()
     {
-        AsciiEncoding.getDigit(0, (byte)'a');
+        assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.getDigit(0, (byte)'a'));
     }
 
-    @Test(expected = AsciiNumberFormatException.class)
+    @Test
     public void shouldThrowExceptionWhenParsingLongContainingLoneMinusSign()
     {
-        AsciiEncoding.parseLongAscii("-", 0, 1);
+        assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.parseLongAscii("-", 0, 1));
     }
 
-    @Test(expected = AsciiNumberFormatException.class)
+    @Test
     public void shouldThrowExceptionWhenParsingIntegerContainingLoneMinusSign()
     {
-        AsciiEncoding.parseIntAscii("-", 0, 1);
+        assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.parseIntAscii("-", 0, 1));
     }
 
-    @Test(expected = AsciiNumberFormatException.class)
+    @Test
     public void shouldThrowExceptionWhenParsingLongContainingLonePlusSign()
     {
-        AsciiEncoding.parseLongAscii("+", 0, 1);
+        assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.parseLongAscii("+", 0, 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldThrowExceptionWhenParsingEmptyLong()
     {
-        AsciiEncoding.parseLongAscii("", 0, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> AsciiEncoding.parseLongAscii("", 0, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldThrowExceptionWhenParsingEmptyInteger()
     {
-        AsciiEncoding.parseIntAscii("", 0, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> AsciiEncoding.parseIntAscii("", 0, 0));
     }
 }

--- a/agrona/src/test/java/org/agrona/AsciiSequenceViewTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiSequenceViewTest.java
@@ -16,10 +16,12 @@
 package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AsciiSequenceViewTest
 {
@@ -100,29 +102,29 @@ public class AsciiSequenceViewTest
         assertEquals(0, asciiSequenceView.getBytes(new UnsafeBuffer(new byte[128]), 16));
     }
 
-    @Test(expected = StringIndexOutOfBoundsException.class)
+    @Test
     public void shouldThrowIndexOutOfBoundsExceptionWhenCharNotPresentAtGivenPosition()
     {
         final String data = "foo";
         buffer.putStringWithoutLengthAscii(INDEX, data);
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        asciiSequenceView.charAt(4);
+        assertThrows(StringIndexOutOfBoundsException.class, () -> asciiSequenceView.charAt(4));
     }
 
-    @Test(expected = StringIndexOutOfBoundsException.class)
+    @Test
     public void shouldThrowExceptionWhenCharAtCalledWithNoBuffer()
     {
-        asciiSequenceView.charAt(0);
+        assertThrows(StringIndexOutOfBoundsException.class, () -> asciiSequenceView.charAt(0));
     }
 
-    @Test(expected = StringIndexOutOfBoundsException.class)
+    @Test
     public void shouldThrowExceptionWhenCharAtCalledWithNegativeIndex()
     {
         final String data = "foo";
         buffer.putStringWithoutLengthAscii(INDEX, data);
         asciiSequenceView.wrap(buffer, INDEX, data.length());
 
-        asciiSequenceView.charAt(-1);
+        assertThrows(StringIndexOutOfBoundsException.class, () -> asciiSequenceView.charAt(-1));
     }
 }

--- a/agrona/src/test/java/org/agrona/BitUtilTest.java
+++ b/agrona/src/test/java/org/agrona/BitUtilTest.java
@@ -15,13 +15,15 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
 import static org.agrona.BitUtil.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BitUtilTest
 {

--- a/agrona/src/test/java/org/agrona/BufferCompareTest.java
+++ b/agrona/src/test/java/org/agrona/BufferCompareTest.java
@@ -16,14 +16,12 @@
 package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class BufferCompareTest
 {

--- a/agrona/src/test/java/org/agrona/BufferExpansionTest.java
+++ b/agrona/src/test/java/org/agrona/BufferExpansionTest.java
@@ -15,24 +15,27 @@
  */
 package org.agrona;
 
-import org.junit.experimental.theories.DataPoint;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(Theories.class)
 public class BufferExpansionTest
 {
-    @DataPoint
-    public static final MutableDirectBuffer EXPANDABLE_ARRAY_BUFFER = new ExpandableArrayBuffer();
+    private static Stream<MutableDirectBuffer> buffers()
+    {
+        return Stream.of(
+            new ExpandableArrayBuffer(),
+            new ExpandableDirectByteBuffer()
+        );
+    }
 
-    @DataPoint
-    public static final MutableDirectBuffer EXPANDABLE_DIRECT_BYTE_BUFFER = new ExpandableDirectByteBuffer();
-
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldExpand(final MutableDirectBuffer buffer)
     {
         final int capacity = buffer.capacity();

--- a/agrona/src/test/java/org/agrona/BufferStringOperationsTest.java
+++ b/agrona/src/test/java/org/agrona/BufferStringOperationsTest.java
@@ -16,37 +16,34 @@
 package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.experimental.theories.DataPoint;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.stream.Stream;
 
 import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-@RunWith(Theories.class)
 public class BufferStringOperationsTest
 {
     private static final int BUFFER_CAPACITY = 256;
     private static final int INDEX = 8;
 
-    @DataPoint
-    public static final MutableDirectBuffer ARRAY_BUFFER = new UnsafeBuffer(new byte[BUFFER_CAPACITY]);
+    private static Stream<MutableDirectBuffer> buffers()
+    {
+        return Stream.of(
+            new UnsafeBuffer(new byte[BUFFER_CAPACITY]),
+            new UnsafeBuffer(ByteBuffer.allocateDirect(BUFFER_CAPACITY)),
+            new ExpandableArrayBuffer(BUFFER_CAPACITY),
+            new ExpandableDirectByteBuffer(BUFFER_CAPACITY)
+        );
+    }
 
-    @DataPoint
-    public static final MutableDirectBuffer BYTE_BUFFER = new UnsafeBuffer(ByteBuffer.allocateDirect(BUFFER_CAPACITY));
-
-    @DataPoint
-    public static final MutableDirectBuffer EXPANDABLE_ARRAY_BUFFER = new ExpandableArrayBuffer(BUFFER_CAPACITY);
-
-    @DataPoint
-    public static final MutableDirectBuffer EXPANDABLE_BYTE_BUFFER = new ExpandableDirectByteBuffer(BUFFER_CAPACITY);
-
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldInsertNonAsciiAsQuestionMark(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World £";
@@ -55,7 +52,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringAscii(INDEX), is("Hello World ?"));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldAppendAsciiStringInParts(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World Test";
@@ -79,7 +77,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringAscii(INDEX), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripAsciiStringNativeLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -89,7 +88,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringAscii(INDEX), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripAsciiStringBigEndianLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -99,7 +99,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringAscii(INDEX, ByteOrder.BIG_ENDIAN), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripAsciiStringWithoutLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -109,7 +110,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringWithoutLengthAscii(INDEX, value.length()), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripUtf8StringNativeLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello£ World £";
@@ -119,7 +121,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringUtf8(INDEX), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripUtf8StringBigEndianLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello£ World £";
@@ -129,7 +132,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringUtf8(INDEX, ByteOrder.BIG_ENDIAN), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldRoundTripUtf8StringWithoutLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello£ World £";
@@ -139,7 +143,8 @@ public class BufferStringOperationsTest
         assertThat(buffer.getStringWithoutLengthUtf8(INDEX, encodedLength), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldGetAsciiToAppendable(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -153,7 +158,8 @@ public class BufferStringOperationsTest
         assertThat(appendable.toString(), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldGetAsciiWithByteOrderToAppendable(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -167,7 +173,8 @@ public class BufferStringOperationsTest
         assertThat(appendable.toString(), is(value));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldGetAsciiToAppendableForLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -182,7 +189,8 @@ public class BufferStringOperationsTest
         assertThat(appendable.toString(), is(value.substring(0, length)));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldAppendWithInvalidChar(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";
@@ -197,7 +205,8 @@ public class BufferStringOperationsTest
         assertThat(appendable.toString(), is("Hello?World"));
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("buffers")
     public void shouldAppendWithInvalidCharWithoutLength(final MutableDirectBuffer buffer)
     {
         final String value = "Hello World";

--- a/agrona/src/test/java/org/agrona/BufferUtilTest.java
+++ b/agrona/src/test/java/org/agrona/BufferUtilTest.java
@@ -15,22 +15,22 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
-import static org.agrona.BitUtil.SIZE_OF_LONG;
-import static org.agrona.BitUtil.isAligned;
+import static org.agrona.BitUtil.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BufferUtilTest
 {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectNonPowerOfTwoAlignment()
     {
-        BufferUtil.allocateDirectAligned(1, 3);
+        assertThrows(IllegalArgumentException.class, () -> BufferUtil.allocateDirectAligned(1, 3));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/DeadlineTimerWheelTest.java
+++ b/agrona/src/test/java/org/agrona/DeadlineTimerWheelTest.java
@@ -16,17 +16,17 @@
 package org.agrona;
 
 import org.agrona.collections.MutableLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeadlineTimerWheelTest
 {
@@ -34,16 +34,16 @@ public class DeadlineTimerWheelTest
     private static final int RESOLUTION =
         BitUtil.findNextPositivePowerOfTwo((int)TimeUnit.MILLISECONDS.toNanos(1));
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldExceptionOnNonPowerOfTwoTicksPerWheel()
     {
-        new DeadlineTimerWheel(TIME_UNIT, 0, 16, 10);
+        assertThrows(IllegalArgumentException.class, () -> new DeadlineTimerWheel(TIME_UNIT, 0, 16, 10));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldExceptionOnNonPowerOfTwoResolution()
     {
-        new DeadlineTimerWheel(TIME_UNIT, 0, 17, 8);
+        assertThrows(IllegalArgumentException.class, () -> new DeadlineTimerWheel(TIME_UNIT, 0, 17, 8));
     }
 
     @Test
@@ -60,443 +60,244 @@ public class DeadlineTimerWheelTest
         assertEquals(wheel.startTime(), startTime);
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void shouldBeAbleToScheduleTimerOnEdgeOfTick()
     {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
-
-        final long deadline = 5 * wheel.tickResolution();
-        final long id = wheel.scheduleTimer(deadline);
-        assertEquals(wheel.deadline(id), deadline);
-
-        do
+        assertTimeout(Duration.ofSeconds(1), () ->
         {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
 
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value);
+            final long deadline = 5 * wheel.tickResolution();
+            final long id = wheel.scheduleTimer(deadline);
+            assertEquals(wheel.deadline(id), deadline);
 
-        // this is the first tick after the timer, so it should be on this edge
-        assertThat(firedTimestamp.value, is(6 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleNonZeroStartTime()
-    {
-        long controlTimestamp = 100 * RESOLUTION;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
-
-        final long id = wheel.scheduleTimer(controlTimestamp + (5 * wheel.tickResolution()));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value);
-
-        // this is the first tick after the timer, so it should be on this edge
-        assertThat(firedTimestamp.value, is(106 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleNanoTimeUnitTimers()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
-
-        final long id = wheel.scheduleTimer(controlTimestamp + (5 * wheel.tickResolution()) + 1);
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value);
-
-        // this is the first tick after the timer, so it should be on this edge
-        assertThat(firedTimestamp.value, is(6 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleMultipleRounds()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 16);
-
-        final long id = wheel.scheduleTimer(controlTimestamp + (63 * wheel.tickResolution()));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value);
-
-        // this is the first tick after the timer, so it should be on this edge
-        assertThat(firedTimestamp.value, is(64 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldBeAbleToCancelTimer()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
-
-        final long id = wheel.scheduleTimer(controlTimestamp + (63 * wheel.tickResolution()));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value && controlTimestamp < (16 * wheel.tickResolution()));
-
-        assertTrue(wheel.cancelTimer(id));
-        assertFalse(wheel.cancelTimer(id));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value && controlTimestamp < (128 * wheel.tickResolution()));
-
-        assertThat(firedTimestamp.value, is(-1L));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleExpiringTimersInPreviousTicks()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
-
-        final long id = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-
-        final long pollStartTimeNs = 32 * wheel.tickResolution();
-        controlTimestamp += pollStartTimeNs;
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            if (wheel.currentTickTime() > pollStartTimeNs)
+            do
             {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
                 controlTimestamp += wheel.tickResolution();
             }
-        }
-        while (-1 == firedTimestamp.value && controlTimestamp < (128 * wheel.tickResolution()));
+            while (-1 == firedTimestamp.value);
 
-        assertThat(firedTimestamp.value, is(pollStartTimeNs));
+            // this is the first tick after the timer, so it should be on this edge
+            assertThat(firedTimestamp.value, is(6 * wheel.tickResolution()));
+        });
     }
 
-    @Test(timeout = 1000)
+    @Test
+    public void shouldHandleNonZeroStartTime()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 100 * RESOLUTION;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
+
+            final long id = wheel.scheduleTimer(controlTimestamp + (5 * wheel.tickResolution()));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value);
+
+            // this is the first tick after the timer, so it should be on this edge
+            assertThat(firedTimestamp.value, is(106 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldHandleNanoTimeUnitTimers()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
+
+            final long id = wheel.scheduleTimer(controlTimestamp + (5 * wheel.tickResolution()) + 1);
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value);
+
+            // this is the first tick after the timer, so it should be on this edge
+            assertThat(firedTimestamp.value, is(6 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldHandleMultipleRounds()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 16);
+
+            final long id = wheel.scheduleTimer(controlTimestamp + (63 * wheel.tickResolution()));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value);
+
+            // this is the first tick after the timer, so it should be on this edge
+            assertThat(firedTimestamp.value, is(64 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToCancelTimer()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
+
+            final long id = wheel.scheduleTimer(controlTimestamp + (63 * wheel.tickResolution()));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value && controlTimestamp < (16 * wheel.tickResolution()));
+
+            assertTrue(wheel.cancelTimer(id));
+            assertFalse(wheel.cancelTimer(id));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value && controlTimestamp < (128 * wheel.tickResolution()));
+
+            assertThat(firedTimestamp.value, is(-1L));
+        });
+    }
+
+    @Test
+    public void shouldHandleExpiringTimersInPreviousTicks()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
+
+            final long id = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+
+            final long pollStartTimeNs = 32 * wheel.tickResolution();
+            controlTimestamp += pollStartTimeNs;
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                if (wheel.currentTickTime() > pollStartTimeNs)
+                {
+                    controlTimestamp += wheel.tickResolution();
+                }
+            }
+            while (-1 == firedTimestamp.value && controlTimestamp < (128 * wheel.tickResolution()));
+
+            assertThat(firedTimestamp.value, is(pollStartTimeNs));
+        });
+    }
+
+    @Test
     public void shouldHandleMultipleTimersInDifferentTicks()
     {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (23 * wheel.tickResolution()));
-
-        do
+        assertTimeout(Duration.ofSeconds(1), () ->
         {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    if (timerId == id1)
-                    {
-                        firedTimestamp1.value = now;
-                    }
-                    else if (timerId == id2)
-                    {
-                        firedTimestamp2.value = now;
-                    }
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 256);
 
-                    return true;
-                },
-                Integer.MAX_VALUE);
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (23 * wheel.tickResolution()));
 
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
-
-        assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(24 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleMultipleTimersInSameTickSameRound()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    if (timerId == id1)
-                    {
-                        firedTimestamp1.value = now;
-                    }
-                    else if (timerId == id2)
-                    {
-                        firedTimestamp2.value = now;
-                    }
-
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
-
-        assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(16 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleMultipleTimersInSameTickDifferentRound()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (23 * wheel.tickResolution()));
-
-        do
-        {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    if (timerId == id1)
-                    {
-                        firedTimestamp1.value = now;
-                    }
-                    else if (timerId == id2)
-                    {
-                        firedTimestamp2.value = now;
-                    }
-
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
-
-        assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(24 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldLimitExpiringTimers()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-
-        int numExpired = 0;
-
-        do
-        {
-            numExpired += wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id1));
-                    firedTimestamp1.value = now;
-                    return true;
-                },
-                1);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value && -1 == firedTimestamp2.value);
-
-        assertThat(numExpired, is(1));
-
-        do
-        {
-            numExpired += wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id2));
-                    firedTimestamp2.value = now;
-                    return true;
-                },
-                1);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value && -1 == firedTimestamp2.value);
-
-        assertThat(numExpired, is(2));
-
-        assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(17 * wheel.tickResolution()));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldHandleFalseReturnToExpireTimerAgain()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-
-        int numExpired = 0;
-
-        do
-        {
-            numExpired += wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    if (timerId == id1)
-                    {
-                        if (-1 == firedTimestamp1.value)
-                        {
-                            firedTimestamp1.value = now;
-                            return false;
-                        }
-
-                        firedTimestamp1.value = now;
-                    }
-                    else if (timerId == id2)
-                    {
-                        firedTimestamp2.value = now;
-                    }
-
-                    return true;
-                },
-                Integer.MAX_VALUE);
-
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
-
-        assertThat(firedTimestamp1.value, is(17 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(17 * wheel.tickResolution()));
-        assertThat(numExpired, is(2));
-    }
-
-    @Test(timeout = 1000)
-    public void shouldCopeWithExceptionFromHandler()
-    {
-        long controlTimestamp = 0;
-        final MutableLong firedTimestamp1 = new MutableLong(-1);
-        final MutableLong firedTimestamp2 = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-
-        final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-        final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
-
-        int numExpired = 0;
-        Exception e = null;
-        do
-        {
-            try
+            do
             {
-                numExpired += wheel.poll(
+                wheel.poll(
                     controlTimestamp,
                     (timeUnit, now, timerId) ->
                     {
                         if (timerId == id1)
                         {
                             firedTimestamp1.value = now;
-                            throw new IllegalStateException();
                         }
                         else if (timerId == id2)
                         {
@@ -509,38 +310,276 @@ public class DeadlineTimerWheelTest
 
                 controlTimestamp += wheel.tickResolution();
             }
-            catch (final Exception ex)
-            {
-                e = ex;
-            }
-        }
-        while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
+            while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
 
-        assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
-        assertThat(firedTimestamp2.value, is(16 * wheel.tickResolution()));
-        assertThat(numExpired, is((1)));
-        assertThat(wheel.timerCount(), is(0L));
-        assertNotNull(e);
+            assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(24 * wheel.tickResolution()));
+        });
     }
 
-    @Test(timeout = 1000)
+    @Test
+    public void shouldHandleMultipleTimersInSameTickSameRound()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        if (timerId == id1)
+                        {
+                            firedTimestamp1.value = now;
+                        }
+                        else if (timerId == id2)
+                        {
+                            firedTimestamp2.value = now;
+                        }
+
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
+
+            assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(16 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldHandleMultipleTimersInSameTickDifferentRound()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (23 * wheel.tickResolution()));
+
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        if (timerId == id1)
+                        {
+                            firedTimestamp1.value = now;
+                        }
+                        else if (timerId == id2)
+                        {
+                            firedTimestamp2.value = now;
+                        }
+
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
+
+            assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(24 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldLimitExpiringTimers()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+
+            int numExpired = 0;
+
+            do
+            {
+                numExpired += wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id1));
+                        firedTimestamp1.value = now;
+                        return true;
+                    },
+                    1);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp1.value && -1 == firedTimestamp2.value);
+
+            assertThat(numExpired, is(1));
+
+            do
+            {
+                numExpired += wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id2));
+                        firedTimestamp2.value = now;
+                        return true;
+                    },
+                    1);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp1.value && -1 == firedTimestamp2.value);
+
+            assertThat(numExpired, is(2));
+
+            assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(17 * wheel.tickResolution()));
+        });
+    }
+
+    @Test
+    public void shouldHandleFalseReturnToExpireTimerAgain()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+
+            int numExpired = 0;
+
+            do
+            {
+                numExpired += wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        if (timerId == id1)
+                        {
+                            if (-1 == firedTimestamp1.value)
+                            {
+                                firedTimestamp1.value = now;
+                                return false;
+                            }
+
+                            firedTimestamp1.value = now;
+                        }
+                        else if (timerId == id2)
+                        {
+                            firedTimestamp2.value = now;
+                        }
+
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
+
+            assertThat(firedTimestamp1.value, is(17 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(17 * wheel.tickResolution()));
+            assertThat(numExpired, is(2));
+        });
+    }
+
+    @Test
+    public void shouldCopeWithExceptionFromHandler()
+    {
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            long controlTimestamp = 0;
+            final MutableLong firedTimestamp1 = new MutableLong(-1);
+            final MutableLong firedTimestamp2 = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+
+            final long id1 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+            final long id2 = wheel.scheduleTimer(controlTimestamp + (15 * wheel.tickResolution()));
+
+            int numExpired = 0;
+            Exception e = null;
+            do
+            {
+                try
+                {
+                    numExpired += wheel.poll(
+                        controlTimestamp,
+                        (timeUnit, now, timerId) ->
+                        {
+                            if (timerId == id1)
+                            {
+                                firedTimestamp1.value = now;
+                                throw new IllegalStateException();
+                            }
+                            else if (timerId == id2)
+                            {
+                                firedTimestamp2.value = now;
+                            }
+
+                            return true;
+                        },
+                        Integer.MAX_VALUE);
+
+                    controlTimestamp += wheel.tickResolution();
+                }
+                catch (final Exception ex)
+                {
+                    e = ex;
+                }
+            }
+            while (-1 == firedTimestamp1.value || -1 == firedTimestamp2.value);
+
+            assertThat(firedTimestamp1.value, is(16 * wheel.tickResolution()));
+            assertThat(firedTimestamp2.value, is(16 * wheel.tickResolution()));
+            assertThat(numExpired, is((1)));
+            assertThat(wheel.timerCount(), is(0L));
+            assertNotNull(e);
+        });
+    }
+
+    @Test
     public void shouldBeAbleToIterateOverTimers()
     {
-        final long controlTimestamp = 0;
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
-        final long deadline1 = controlTimestamp + (15 * wheel.tickResolution());
-        final long deadline2 = controlTimestamp + ((15 + 7) * wheel.tickResolution());
+        assertTimeout(Duration.ofSeconds(1), () ->
+        {
+            final long controlTimestamp = 0;
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
+            final long deadline1 = controlTimestamp + (15 * wheel.tickResolution());
+            final long deadline2 = controlTimestamp + ((15 + 7) * wheel.tickResolution());
 
-        final long id1 = wheel.scheduleTimer(deadline1);
-        final long id2 = wheel.scheduleTimer(deadline2);
+            final long id1 = wheel.scheduleTimer(deadline1);
+            final long id2 = wheel.scheduleTimer(deadline2);
 
-        final Map<Long, Long> timerIdByDeadlineMap = new HashMap<>();
+            final Map<Long, Long> timerIdByDeadlineMap = new HashMap<>();
 
-        wheel.forEach(timerIdByDeadlineMap::put);
+            wheel.forEach(timerIdByDeadlineMap::put);
 
-        assertThat(timerIdByDeadlineMap.size(), is(2));
-        assertThat(timerIdByDeadlineMap.get(deadline1), is(id1));
-        assertThat(timerIdByDeadlineMap.get(deadline2), is(id2));
+            assertThat(timerIdByDeadlineMap.size(), is(2));
+            assertThat(timerIdByDeadlineMap.get(deadline1), is(id1));
+            assertThat(timerIdByDeadlineMap.get(deadline2), is(id2));
+        });
     }
 
     @Test
@@ -561,14 +600,14 @@ public class DeadlineTimerWheelTest
         assertThat(wheel.deadline(id2), is(DeadlineTimerWheel.NULL_DEADLINE));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotAllowResetWhenTimersActive()
     {
         final long controlTimestamp = 0;
         final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 8);
 
         wheel.scheduleTimer(controlTimestamp + 100);
-        wheel.resetStartTime(controlTimestamp + 1);
+        assertThrows(IllegalStateException.class, () -> wheel.resetStartTime(controlTimestamp + 1));
     }
 
     @Test
@@ -585,33 +624,36 @@ public class DeadlineTimerWheelTest
         assertThat(wheel.currentTickTime(), is(currentTickTime * 6));
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void shouldScheduleDeadlineInThePast()
     {
-        long controlTimestamp = 100 * RESOLUTION;
-        final MutableLong firedTimestamp = new MutableLong(-1);
-        final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
-
-        final long deadline = controlTimestamp - 3;
-        final long id = wheel.scheduleTimer(deadline);
-
-        do
+        assertTimeout(Duration.ofSeconds(1), () ->
         {
-            wheel.poll(
-                controlTimestamp,
-                (timeUnit, now, timerId) ->
-                {
-                    assertThat(timerId, is(id));
-                    firedTimestamp.value = now;
-                    return true;
-                },
-                Integer.MAX_VALUE);
+            long controlTimestamp = 100 * RESOLUTION;
+            final MutableLong firedTimestamp = new MutableLong(-1);
+            final DeadlineTimerWheel wheel = new DeadlineTimerWheel(TIME_UNIT, controlTimestamp, RESOLUTION, 1024);
 
-            controlTimestamp += wheel.tickResolution();
-        }
-        while (-1 == firedTimestamp.value);
+            final long deadline = controlTimestamp - 3;
+            final long id = wheel.scheduleTimer(deadline);
 
-        assertThat(firedTimestamp.value, greaterThan(deadline));
+            do
+            {
+                wheel.poll(
+                    controlTimestamp,
+                    (timeUnit, now, timerId) ->
+                    {
+                        assertThat(timerId, is(id));
+                        firedTimestamp.value = now;
+                        return true;
+                    },
+                    Integer.MAX_VALUE);
+
+                controlTimestamp += wheel.tickResolution();
+            }
+            while (-1 == firedTimestamp.value);
+
+            assertThat(firedTimestamp.value, greaterThan(deadline));
+        });
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableRingBufferTest.java
@@ -16,20 +16,17 @@
 package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import static org.agrona.ExpandableRingBuffer.HEADER_ALIGNMENT;
 import static org.agrona.ExpandableRingBuffer.HEADER_LENGTH;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class ExpandableRingBufferTest
@@ -39,16 +36,18 @@ public class ExpandableRingBufferTest
     private static final int MSG_LENGTH_THREE = 700;
     private static final UnsafeBuffer TEST_MSG = new UnsafeBuffer(new byte[MSG_LENGTH_THREE]);
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldExceptionForNegativeInitialCapacity()
     {
-        new ExpandableRingBuffer(-1, 0, true);
+        assertThrows(IllegalArgumentException.class,
+            () -> new ExpandableRingBuffer(-1, 0, true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldExceptionForOverMaxInitialCapacity()
     {
-        new ExpandableRingBuffer(ExpandableRingBuffer.MAX_CAPACITY + 1, ExpandableRingBuffer.MAX_CAPACITY, true);
+        assertThrows(IllegalArgumentException.class, () -> new ExpandableRingBuffer(
+            ExpandableRingBuffer.MAX_CAPACITY + 1, ExpandableRingBuffer.MAX_CAPACITY, true));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/LangUtilTest.java
+++ b/agrona/src/test/java/org/agrona/LangUtilTest.java
@@ -15,17 +15,16 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LangUtilTest
 {
-    @Test(expected = Throwable.class)
+    @Test
     public void shouldCatchCheckedException()
     {
-        throwHiddenCheckedException();
-        fail("Should have had an exception");
+        assertThrows(Throwable.class, LangUtilTest::throwHiddenCheckedException);
     }
 
     private static void throwHiddenCheckedException()

--- a/agrona/src/test/java/org/agrona/MarkFileTest.java
+++ b/agrona/src/test/java/org/agrona/MarkFileTest.java
@@ -1,5 +1,9 @@
 package org.agrona;
 
+import org.agrona.concurrent.SystemEpochClock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -8,18 +12,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
-import org.agrona.concurrent.SystemEpochClock;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MarkFileTest
 {
-    public final TemporaryFolder tmpDir = new TemporaryFolder();
+    @TempDir
+    File directory;
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldWaitForMarkFileToContainEnoughDataForVersionCheck() throws IOException
     {
-        final File directory = tmpDir.newFolder();
+
         final String filename = "markfile.dat";
         final Path markFilePath = directory.toPath().resolve(filename);
         Files.createFile(markFilePath);
@@ -28,7 +31,7 @@ public class MarkFileTest
         {
             channel.write(ByteBuffer.allocate(1));
         }
-        new MarkFile(directory, filename, 0,
-          16, 10, new SystemEpochClock(), v -> {}, msg -> {});
+        assertThrows(IllegalStateException.class, () ->
+            new MarkFile(directory, filename, 0, 16, 10, new SystemEpochClock(), v -> {}, msg -> {}));
     }
 }

--- a/agrona/src/test/java/org/agrona/PrintBufferUtilTest.java
+++ b/agrona/src/test/java/org/agrona/PrintBufferUtilTest.java
@@ -15,10 +15,10 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
 
 public class PrintBufferUtilTest
 {

--- a/agrona/src/test/java/org/agrona/ReferencesTest.java
+++ b/agrona/src/test/java/org/agrona/ReferencesTest.java
@@ -16,13 +16,13 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReferencesTest
 {

--- a/agrona/src/test/java/org/agrona/SemanticVersionTest.java
+++ b/agrona/src/test/java/org/agrona/SemanticVersionTest.java
@@ -15,9 +15,10 @@
  */
 package org.agrona;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SemanticVersionTest
 {
@@ -35,46 +36,46 @@ public class SemanticVersionTest
         assertEquals(patch, SemanticVersion.patch(version));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectNegativeMajor()
     {
-        SemanticVersion.compose(-1, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(-1, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectNegativeMinor()
     {
-        SemanticVersion.compose(1, -1, 1);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(1, -1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectNegativePatch()
     {
-        SemanticVersion.compose(1, 1, -1);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(1, 1, -1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectZeroVersion()
     {
-        SemanticVersion.compose(0, 0, 0);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(0, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectExcessiveMajor()
     {
-        SemanticVersion.compose(256, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(256, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectExcessiveMinor()
     {
-        SemanticVersion.compose(1, 256, 1);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(1, 256, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldDetectExcessivePatch()
     {
-        SemanticVersion.compose(1, 1, 256);
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.compose(1, 1, 256));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/StringNumbersLengthsTest.java
+++ b/agrona/src/test/java/org/agrona/StringNumbersLengthsTest.java
@@ -16,38 +16,35 @@
 package org.agrona;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Theories.class)
 public class StringNumbersLengthsTest
 {
-    @DataPoints
-    public static int[][] valuesAndLengths()
+    private static int[][] valuesAndLengths()
     {
         return new int[][]
-        {
-            {1, 1},
-            {10, 2},
-            {100, 3},
-            {1000, 4},
-            {12, 2},
-            {123, 3},
-            {2345, 4},
-            {9, 1},
-            {99, 2},
-            {999, 3},
-            {9999, 4},
-        };
+            {
+                { 1, 1 },
+                { 10, 2 },
+                { 100, 3 },
+                { 1000, 4 },
+                { 12, 2 },
+                { 123, 3 },
+                { 2345, 4 },
+                { 9, 1 },
+                { 99, 2 },
+                { 999, 3 },
+                { 9999, 4 },
+            };
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("valuesAndLengths")
     public void shouldPutNaturalInt(final int[] valueAndLength)
     {
         final int value = valueAndLength[0];
@@ -58,7 +55,8 @@ public class StringNumbersLengthsTest
         assertValueAndLengthEquals(valueAndLength, buffer, length);
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("valuesAndLengths")
     public void shouldPutNaturalLong(final int[] valueAndLength)
     {
         final long value = valueAndLength[0];
@@ -69,7 +67,8 @@ public class StringNumbersLengthsTest
         assertValueAndLengthEquals(valueAndLength, buffer, length);
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("valuesAndLengths")
     public void shouldPutInt(final int[] valueAndLength)
     {
         final int value = valueAndLength[0];
@@ -80,7 +79,8 @@ public class StringNumbersLengthsTest
         assertValueAndLengthEquals(valueAndLength, buffer, length);
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("valuesAndLengths")
     public void shouldPutLong(final int[] valueAndLength)
     {
         final int value = valueAndLength[0];
@@ -96,11 +96,13 @@ public class StringNumbersLengthsTest
         final int value = valueAndLength[0];
         final int expectedLength = valueAndLength[1];
 
-        assertEquals("for " + Arrays.toString(valueAndLength), expectedLength, length);
+        final String message = "for " + Arrays.toString(valueAndLength);
+
+        assertEquals(expectedLength, length, message);
 
         assertEquals(
-            "for " + Arrays.toString(valueAndLength),
             String.valueOf(value),
-            buffer.getStringWithoutLengthAscii(1, expectedLength));
+            buffer.getStringWithoutLengthAscii(1, expectedLength),
+            message);
     }
 }

--- a/agrona/src/test/java/org/agrona/SystemUtilTest.java
+++ b/agrona/src/test/java/org/agrona/SystemUtilTest.java
@@ -15,13 +15,14 @@
  */
 package org.agrona;
 
+import org.junit.jupiter.api.Test;
+
 import static org.agrona.SystemUtil.parseDuration;
 import static org.agrona.SystemUtil.parseSize;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SystemUtilTest
 {
@@ -52,22 +53,22 @@ public class SystemUtilTest
         assertThat(parseDuration("", "12s"), is(12L * 1000 * 1000 * 1000));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void shouldThrowWhenParseTimeHasBadSuffix()
     {
-        parseDuration("", "1g");
+        assertThrows(NumberFormatException.class, () -> parseDuration("", "1g"));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void shouldThrowWhenParseTimeHasBadTwoLetterSuffix()
     {
-        parseDuration("", "1zs");
+        assertThrows(NumberFormatException.class, () -> parseDuration("", "1zs"));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void shouldThrowWhenParseSizeOverflows()
     {
-        parseSize("", 8589934592L + "g");
+        assertThrows(NumberFormatException.class, () -> parseSize("", 8589934592L + "g"));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/ArrayUtilTest.java
+++ b/agrona/src/test/java/org/agrona/collections/ArrayUtilTest.java
@@ -15,10 +15,10 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.Integer.valueOf;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ArrayUtilTest
 {

--- a/agrona/src/test/java/org/agrona/collections/BiInt2ObjectMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/BiInt2ObjectMapTest.java
@@ -15,17 +15,15 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BiInt2ObjectMapTest
 {

--- a/agrona/src/test/java/org/agrona/collections/CollectionUtilTest.java
+++ b/agrona/src/test/java/org/agrona/collections/CollectionUtilTest.java
@@ -15,16 +15,18 @@
  */
 package org.agrona.collections;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.agrona.collections.CollectionUtil.removeIf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CollectionUtilTest
 {
@@ -73,7 +75,7 @@ public class CollectionUtilTest
             0,
             (x) ->
             {
-                Assert.fail("Shouldn't be called");
+                fail("Shouldn't be called");
                 return x + 1;
             });
 
@@ -88,21 +90,21 @@ public class CollectionUtilTest
         CollectionUtil.validatePositivePowerOfTwo(64);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void validatePositivePowerOfTwoFailWith3()
     {
-        CollectionUtil.validatePositivePowerOfTwo(3);
+        assertThrows(IllegalArgumentException.class, () -> CollectionUtil.validatePositivePowerOfTwo(3));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void validatePositivePowerOfTwoFailWith15()
     {
-        CollectionUtil.validatePositivePowerOfTwo(15);
+        assertThrows(IllegalArgumentException.class, () -> CollectionUtil.validatePositivePowerOfTwo(15));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void validatePositivePowerOfTwFailWith33()
     {
-        CollectionUtil.validatePositivePowerOfTwo(33);
+        assertThrows(IllegalArgumentException.class, () -> CollectionUtil.validatePositivePowerOfTwo(33));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2IntCounterMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntCounterMapTest.java
@@ -15,16 +15,18 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -238,16 +240,16 @@ public class Int2IntCounterMapTest
         assertEquals(count, map.size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSupportLoadFactorOfGreaterThanOne()
     {
-        new Int2IntHashMap(4, 2, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Int2IntHashMap(4, 2, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSupportLoadFactorOfOne()
     {
-        new Int2IntHashMap(4, 1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Int2IntHashMap(4, 1, 0));
     }
 
     @Test
@@ -256,12 +258,12 @@ public class Int2IntCounterMapTest
         final Int2IntHashMap map = new Int2IntHashMap(16, 0.6f, -1);
 
         IntStream.range(1, 17).forEach((i) -> map.put(i, i));
-        assertEquals("Map has correct size", 16, map.size());
+        assertEquals(16, map.size(), "Map has correct size");
 
         final List<Integer> keys = new ArrayList<>(map.keySet());
         keys.forEach(map::remove);
 
-        assertTrue("Map isn't empty", map.isEmpty());
+        assertTrue(map.isEmpty(), "Map isn't empty");
     }
 
     @Test
@@ -391,10 +393,10 @@ public class Int2IntCounterMapTest
         assertFalse(map.containsKey(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowInitialValueAsValue()
     {
-        map.put(1, INITIAL_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> map.put(1, INITIAL_VALUE));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapNotAvoidingAllocationTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapNotAvoidingAllocationTest.java
@@ -15,19 +15,23 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
 
 import static org.agrona.collections.Int2IntHashMap.MIN_CAPACITY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 public class Int2IntHashMapNotAvoidingAllocationTest extends Int2IntHashMapTest
 {
-    public Int2IntHashMapNotAvoidingAllocationTest()
+
+    @BeforeEach
+    void before()
     {
-        super(new Int2IntHashMap(MIN_CAPACITY, Hashing.DEFAULT_LOAD_FACTOR, MISSING_VALUE, false));
+        map = new Int2IntHashMap(MIN_CAPACITY, Hashing.DEFAULT_LOAD_FACTOR, MISSING_VALUE, false);
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -15,17 +15,19 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -33,16 +35,12 @@ public class Int2IntHashMapTest
 {
     static final int MISSING_VALUE = -1;
 
-    final Int2IntHashMap map;
+    Int2IntHashMap map;
 
-    public Int2IntHashMapTest()
+    @BeforeEach
+    void before()
     {
-        this (new Int2IntHashMap(MISSING_VALUE));
-    }
-
-    Int2IntHashMapTest(final Int2IntHashMap map)
-    {
-        this.map = map;
+        map = new Int2IntHashMap(MISSING_VALUE);
     }
 
     @Test
@@ -223,13 +221,13 @@ public class Int2IntHashMapTest
         assertIterateKeysWithoutHasNext();
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void shouldExceptionForEmptyIteration()
     {
-        keyIterator().next();
+        assertThrows(NoSuchElementException.class, () -> keyIterator().next());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void shouldExceptionWhenRunningOutOfElements()
     {
         addTwoElements();
@@ -237,7 +235,8 @@ public class Int2IntHashMapTest
         final Iterator<Integer> iterator = keyIterator();
         iterator.next();
         iterator.next();
-        iterator.next();
+
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
     @Test
@@ -371,16 +370,16 @@ public class Int2IntHashMapTest
         assertEquals(count, map.size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSupportLoadFactorOfGreaterThanOne()
     {
-        new Int2IntHashMap(4, 2, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Int2IntHashMap(4, 2, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSupportLoadFactorOfOne()
     {
-        new Int2IntHashMap(4, 1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Int2IntHashMap(4, 1, 0));
     }
 
     @Test
@@ -389,12 +388,12 @@ public class Int2IntHashMapTest
         final Int2IntHashMap map = new Int2IntHashMap(16, 0.6f, -1);
 
         IntStream.range(1, 17).forEach((i) -> map.put(i, i));
-        assertEquals("Map has correct size", 16, map.size());
+        assertEquals(16, map.size(), "Map has correct size");
 
         final List<Integer> keys = new ArrayList<>(map.keySet());
         keys.forEach(map::remove);
 
-        assertTrue("Map isn't empty", map.isEmpty());
+        assertTrue(map.isEmpty(), "Map isn't empty");
     }
 
     @Test
@@ -421,10 +420,10 @@ public class Int2IntHashMapTest
         assertThat(map.get(testKey), is(testValue));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowMissingValueAsValue()
     {
-        map.put(1, MISSING_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> map.put(1, MISSING_VALUE));
     }
 
     @Test
@@ -732,17 +731,17 @@ public class Int2IntHashMapTest
     private void assertHashcodeEquals(final Object expected, final Object value)
     {
         assertEquals(
-            value + " should have the same hashcode as " + expected,
             expected.hashCode(),
-            value.hashCode());
+            value.hashCode(),
+            value + " should have the same hashcode as " + expected);
     }
 
     private void assertHashcodeNotEquals(final Object unexpected, final Object value)
     {
         assertNotEquals(
-            value + " should not have the same hashcode as " + unexpected,
             unexpected.hashCode(),
-            value.hashCode());
+            value.hashCode(),
+            value + " should not have the same hashcode as " + unexpected);
     }
 
     private void entrySetContainsTwoElements()

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
@@ -15,17 +15,20 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Int2ObjectCacheTest
 {

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapNotAvoidingAllocationTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapNotAvoidingAllocationTest.java
@@ -15,12 +15,12 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Int2ObjectHashMapNotAvoidingAllocationTest extends Int2ObjectHashMapTest
 {

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -15,21 +15,19 @@
  */
 package org.agrona.collections;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Int2ObjectHashMapTest
 {
@@ -127,7 +125,7 @@ public class Int2ObjectHashMapTest
         intToObjectMap.clear();
 
         assertThat(intToObjectMap.size(), is(0));
-        Assert.assertNull(intToObjectMap.get(1));
+        assertNull(intToObjectMap.get(1));
     }
 
     @Test
@@ -158,8 +156,8 @@ public class Int2ObjectHashMapTest
 
         intToObjectMap.put(key, value);
 
-        Assert.assertTrue(intToObjectMap.containsValue(value));
-        Assert.assertFalse(intToObjectMap.containsValue("NoKey"));
+        assertTrue(intToObjectMap.containsValue(value));
+        assertFalse(intToObjectMap.containsValue("NoKey"));
     }
 
     @Test
@@ -170,8 +168,8 @@ public class Int2ObjectHashMapTest
 
         intToObjectMap.put(key, value);
 
-        Assert.assertTrue(intToObjectMap.containsKey(key));
-        Assert.assertFalse(intToObjectMap.containsKey(0));
+        assertTrue(intToObjectMap.containsKey(key));
+        assertFalse(intToObjectMap.containsKey(0));
     }
 
     @Test
@@ -182,11 +180,11 @@ public class Int2ObjectHashMapTest
 
         intToObjectMap.put(key, value);
 
-        Assert.assertTrue(intToObjectMap.containsKey(key));
+        assertTrue(intToObjectMap.containsKey(key));
 
         intToObjectMap.remove(key);
 
-        Assert.assertFalse(intToObjectMap.containsKey(key));
+        assertFalse(intToObjectMap.containsKey(key));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -15,16 +15,17 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IntArrayListTest
 {
@@ -247,10 +248,10 @@ public class IntArrayListTest
         }
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void shouldThrowExceptionWhenPoppingEmptyList()
     {
-        list.popInt();
+        assertThrows(NoSuchElementException.class, list::popInt);
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/IntArrayQueueTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayQueueTest.java
@@ -15,9 +15,9 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IntArrayQueueTest
 {

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -15,14 +15,15 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
 import static org.agrona.collections.IntHashSet.MISSING_VALUE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IntHashSetTest
 {
@@ -146,15 +147,15 @@ public class IntHashSetTest
         assertIteratorHasElementsWithoutHasNext();
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iteratorsThrowNoSuchElementException()
     {
         addTwoElements(testSet);
 
-        exhaustIterator();
+        assertThrows(NoSuchElementException.class, this::exhaustIterator);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
     {
         addTwoElements(testSet);
@@ -167,7 +168,7 @@ public class IntHashSetTest
         {
         }
 
-        exhaustIterator();
+        assertThrows(NoSuchElementException.class, this::exhaustIterator);
     }
 
     @Test
@@ -176,10 +177,10 @@ public class IntHashSetTest
         assertFalse(testSet.iterator().hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iteratorThrowExceptionForEmptySet()
     {
-        testSet.iterator().next();
+        assertThrows(NoSuchElementException.class, () -> testSet.iterator().next());
     }
 
     @Test
@@ -299,19 +300,19 @@ public class IntHashSetTest
         assertEquals(1, testSet.size());
     }
 
-    @Test(expected = ArrayStoreException.class)
+    @Test
     @SuppressWarnings("SuspiciousToArrayCall")
     public void toArrayThrowsArrayStoreExceptionForWrongType()
     {
-        testSet.toArray(new String[1]);
+        assertThrows(ArrayStoreException.class, () -> testSet.toArray(new String[1]));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("ConstantConditions")
     public void toArrayThrowsNullPointerExceptionForNullArgument()
     {
         final Integer[] into = null;
-        testSet.toArray(into);
+        assertThrows(NullPointerException.class, () -> testSet.toArray(into));
     }
 
     @Test
@@ -357,8 +358,8 @@ public class IntHashSetTest
         requiredFields.add(49);
         requiredFields.add(56);
 
-        assertTrue("Failed to remove 8", requiredFields.remove(8));
-        assertTrue("Failed to remove 9", requiredFields.remove(9));
+        assertTrue(requiredFields.remove(8), "Failed to remove 8");
+        assertTrue(requiredFields.remove(9), "Failed to remove 9");
 
         assertThat(requiredFields, containsInAnyOrder(35, 49, 56));
     }
@@ -831,9 +832,9 @@ public class IntHashSetTest
             testSet.add(MISSING_VALUE);
         }
 
-        assertEquals("Fail with seed:" + seed, testSet, compatibleSet);
-        assertEquals("Fail with seed:" + seed, compatibleSet, testSet);
-        assertEquals("Fail with seed:" + seed, compatibleSet.hashCode(), testSet.hashCode());
+        assertEquals(testSet, compatibleSet, "Fail with seed:" + seed);
+        assertEquals(compatibleSet, testSet, "Fail with seed:" + seed);
+        assertEquals(compatibleSet.hashCode(), testSet.hashCode(), "Fail with seed:" + seed);
     }
 
     private static void addTwoElements(final IntHashSet obj)

--- a/agrona/src/test/java/org/agrona/collections/IntLruCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntLruCacheTest.java
@@ -15,14 +15,14 @@
  */
 package org.agrona.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 public class IntLruCacheTest
@@ -38,7 +38,7 @@ public class IntLruCacheTest
 
     private AutoCloseable lastValue;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         when(mockFactory.apply(anyInt())).thenAnswer(

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapNotAvoidingAllocationTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapNotAvoidingAllocationTest.java
@@ -15,12 +15,12 @@
  */
 package org.agrona.collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Object2IntHashMapNotAvoidingAllocationTest extends Object2IntHashMapTest
 {

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -15,17 +15,19 @@
  */
 package org.agrona.collections;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Object2IntHashMapTest
 {
@@ -125,7 +127,7 @@ public class Object2IntHashMapTest
         objectToIntMap.clear();
 
         assertThat(objectToIntMap.size(), is(0));
-        Assert.assertEquals(MISSING_VALUE, objectToIntMap.getValue("1"));
+        assertEquals(MISSING_VALUE, objectToIntMap.getValue("1"));
     }
 
     @Test
@@ -156,8 +158,8 @@ public class Object2IntHashMapTest
 
         objectToIntMap.put(key, value);
 
-        Assert.assertTrue(objectToIntMap.containsValue(value));
-        Assert.assertFalse(objectToIntMap.containsValue(8));
+        assertTrue(objectToIntMap.containsValue(value));
+        assertFalse(objectToIntMap.containsValue(8));
     }
 
     @Test
@@ -168,8 +170,8 @@ public class Object2IntHashMapTest
 
         objectToIntMap.put(key, value);
 
-        Assert.assertTrue(objectToIntMap.containsKey(key));
-        Assert.assertFalse(objectToIntMap.containsKey("Eight"));
+        assertTrue(objectToIntMap.containsKey(key));
+        assertFalse(objectToIntMap.containsKey("Eight"));
     }
 
     @Test
@@ -180,11 +182,11 @@ public class Object2IntHashMapTest
 
         objectToIntMap.put(key, value);
 
-        Assert.assertTrue(objectToIntMap.containsKey(key));
+        assertTrue(objectToIntMap.containsKey(key));
 
         objectToIntMap.remove(key);
 
-        Assert.assertFalse(objectToIntMap.containsKey(key));
+        assertFalse(objectToIntMap.containsKey(key));
     }
 
     @Test
@@ -222,7 +224,7 @@ public class Object2IntHashMapTest
 
         final Collection<Integer> copyToSet = new HashSet<>();
 
-        for (final Object2IntHashMap<String>.ValueIterator iter = objectToIntMap.values().iterator(); iter.hasNext();)
+        for (final Object2IntHashMap<String>.ValueIterator iter = objectToIntMap.values().iterator(); iter.hasNext(); )
         {
             copyToSet.add(iter.nextInt());
         }

--- a/agrona/src/test/java/org/agrona/collections/ObjectHashSetIntegerTest.java
+++ b/agrona/src/test/java/org/agrona/collections/ObjectHashSetIntegerTest.java
@@ -15,22 +15,20 @@
  */
 package org.agrona.collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.*;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class ObjectHashSetIntegerTest
 {
-    @Parameterized.Parameters
-    public static Iterable<ObjectHashSet<Integer>> data()
+    private static Iterable<ObjectHashSet<Integer>> data()
     {
         return Arrays.asList(
             new ObjectHashSet<>(INITIAL_CAPACITY),
@@ -39,21 +37,9 @@ public class ObjectHashSetIntegerTest
 
     private static final int INITIAL_CAPACITY = 100;
 
-    private final ObjectHashSet<Integer> testSet;
-
-    public ObjectHashSetIntegerTest(final ObjectHashSet<Integer> testSet)
-    {
-        this.testSet = testSet;
-    }
-
-    @Before
-    public void clear()
-    {
-        testSet.clear();
-    }
-
-    @Test
-    public void initiallyContainsNoElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void initiallyContainsNoElements(final ObjectHashSet<Integer> testSet)
     {
         for (int i = 0; i < 10_000; i++)
         {
@@ -61,8 +47,9 @@ public class ObjectHashSetIntegerTest
         }
     }
 
-    @Test
-    public void initiallyContainsNoBoxedElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void initiallyContainsNoBoxedElements(final ObjectHashSet<Integer> testSet)
     {
         for (int i = 0; i < 10_000; i++)
         {
@@ -71,24 +58,27 @@ public class ObjectHashSetIntegerTest
         }
     }
 
-    @Test
-    public void containsAddedElement()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsAddedElement(final ObjectHashSet<Integer> testSet)
     {
         assertTrue(testSet.add(1));
 
         assertTrue(testSet.contains(1));
     }
 
-    @Test
-    public void addingAnElementTwiceDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingAnElementTwiceDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         assertTrue(testSet.add(1));
 
         assertFalse(testSet.add(1));
     }
 
-    @Test
-    public void containsAddedBoxedElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsAddedBoxedElements(final ObjectHashSet<Integer> testSet)
     {
         assertTrue(testSet.add(1));
         //noinspection UnnecessaryBoxing
@@ -99,20 +89,23 @@ public class ObjectHashSetIntegerTest
         assertTrue(testSet.contains(2));
     }
 
-    @Test
-    public void doesNotContainMissingValue()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainMissingValue(final ObjectHashSet<Integer> testSet)
     {
         assertFalse(testSet.contains(2048));
     }
 
-    @Test
-    public void removingAnElementFromAnEmptyListDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingAnElementFromAnEmptyListDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         assertFalse(testSet.remove(0));
     }
 
-    @Test
-    public void removingAPresentElementRemovesIt()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingAPresentElementRemovesIt(final ObjectHashSet<Integer> testSet)
     {
         assertTrue(testSet.add(1));
 
@@ -121,24 +114,26 @@ public class ObjectHashSetIntegerTest
         assertFalse(testSet.contains(1));
     }
 
-    @Test
-    public void sizeIsInitiallyZero()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void sizeIsInitiallyZero(final ObjectHashSet<Integer> testSet)
     {
         assertEquals(0, testSet.size());
     }
 
-    @Test
-    public void sizeIncrementsWithNumberOfAddedElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void sizeIncrementsWithNumberOfAddedElements(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
-
         assertEquals(2, testSet.size());
     }
 
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("data")
     @SuppressWarnings("OverwrittenKey")
-    public void sizeContainsNumberOfNewElements()
+    public void sizeContainsNumberOfNewElements(final ObjectHashSet<Integer> testSet)
     {
         testSet.add(1);
         testSet.add(1);
@@ -146,76 +141,85 @@ public class ObjectHashSetIntegerTest
         assertEquals(1, testSet.size());
     }
 
-    @Test
-    public void iteratorsListElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsListElements(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
-        assertIteratorHasElements();
+        assertIteratorHasElements(testSet);
     }
 
-    @Test
-    public void iteratorsStartFromTheBeginningEveryTime()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsStartFromTheBeginningEveryTime(final ObjectHashSet<Integer> testSet)
     {
-        iteratorsListElements();
+        iteratorsListElements(testSet);
 
-        assertIteratorHasElements();
+        assertIteratorHasElements(testSet);
     }
 
-    @Test
-    public void iteratorsListElementsWithoutHasNext()
-    {
-        addTwoElements(testSet);
-
-        assertIteratorHasElementsWithoutHasNext();
-    }
-
-    @Test
-    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
-    {
-        iteratorsListElementsWithoutHasNext();
-
-        assertIteratorHasElementsWithoutHasNext();
-    }
-
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorsThrowNoSuchElementException()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsListElementsWithoutHasNext(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
-        exhaustIterator();
+        assertIteratorHasElementsWithoutHasNext(testSet);
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext(final ObjectHashSet<Integer> testSet)
+    {
+        iteratorsListElementsWithoutHasNext(testSet);
+
+        assertIteratorHasElementsWithoutHasNext(testSet);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsThrowNoSuchElementException(final ObjectHashSet<Integer> testSet)
+    {
+        addTwoElements(testSet);
+
+        assertThrows(NoSuchElementException.class, () -> exhaustIterator(testSet));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
         try
         {
-            exhaustIterator();
+            exhaustIterator(testSet);
         }
         catch (final NoSuchElementException ignore)
         {
         }
 
-        exhaustIterator();
+        assertThrows(NoSuchElementException.class, () -> exhaustIterator(testSet));
     }
 
-    @Test
-    public void iteratorHasNoElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorHasNoElements(final ObjectHashSet<Integer> testSet)
     {
         assertFalse(testSet.iterator().hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorThrowExceptionForEmptySet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorThrowExceptionForEmptySet(final ObjectHashSet<Integer> testSet)
     {
-        testSet.iterator().next();
+        assertThrows(NoSuchElementException.class, () -> testSet.iterator().next());
     }
 
-    @Test
-    public void clearRemovesAllElementsOfTheSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void clearRemovesAllElementsOfTheSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -226,8 +230,9 @@ public class ObjectHashSetIntegerTest
         assertFalse(testSet.contains(1001));
     }
 
-    @Test
-    public void differenceReturnsNullIfBothSetsEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void differenceReturnsNullIfBothSetsEqual(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -237,8 +242,9 @@ public class ObjectHashSetIntegerTest
         assertNull(testSet.difference(other));
     }
 
-    @Test
-    public void differenceReturnsSetDifference()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void differenceReturnsSetDifference(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -249,8 +255,9 @@ public class ObjectHashSetIntegerTest
         assertThat(diff, containsInAnyOrder(1001));
     }
 
-    @Test
-    public void copiesOtherIntHashSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void copiesOtherIntHashSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -260,15 +267,17 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(other);
     }
 
-    @Test
-    public void twoEmptySetsAreEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void twoEmptySetsAreEqual(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet other = new ObjectHashSet(100);
         assertEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheSameValuesAreEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheSameValuesAreEqual(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet<Integer> other = new ObjectHashSet<>(100);
 
@@ -278,8 +287,9 @@ public class ObjectHashSetIntegerTest
         assertEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheDifferentSizesAreNotEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheDifferentSizesAreNotEqual(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet<Integer> other = new ObjectHashSet<>(100);
 
@@ -290,8 +300,9 @@ public class ObjectHashSetIntegerTest
         assertNotEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheDifferentValuesAreNotEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheDifferentValuesAreNotEqual(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet<Integer> other = new ObjectHashSet<>(100);
 
@@ -303,14 +314,16 @@ public class ObjectHashSetIntegerTest
         assertNotEquals(testSet, other);
     }
 
-    @Test
-    public void twoEmptySetsHaveTheSameHashcode()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void twoEmptySetsHaveTheSameHashcode(final ObjectHashSet<Integer> testSet)
     {
         assertEquals(testSet.hashCode(), new ObjectHashSet<Integer>(100).hashCode());
     }
 
-    @Test
-    public void setsWithTheSameValuesHaveTheSameHashcode()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheSameValuesHaveTheSameHashcode(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -320,8 +333,9 @@ public class ObjectHashSetIntegerTest
         assertEquals(testSet.hashCode(), secondSet.hashCode());
     }
 
-    @Test
-    public void reducesSizeWhenElementRemoved()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void reducesSizeWhenElementRemoved(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -330,15 +344,17 @@ public class ObjectHashSetIntegerTest
         assertEquals(1, testSet.size());
     }
 
-    @Test(expected = NullPointerException.class)
-    public void toArrayThrowsNullPointerExceptionForNullArgument()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void toArrayThrowsNullPointerExceptionForNullArgument(final ObjectHashSet<Integer> testSet)
     {
         final Integer[] into = null;
-        testSet.toArray(into);
+        assertThrows(NullPointerException.class, () -> testSet.toArray(into));
     }
 
-    @Test
-    public void toArrayCopiesElementsIntoSufficientlySizedArray()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void toArrayCopiesElementsIntoSufficientlySizedArray(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -347,8 +363,9 @@ public class ObjectHashSetIntegerTest
         assertArrayContainingElements(result);
     }
 
-    @Test
-    public void toArrayCopiesElementsIntoNewArray()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void toArrayCopiesElementsIntoNewArray(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -357,8 +374,9 @@ public class ObjectHashSetIntegerTest
         assertArrayContainingElements(result);
     }
 
-    @Test
-    public void toArraySupportsEmptyCollection()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void toArraySupportsEmptyCollection(final ObjectHashSet<Integer> testSet)
     {
         final Integer[] result = testSet.toArray(new Integer[0]);
 
@@ -376,14 +394,15 @@ public class ObjectHashSetIntegerTest
         requiredFields.add(49);
         requiredFields.add(56);
 
-        assertTrue("Failed to remove 8", requiredFields.remove(8));
-        assertTrue("Failed to remove 9", requiredFields.remove(9));
+        assertTrue(requiredFields.remove(8), "Failed to remove 8");
+        assertTrue(requiredFields.remove(9), "Failed to remove 9");
 
         assertThat(requiredFields, containsInAnyOrder(35, 49, 56));
     }
 
-    @Test
-    public void shouldResizeWhenItHitsCapacity()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldResizeWhenItHitsCapacity(final ObjectHashSet<Integer> testSet)
     {
         for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
         {
@@ -396,16 +415,18 @@ public class ObjectHashSetIntegerTest
         }
     }
 
-    @Test
-    public void containsEmptySet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsEmptySet(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet<Integer> other = new ObjectHashSet<>(100);
 
         assertTrue(testSet.containsAll(other));
     }
 
-    @Test
-    public void containsSubset()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsSubset(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -416,8 +437,9 @@ public class ObjectHashSetIntegerTest
         assertTrue(testSet.containsAll(subset));
     }
 
-    @Test
-    public void doesNotContainDisjointSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainDisjointSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -429,8 +451,9 @@ public class ObjectHashSetIntegerTest
         assertFalse(testSet.containsAll(other));
     }
 
-    @Test
-    public void doesNotContainSuperset()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainSuperset(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -442,8 +465,9 @@ public class ObjectHashSetIntegerTest
         assertFalse(testSet.containsAll(superset));
     }
 
-    @Test
-    public void addingEmptySetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingEmptySetDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -451,8 +475,9 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void addingSubsetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingSubsetDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -464,8 +489,9 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void addingEqualSetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingEqualSetDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -477,8 +503,9 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void containsValuesAddedFromDisjointSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsValuesAddedFromDisjointSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -493,8 +520,9 @@ public class ObjectHashSetIntegerTest
         assertTrue(testSet.containsAll(disjoint));
     }
 
-    @Test
-    public void containsValuesAddedFromIntersectingSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsValuesAddedFromIntersectingSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -509,8 +537,9 @@ public class ObjectHashSetIntegerTest
         assertTrue(testSet.containsAll(intersecting));
     }
 
-    @Test
-    public void removingEmptySetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingEmptySetDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -518,8 +547,9 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void removingDisjointSetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingDisjointSetDoesNothing(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -532,8 +562,9 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void doesNotContainRemovedIntersectingSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainRemovedIntersectingSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -547,8 +578,9 @@ public class ObjectHashSetIntegerTest
         assertFalse(testSet.containsAll(intersecting));
     }
 
-    @Test
-    public void isEmptyAfterRemovingEqualSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void isEmptyAfterRemovingEqualSet(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -560,8 +592,9 @@ public class ObjectHashSetIntegerTest
         assertTrue(testSet.isEmpty());
     }
 
-    @Test
-    public void removeElementsFromIterator()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removeElementsFromIterator(final ObjectHashSet<Integer> testSet)
     {
         addTwoElements(testSet);
 
@@ -580,8 +613,9 @@ public class ObjectHashSetIntegerTest
     }
 
 
-    @Test
-    public void shouldGenerateStringRepresentation()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldGenerateStringRepresentation(final ObjectHashSet<Integer> testSet)
     {
         final int[] testEntries = { 3, 1, -1, 19, 7, 11, 12, 7 };
 
@@ -616,8 +650,9 @@ public class ObjectHashSetIntegerTest
         assertFalse(iter.hasNext());
     }
 
-    @Test
-    public void shouldHaveCompatibleEqualsAndHashcode()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldHaveCompatibleEqualsAndHashcode(final ObjectHashSet<Integer> testSet)
     {
         final HashSet<Integer> compatibleSet = new HashSet<>();
         final long seed = System.nanoTime();
@@ -629,9 +664,9 @@ public class ObjectHashSetIntegerTest
             testSet.add(value);
         }
 
-        assertEquals("Fail with seed:" + seed, testSet, compatibleSet);
-        assertEquals("Fail with seed:" + seed, compatibleSet, testSet);
-        assertEquals("Fail with seed:" + seed, compatibleSet.hashCode(), testSet.hashCode());
+        assertEquals(testSet, compatibleSet, "Fail with seed:" + seed);
+        assertEquals(compatibleSet, testSet, "Fail with seed:" + seed);
+        assertEquals(compatibleSet.hashCode(), testSet.hashCode(), "Fail with seed:" + seed);
     }
 
     private static void addTwoElements(final ObjectHashSet<Integer> obj)
@@ -640,7 +675,7 @@ public class ObjectHashSetIntegerTest
         obj.add(1001);
     }
 
-    private void assertIteratorHasElements()
+    private void assertIteratorHasElements(final ObjectHashSet<Integer> testSet)
     {
         final Iterator<Integer> iter = testSet.iterator();
 
@@ -655,7 +690,7 @@ public class ObjectHashSetIntegerTest
         assertContainsElements(values);
     }
 
-    private void assertIteratorHasElementsWithoutHasNext()
+    private void assertIteratorHasElementsWithoutHasNext(final ObjectHashSet<Integer> testSet)
     {
         final Iterator<Integer> iter = testSet.iterator();
 
@@ -677,7 +712,7 @@ public class ObjectHashSetIntegerTest
         assertThat(other, containsInAnyOrder(1, 1001));
     }
 
-    private void exhaustIterator()
+    private void exhaustIterator(final ObjectHashSet<Integer> testSet)
     {
         final ObjectHashSet.ObjectIterator iterator = testSet.iterator();
         iterator.next();

--- a/agrona/src/test/java/org/agrona/collections/ObjectHashSetStringTest.java
+++ b/agrona/src/test/java/org/agrona/collections/ObjectHashSetStringTest.java
@@ -15,67 +15,58 @@
  */
 package org.agrona.collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class ObjectHashSetStringTest
 {
-    @Parameters
-    public static ObjectHashSet[] data()
+    private static ObjectHashSet[] data()
     {
-        return new ObjectHashSet[] {
+        return new ObjectHashSet[]{
             new ObjectHashSet<String>(INITIAL_CAPACITY),
-            new ObjectHashSet<String>(INITIAL_CAPACITY, Hashing.DEFAULT_LOAD_FACTOR, false)};
+            new ObjectHashSet<String>(INITIAL_CAPACITY, Hashing.DEFAULT_LOAD_FACTOR, false) };
     }
 
     private static final int INITIAL_CAPACITY = 100;
 
-    private final ObjectHashSet<String> testSet;
-
-    public ObjectHashSetStringTest(final ObjectHashSet<String> testSet)
-    {
-        this.testSet = testSet;
-    }
-
-    @Before
-    public void clear()
-    {
-        testSet.clear();
-    }
-
-    @Test
-    public void containsAddedElement()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsAddedElement(final ObjectHashSet<String> testSet)
     {
         assertTrue(testSet.add("1"));
 
         assertTrue(testSet.contains("1"));
     }
 
-    @Test
-    public void addingAnElementTwiceDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingAnElementTwiceDoesNothing(final ObjectHashSet<String> testSet)
     {
         assertTrue(testSet.add("1"));
 
         assertFalse(testSet.add("1"));
     }
 
-    @Test
-    public void removingAnElementFromAnEmptyListDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingAnElementFromAnEmptyListDoesNothing(final ObjectHashSet<String> testSet)
     {
         assertFalse(testSet.remove("0"));
     }
 
-    @Test
-    public void removingAPresentElementRemovesIt()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingAPresentElementRemovesIt(final ObjectHashSet<String> testSet)
     {
         assertTrue(testSet.add("1"));
 
@@ -84,22 +75,25 @@ public class ObjectHashSetStringTest
         assertFalse(testSet.contains("1"));
     }
 
-    @Test
-    public void sizeIsInitiallyZero()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void sizeIsInitiallyZero(final ObjectHashSet<String> testSet)
     {
         assertEquals(0, testSet.size());
     }
 
-    @Test
-    public void sizeIncrementsWithNumberOfAddedElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void sizeIncrementsWithNumberOfAddedElements(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
         assertEquals(2, testSet.size());
     }
 
-    @Test
-    public void sizeContainsNumberOfNewElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void sizeContainsNumberOfNewElements(final ObjectHashSet<String> testSet)
     {
         testSet.add("1");
         testSet.add("1");
@@ -107,76 +101,85 @@ public class ObjectHashSetStringTest
         assertEquals(1, testSet.size());
     }
 
-    @Test
-    public void iteratorsListElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsListElements(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
-        assertIteratorHasElements();
+        assertIteratorHasElements(testSet);
     }
 
-    @Test
-    public void iteratorsStartFromTheBeginningEveryTime()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsStartFromTheBeginningEveryTime(final ObjectHashSet<String> testSet)
     {
-        iteratorsListElements();
+        iteratorsListElements(testSet);
 
-        assertIteratorHasElements();
+        assertIteratorHasElements(testSet);
     }
 
-    @Test
-    public void iteratorsListElementsWithoutHasNext()
-    {
-        addTwoElements(testSet);
-
-        assertIteratorHasElementsWithoutHasNext();
-    }
-
-    @Test
-    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
-    {
-        iteratorsListElementsWithoutHasNext();
-
-        assertIteratorHasElementsWithoutHasNext();
-    }
-
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorsThrowNoSuchElementException()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsListElementsWithoutHasNext(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
-        exhaustIterator();
+        assertIteratorHasElementsWithoutHasNext(testSet);
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext(final ObjectHashSet<String> testSet)
+    {
+        iteratorsListElementsWithoutHasNext(testSet);
+
+        assertIteratorHasElementsWithoutHasNext(testSet);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsThrowNoSuchElementException(final ObjectHashSet<String> testSet)
+    {
+        addTwoElements(testSet);
+
+        assertThrows(NoSuchElementException.class, () -> exhaustIterator(testSet));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
         try
         {
-            exhaustIterator();
+            exhaustIterator(testSet);
         }
         catch (final NoSuchElementException ignore)
         {
         }
 
-        exhaustIterator();
+        assertThrows(NoSuchElementException.class, () -> exhaustIterator(testSet));
     }
 
-    @Test
-    public void iteratorHasNoElements()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorHasNoElements(final ObjectHashSet<String> testSet)
     {
         assertFalse(testSet.iterator().hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void iteratorThrowExceptionForEmptySet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void iteratorThrowExceptionForEmptySet(final ObjectHashSet<String> testSet)
     {
-        testSet.iterator().next();
+        assertThrows(NoSuchElementException.class, () -> testSet.iterator().next());
     }
 
-    @Test
-    public void clearRemovesAllElementsOfTheSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void clearRemovesAllElementsOfTheSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -187,8 +190,9 @@ public class ObjectHashSetStringTest
         assertFalse(testSet.contains("1001"));
     }
 
-    @Test
-    public void differenceReturnsNullIfBothSetsEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void differenceReturnsNullIfBothSetsEqual(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -198,8 +202,9 @@ public class ObjectHashSetStringTest
         assertNull(testSet.difference(other));
     }
 
-    @Test
-    public void differenceReturnsSetDifference()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void differenceReturnsSetDifference(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -210,15 +215,17 @@ public class ObjectHashSetStringTest
         assertThat(diff, containsInAnyOrder("1001"));
     }
 
-    @Test
-    public void twoEmptySetsAreEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void twoEmptySetsAreEqual(final ObjectHashSet<String> testSet)
     {
         final ObjectHashSet other = new ObjectHashSet(100);
         assertEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheSameValuesAreEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheSameValuesAreEqual(final ObjectHashSet<String> testSet)
     {
         final ObjectHashSet<String> other = new ObjectHashSet<>(100);
 
@@ -228,8 +235,9 @@ public class ObjectHashSetStringTest
         assertEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheDifferentSizesAreNotEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheDifferentSizesAreNotEqual(final ObjectHashSet<String> testSet)
     {
         final ObjectHashSet<String> other = new ObjectHashSet<>(100);
 
@@ -240,8 +248,9 @@ public class ObjectHashSetStringTest
         assertNotEquals(testSet, other);
     }
 
-    @Test
-    public void setsWithTheDifferentValuesAreNotEqual()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setsWithTheDifferentValuesAreNotEqual(final ObjectHashSet<String> testSet)
     {
         final ObjectHashSet<String> other = new ObjectHashSet<>(100);
 
@@ -253,14 +262,16 @@ public class ObjectHashSetStringTest
         assertNotEquals(testSet, other);
     }
 
-    @Test
-    public void twoEmptySetsHaveTheSameHashcode()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void twoEmptySetsHaveTheSameHashcode(final ObjectHashSet<String> testSet)
     {
         assertEquals(testSet.hashCode(), new ObjectHashSet<String>(100).hashCode());
     }
 
-    @Test
-    public void reducesSizeWhenElementRemoved()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void reducesSizeWhenElementRemoved(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -269,9 +280,10 @@ public class ObjectHashSetStringTest
         assertEquals(1, testSet.size());
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("data")
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArrayCopiesElementsIntoSufficientlySizedArray()
+    public void toArrayCopiesElementsIntoSufficientlySizedArray(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -280,9 +292,10 @@ public class ObjectHashSetStringTest
         assertArrayContainingElements(result);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("data")
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArrayCopiesElementsIntoNewArray()
+    public void toArrayCopiesElementsIntoNewArray(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -291,9 +304,10 @@ public class ObjectHashSetStringTest
         assertArrayContainingElements(result);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("data")
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArraySupportsEmptyCollection()
+    public void toArraySupportsEmptyCollection(final ObjectHashSet<String> testSet)
     {
         final String[] result = testSet.toArray(new String[testSet.size()]);
 
@@ -312,14 +326,15 @@ public class ObjectHashSetStringTest
         requiredFields.add("49");
         requiredFields.add("56");
 
-        assertTrue("Failed to remove 8", requiredFields.remove("8"));
-        assertTrue("Failed to remove 9", requiredFields.remove("9"));
+        assertTrue(requiredFields.remove("8"), "Failed to remove 8");
+        assertTrue(requiredFields.remove("9"), "Failed to remove 9");
 
         assertThat(requiredFields, containsInAnyOrder("35", "49", "56"));
     }
 
-    @Test
-    public void shouldResizeWhenItHitsCapacity()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldResizeWhenItHitsCapacity(final ObjectHashSet<String> testSet)
     {
         for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
         {
@@ -332,8 +347,9 @@ public class ObjectHashSetStringTest
         }
     }
 
-    @Test
-    public void containsSubset()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsSubset(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -344,8 +360,9 @@ public class ObjectHashSetStringTest
         assertTrue(testSet.containsAll(subset));
     }
 
-    @Test
-    public void doesNotContainDisjointSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainDisjointSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -357,8 +374,9 @@ public class ObjectHashSetStringTest
         assertFalse(testSet.containsAll(other));
     }
 
-    @Test
-    public void doesNotContainSuperset()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainSuperset(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -370,8 +388,9 @@ public class ObjectHashSetStringTest
         assertFalse(testSet.containsAll(superset));
     }
 
-    @Test
-    public void addingEmptySetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingEmptySetDoesNothing(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -379,8 +398,9 @@ public class ObjectHashSetStringTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void addingSubsetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingSubsetDoesNothing(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -392,8 +412,9 @@ public class ObjectHashSetStringTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void addingEqualSetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void addingEqualSetDoesNothing(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -405,8 +426,9 @@ public class ObjectHashSetStringTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void containsValuesAddedFromDisjointSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsValuesAddedFromDisjointSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -421,8 +443,9 @@ public class ObjectHashSetStringTest
         assertTrue(testSet.containsAll(disjoint));
     }
 
-    @Test
-    public void containsValuesAddedFromIntersectingSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void containsValuesAddedFromIntersectingSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -437,8 +460,9 @@ public class ObjectHashSetStringTest
         assertTrue(testSet.containsAll(intersecting));
     }
 
-    @Test
-    public void removingEmptySetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingEmptySetDoesNothing(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -446,8 +470,9 @@ public class ObjectHashSetStringTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void removingDisjointSetDoesNothing()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removingDisjointSetDoesNothing(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -460,8 +485,9 @@ public class ObjectHashSetStringTest
         assertContainsElements(testSet);
     }
 
-    @Test
-    public void doesNotContainRemovedIntersectingSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void doesNotContainRemovedIntersectingSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -475,8 +501,9 @@ public class ObjectHashSetStringTest
         assertFalse(testSet.containsAll(intersecting));
     }
 
-    @Test
-    public void isEmptyAfterRemovingEqualSet()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void isEmptyAfterRemovingEqualSet(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -488,8 +515,9 @@ public class ObjectHashSetStringTest
         assertTrue(testSet.isEmpty());
     }
 
-    @Test
-    public void removeElementsFromIterator()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void removeElementsFromIterator(final ObjectHashSet<String> testSet)
     {
         addTwoElements(testSet);
 
@@ -513,7 +541,7 @@ public class ObjectHashSetStringTest
         obj.add("1001");
     }
 
-    private void assertIteratorHasElements()
+    private void assertIteratorHasElements(final ObjectHashSet<String> testSet)
     {
         final Iterator<String> iter = testSet.iterator();
 
@@ -528,7 +556,7 @@ public class ObjectHashSetStringTest
         assertContainsElements(values);
     }
 
-    private void assertIteratorHasElementsWithoutHasNext()
+    private void assertIteratorHasElementsWithoutHasNext(final ObjectHashSet<String> testSet)
     {
         final Iterator<String> iter = testSet.iterator();
 
@@ -550,7 +578,7 @@ public class ObjectHashSetStringTest
         assertThat(other, containsInAnyOrder("1", "1001"));
     }
 
-    private void exhaustIterator()
+    private void exhaustIterator(final ObjectHashSet<String> testSet)
     {
         final Iterator<String> iterator = testSet.iterator();
         iterator.next();

--- a/agrona/src/test/java/org/agrona/concurrent/AgentInvokerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/AgentInvokerTest.java
@@ -18,15 +18,15 @@ package org.agrona.concurrent;
 import org.agrona.ErrorHandler;
 import org.agrona.LangUtil;
 import org.agrona.concurrent.status.AtomicCounter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.channels.ClosedByInterruptException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class AgentInvokerTest

--- a/agrona/src/test/java/org/agrona/concurrent/AgentRunnerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/AgentRunnerTest.java
@@ -19,7 +19,7 @@ import org.agrona.ErrorHandler;
 import org.agrona.LangUtil;
 import org.agrona.collections.MutableBoolean;
 import org.agrona.concurrent.status.AtomicCounter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.CountDownLatch;
@@ -27,9 +27,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalAnswers.answersWithDelay;
 import static org.mockito.Mockito.*;
 

--- a/agrona/src/test/java/org/agrona/concurrent/CachedClockTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/CachedClockTest.java
@@ -15,10 +15,10 @@
  */
 package org.agrona.concurrent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class CachedClockTest
 {

--- a/agrona/src/test/java/org/agrona/concurrent/CompositeAgentTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/CompositeAgentTest.java
@@ -15,10 +15,9 @@
  */
 package org.agrona.concurrent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class CompositeAgentTest
@@ -33,18 +32,18 @@ public class CompositeAgentTest
         }
     }
 
-    private final Agent[] agents = new Agent[]{mock(Agent.class), mock(Agent.class), mock(Agent.class)};
+    private final Agent[] agents = new Agent[]{ mock(Agent.class), mock(Agent.class), mock(Agent.class) };
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAcceptEmptyList()
     {
-        final CompositeAgent ignore = new CompositeAgent();
+        assertThrows(IllegalArgumentException.class, CompositeAgent::new);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAcceptNullAgents()
     {
-        final CompositeAgent ignore = new CompositeAgent(agents[0], null, agents[1]);
+        assertThrows(NullPointerException.class, () -> new CompositeAgent(agents[0], null, agents[1]));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/DynamicCompositeAgentTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/DynamicCompositeAgentTest.java
@@ -15,34 +15,37 @@
  */
 package org.agrona.concurrent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class DynamicCompositeAgentTest
 {
     private static final String ROLE_NAME = "roleName";
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotAllowAddAfterClose()
     {
         final DynamicCompositeAgent compositeAgent = new DynamicCompositeAgent(ROLE_NAME);
         final AgentInvoker invoker = new AgentInvoker(Throwable::printStackTrace, null, compositeAgent);
 
         invoker.close();
-        compositeAgent.tryAdd(mock(Agent.class));
+
+        assertThrows(IllegalStateException.class, () -> compositeAgent.tryAdd(mock(Agent.class)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotAllowRemoveAfterClose()
     {
         final DynamicCompositeAgent compositeAgent = new DynamicCompositeAgent(ROLE_NAME);
         final AgentInvoker invoker = new AgentInvoker(Throwable::printStackTrace, null, compositeAgent);
 
         invoker.close();
-        compositeAgent.tryRemove(mock(Agent.class));
+
+        assertThrows(IllegalStateException.class, () -> compositeAgent.tryRemove(mock(Agent.class)));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/HighResolutionTimerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/HighResolutionTimerTest.java
@@ -15,9 +15,9 @@
  */
 package org.agrona.concurrent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HighResolutionTimerTest
 {

--- a/agrona/src/test/java/org/agrona/concurrent/MappedResizeableBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/MappedResizeableBufferTest.java
@@ -16,19 +16,21 @@
 package org.agrona.concurrent;
 
 import org.agrona.CloseHelper;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.agrona.IoUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MappedResizeableBufferTest
 {
@@ -40,7 +42,7 @@ public class MappedResizeableBufferTest
 
     private MappedResizeableBuffer buffer;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException
     {
         final RandomAccessFile file = new RandomAccessFile(PATH, "rw");
@@ -48,13 +50,13 @@ public class MappedResizeableBufferTest
         channel = file.getChannel();
     }
 
-    @After
+    @AfterEach
     public void close()
     {
         CloseHelper.close(buffer);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown()
     {
         CloseHelper.close(channel);

--- a/agrona/src/test/java/org/agrona/concurrent/QueuedPipeTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/QueuedPipeTest.java
@@ -15,70 +15,57 @@
  */
 package org.agrona.concurrent;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoint;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.NoSuchElementException;
-import java.util.Queue;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Theories.class)
 public class QueuedPipeTest
 {
     private static final int QUEUE_CAPACITY = 8;
 
-    interface Fixture
+    private static Stream<QueuedPipe<Integer>> data()
     {
-        QueuedPipe<Integer> newInstance();
+        return Stream.of(
+            new OneToOneConcurrentArrayQueue<>(QUEUE_CAPACITY),
+            new ManyToOneConcurrentArrayQueue<>(QUEUE_CAPACITY),
+            new ManyToManyConcurrentArrayQueue<>(QUEUE_CAPACITY)
+        );
     }
 
-    @DataPoint
-    public static final Fixture ONE_TO_ONE_QUEUE = () -> new OneToOneConcurrentArrayQueue<>(QUEUE_CAPACITY);
-
-    @DataPoint
-    public static final Fixture MANY_TO_ONE_QUEUE = () -> new ManyToOneConcurrentArrayQueue<>(QUEUE_CAPACITY);
-
-    @DataPoint
-    public static final Fixture MANY_TO_MANY_QUEUE = () -> new ManyToManyConcurrentArrayQueue<>(QUEUE_CAPACITY);
-
-    @Theory
-    public void shouldGetSizeWhenEmpty(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldGetSizeWhenEmpty(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowExceptionWhenNullOffered(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldThrowExceptionWhenNullOffered(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-        queue.offer(null);
+        assertThrows(NullPointerException.class, () -> queue.offer(null));
     }
 
-    @Theory
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowExceptionWhenNullAdded(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldThrowExceptionWhenNullAdded(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-        queue.add(null);
+        assertThrows(NullPointerException.class, () -> queue.add(null));
     }
 
-    @Theory
-    public void shouldOfferAndPollToEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldOfferAndPollToEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-
         final Integer testValue = 7;
 
         final boolean success = queue.offer(testValue);
@@ -86,16 +73,15 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(1));
 
         final Integer polledValue = queue.poll();
-        Assert.assertEquals(testValue, polledValue);
+        assertEquals(testValue, polledValue);
         assertThat(polledValue, is(testValue));
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    public void shouldAddAndRemoveFromEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldAddAndRemoveFromEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-
         final Integer testValue = 7;
 
         final boolean success = queue.add(testValue);
@@ -107,22 +93,21 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    public void shouldFailToOfferToFullQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldFailToOfferToFullQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
         assertThat(queue.size(), is(queue.capacity()));
         final boolean success = queue.offer(0);
-        Assert.assertFalse(success);
+        assertFalse(success);
     }
 
-    @Theory
-    public void shouldPollSingleElementFromFullQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldPollSingleElementFromFullQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
         fillQueue(queue);
 
         final Integer polledValue = queue.poll();
@@ -130,20 +115,18 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(queue.capacity() - 1));
     }
 
-    @Theory
-    public void shouldPollNullFromEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldPollNullFromEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-
         final Integer polledValue = queue.poll();
-        Assert.assertNull(polledValue);
+        assertNull(polledValue);
     }
 
-    @Theory
-    public void shouldPeakQueueHead(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldPeakQueueHead(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
         final Integer headValue = queue.peek();
@@ -151,20 +134,18 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(queue.capacity()));
     }
 
-    @Theory
-    public void shouldReturnNullForPeekOnEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldReturnNullForPeekOnEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         final Integer value = queue.peek();
-        Assert.assertNull(value);
+        assertNull(value);
     }
 
-    @Theory
-    public void shouldReturnElementQueueHead(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldReturnElementQueueHead(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
         final Integer headValue = queue.element();
@@ -172,52 +153,46 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(queue.capacity()));
     }
 
-    @Theory
-    @Test(expected = NoSuchElementException.class)
-    public void shouldThrowExceptionForElementOnEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldThrowExceptionForElementOnEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-
-        queue.element();
+        assertThrows(NoSuchElementException.class, queue::element);
     }
 
-    @Theory
-    public void shouldRemoveSingleElementFromFullQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldRemoveSingleElementFromFullQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
-        Assert.assertEquals(queue.capacity(), queue.size());
+        assertEquals(queue.capacity(), queue.size());
         final Integer removedValue = queue.remove();
         assertThat(removedValue, is(0));
         assertThat(queue.size(), is(queue.capacity() - 1));
     }
 
-    @Theory
-    @Test(expected = NoSuchElementException.class)
-    public void shouldThrowExceptionForRemoveOnEmptyQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldThrowExceptionForRemoveOnEmptyQueue(final QueuedPipe<Integer> queue)
     {
-        final Queue<Integer> queue = fixture.newInstance();
-        queue.remove();
+        assertThrows(NoSuchElementException.class, queue::remove);
     }
 
-    @Theory
-    public void shouldClearFullQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldClearFullQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
         queue.clear();
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    public void shouldDrainFullQueue(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldDrainFullQueue(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
-
         fillQueue(queue);
 
         final int[] counter = new int[1];
@@ -230,11 +205,11 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    public void shouldHandleExceptionWhenDraining(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldHandleExceptionWhenDraining(final QueuedPipe<Integer> queue)
     {
         final String testMessage = "Test Exception";
-        final QueuedPipe<Integer> queue = fixture.newInstance();
 
         fillQueue(queue);
 
@@ -261,14 +236,14 @@ public class QueuedPipeTest
             exception = ex;
         }
 
-        Assert.assertNotNull(exception);
+        assertNotNull(exception);
         assertThat(queue.size(), is(queue.capacity() - exceptionTrigger));
     }
 
-    @Theory
-    public void shouldDrainFullQueueToCollection(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldDrainFullQueueToCollection(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
         final Collection<Integer> target = new ArrayList<>();
 
         fillQueue(queue);
@@ -280,10 +255,10 @@ public class QueuedPipeTest
         assertThat(queue.size(), is(0));
     }
 
-    @Theory
-    public void shouldDrainQueueWithCountToCollection(final Fixture fixture)
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldDrainQueueWithCountToCollection(final QueuedPipe<Integer> queue)
     {
-        final QueuedPipe<Integer> queue = fixture.newInstance();
         final Collection<Integer> target = new ArrayList<>();
         final int count = 3;
 

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -16,23 +16,18 @@
 package org.agrona.concurrent;
 
 import org.agrona.MutableDirectBuffer;
-import org.junit.Test;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Theories.class)
 public class UnsafeBufferTest
 {
     private static final byte VALUE = 42;
@@ -235,26 +230,26 @@ public class UnsafeBufferTest
         buffer.putBytes(INDEX, value.getBytes(US_ASCII));
     }
 
-    @DataPoints
-    public static int[][] valuesAndLengths()
+    private static int[][] valuesAndLengths()
     {
         return new int[][]
             {
-                {1, 1},
-                {10, 2},
-                {100, 3},
-                {1000, 4},
-                {12, 2},
-                {123, 3},
-                {2345, 4},
-                {9, 1},
-                {99, 2},
-                {999, 3},
-                {9999, 4},
+                { 1, 1 },
+                { 10, 2 },
+                { 100, 3 },
+                { 1000, 4 },
+                { 12, 2 },
+                { 123, 3 },
+                { 2345, 4 },
+                { 9, 1 },
+                { 99, 2 },
+                { 999, 3 },
+                { 9999, 4 },
             };
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("valuesAndLengths")
     public void shouldPutNaturalFromEnd(final int[] valueAndLength)
     {
         final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[8 * 1024]);
@@ -262,11 +257,12 @@ public class UnsafeBufferTest
         final int length = valueAndLength[1];
 
         final int start = buffer.putNaturalIntAsciiFromEnd(value, length);
-        assertEquals("for " + Arrays.toString(valueAndLength), 0, start);
+        final String message = "for " + Arrays.toString(valueAndLength);
+        assertEquals(0, start, message);
 
         assertEquals(
-            "for " + Arrays.toString(valueAndLength),
             String.valueOf(value),
-            buffer.getStringWithoutLengthAscii(0, length));
+            buffer.getStringWithoutLengthAscii(0, length),
+            message);
     }
 }

--- a/agrona/src/test/java/org/agrona/concurrent/broadcast/BroadcastReceiverTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/broadcast/BroadcastReceiverTest.java
@@ -15,17 +15,18 @@
  */
 package org.agrona.concurrent.broadcast;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.broadcast.RecordDescriptor.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class BroadcastReceiverTest
 {
@@ -40,7 +41,7 @@ public class BroadcastReceiverTest
     private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
     private BroadcastReceiver broadcastReceiver;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
@@ -54,7 +55,7 @@ public class BroadcastReceiverTest
         assertThat(broadcastReceiver.capacity(), is(CAPACITY));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
     {
         final int capacity = 777;
@@ -62,7 +63,7 @@ public class BroadcastReceiverTest
 
         when(buffer.capacity()).thenReturn(totalBufferLength);
 
-        new BroadcastReceiver(buffer);
+        assertThrows(IllegalStateException.class, () -> new BroadcastReceiver(buffer));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/broadcast/BroadcastTransmitterTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/broadcast/BroadcastTransmitterTest.java
@@ -15,16 +15,17 @@
  */
 package org.agrona.concurrent.broadcast;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.broadcast.RecordDescriptor.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 public class BroadcastTransmitterTest
 {
@@ -39,7 +40,7 @@ public class BroadcastTransmitterTest
     private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
     private BroadcastTransmitter broadcastTransmitter;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
@@ -53,7 +54,7 @@ public class BroadcastTransmitterTest
         assertThat(broadcastTransmitter.capacity(), is(CAPACITY));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
     {
         final int capacity = 777;
@@ -61,24 +62,26 @@ public class BroadcastTransmitterTest
 
         when(buffer.capacity()).thenReturn(totalBufferLength);
 
-        new BroadcastTransmitter(buffer);
+        assertThrows(IllegalStateException.class, () -> new BroadcastTransmitter(buffer));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenMaxMessageLengthExceeded()
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
 
-        broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, 0, broadcastTransmitter.maxMsgLength() + 1);
+        assertThrows(IllegalArgumentException.class, () ->
+            broadcastTransmitter.transmit(MSG_TYPE_ID, srcBuffer, 0, broadcastTransmitter.maxMsgLength() + 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenMessageTypeIdInvalid()
     {
         final int invalidMsgId = -1;
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
 
-        broadcastTransmitter.transmit(invalidMsgId, srcBuffer, 0, 32);
+        assertThrows(IllegalArgumentException.class, () ->
+            broadcastTransmitter.transmit(invalidMsgId, srcBuffer, 0, 32));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/errors/DistinctErrorLogTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/errors/DistinctErrorLogTest.java
@@ -15,7 +15,7 @@
  */
 package org.agrona.concurrent.errors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.agrona.BitUtil;
@@ -25,7 +25,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.agrona.concurrent.errors.DistinctErrorLog.*;
 

--- a/agrona/src/test/java/org/agrona/concurrent/errors/ErrorLogReaderTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/errors/ErrorLogReaderTest.java
@@ -15,18 +15,20 @@
  */
 package org.agrona.concurrent.errors;
 
-import org.junit.Test;
-import org.mockito.InOrder;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.EpochClock;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class ErrorLogReaderTest

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferConcurrentTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferConcurrentTest.java
@@ -15,17 +15,17 @@
  */
 package org.agrona.concurrent.ringbuffer;
 
-import org.junit.Test;
 import org.agrona.BitUtil;
 import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CyclicBarrier;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 public class ManyToOneRingBufferConcurrentTest
 {

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
@@ -15,19 +15,20 @@
  */
 package org.agrona.concurrent.ringbuffer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
 import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import static java.lang.Boolean.TRUE;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer.PADDING_MSG_TYPE_ID;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class ManyToOneRingBufferTest
 {
@@ -41,7 +42,7 @@ public class ManyToOneRingBufferTest
     private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
     private ManyToOneRingBuffer ringBuffer;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
@@ -411,20 +412,22 @@ public class ManyToOneRingBufferTest
         assertThat(ringBuffer.capacity(), is(CAPACITY));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
     {
         final int capacity = 777;
         final int totalBufferLength = capacity + RingBufferDescriptor.TRAILER_LENGTH;
-        new ManyToOneRingBuffer(new UnsafeBuffer(new byte[totalBufferLength]));
+        assertThrows(IllegalStateException.class, () ->
+            new ManyToOneRingBuffer(new UnsafeBuffer(new byte[totalBufferLength])));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenMaxMessageSizeExceeded()
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
 
-        ringBuffer.write(MSG_TYPE_ID, srcBuffer, 0, ringBuffer.maxMsgLength() + 1);
+        assertThrows(IllegalArgumentException.class,
+            () -> ringBuffer.write(MSG_TYPE_ID, srcBuffer, 0, ringBuffer.maxMsgLength() + 1));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferConcurrentTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferConcurrentTest.java
@@ -15,17 +15,17 @@
  */
 package org.agrona.concurrent.ringbuffer;
 
-import org.junit.Test;
 import org.agrona.BitUtil;
 import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CyclicBarrier;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 public class OneToOneRingBufferConcurrentTest
 {

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
@@ -15,18 +15,19 @@
  */
 package org.agrona.concurrent.ringbuffer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
 import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer.PADDING_MSG_TYPE_ID;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class OneToOneRingBufferTest
 {
@@ -40,7 +41,7 @@ public class OneToOneRingBufferTest
     private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
     private OneToOneRingBuffer ringBuffer;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
@@ -314,20 +315,22 @@ public class OneToOneRingBufferTest
         assertThat(ringBuffer.capacity(), is(CAPACITY));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
     {
         final int capacity = 777;
         final int totalBufferLength = capacity + RingBufferDescriptor.TRAILER_LENGTH;
-        new OneToOneRingBuffer(new UnsafeBuffer(new byte[totalBufferLength]));
+        assertThrows(IllegalStateException.class,
+            () -> new OneToOneRingBuffer(new UnsafeBuffer(new byte[totalBufferLength])));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenMaxMessageSizeExceeded()
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[1024]);
 
-        ringBuffer.write(MSG_TYPE_ID, srcBuffer, 0, ringBuffer.maxMsgLength() + 1);
+        assertThrows(IllegalArgumentException.class,
+            () -> ringBuffer.write(MSG_TYPE_ID, srcBuffer, 0, ringBuffer.maxMsgLength() + 1));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/concurrent/status/CountersManagerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/status/CountersManagerTest.java
@@ -15,29 +15,28 @@
  */
 package org.agrona.concurrent.status;
 
+import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.IntObjConsumer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.agrona.DirectBuffer;
-import org.agrona.collections.IntObjConsumer;
 
 import java.nio.ByteBuffer;
 
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.agrona.concurrent.status.CountersReader.MAX_LABEL_LENGTH;
+import static org.agrona.concurrent.status.CountersReader.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.agrona.concurrent.status.CountersReader.COUNTER_LENGTH;
-import static org.agrona.concurrent.status.CountersReader.METADATA_LENGTH;
 
 public class CountersManagerTest
 {
@@ -172,14 +171,15 @@ public class CountersManagerTest
         assertThat(managerWithCooldown.allocate("the next label"), is(def));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotOverAllocateCounters()
     {
         manager.allocate("abc");
         manager.allocate("def");
         manager.allocate("ghi");
         manager.allocate("jkl");
-        manager.allocate("mno");
+
+        assertThrows(IllegalStateException.class, () -> manager.allocate("mno"));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/hints/ThreadHintsTest.java
+++ b/agrona/src/test/java/org/agrona/hints/ThreadHintsTest.java
@@ -15,7 +15,7 @@
  */
 package org.agrona.hints;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThreadHintsTest
 {

--- a/agrona/src/test/java/org/agrona/io/DirectBufferInputStreamTest.java
+++ b/agrona/src/test/java/org/agrona/io/DirectBufferInputStreamTest.java
@@ -17,9 +17,9 @@ package org.agrona.io;
 
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DirectBufferInputStreamTest
 {

--- a/agrona/src/test/java/org/agrona/io/DirectBufferOutputStreamTest.java
+++ b/agrona/src/test/java/org/agrona/io/DirectBufferOutputStreamTest.java
@@ -16,9 +16,9 @@
 package org.agrona.io;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DirectBufferOutputStreamTest
 {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ def checkstyleVersion = '8.28'
 def hamcrestVersion = '2.2'
 def mockitoVersion = '3.2.4'
 def junitVersion = '5.5.2'
+def guavaTestLib = '28.1-jre'
 def jmhVersion = '1.22'
 
 def agronaGroup = 'org.agrona'
@@ -218,9 +219,11 @@ project(':agrona') {
     apply plugin: 'biz.aQute.bnd.builder'
 
     dependencies {
-        testImplementation 'com.google.guava:guava-testlib:28.1-jre'
+        testImplementation("com.google.guava:guava-testlib:${guavaTestLib}") {
+            exclude group: 'junit'
+        }
         // Compatibility with JUnit 4
-        testRuntimeOnly "junit:junit:4.12"
+        testImplementation "junit:junit:4.13"
         testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -148,9 +148,6 @@ subprojects {
         testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
         testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
-        // Compatibility with JUnit 4
-        testCompileOnly "junit:junit:4.12"
-        testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
     }
 
     checkstyle.toolVersion = "${checkstyleVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,9 @@ project(':agrona') {
 
     dependencies {
         testImplementation 'com.google.guava:guava-testlib:28.1-jre'
+        // Compatibility with JUnit 4
+        testRuntimeOnly "junit:junit:4.12"
+        testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
     }
 
     uploadArchives {


### PR DESCRIPTION
Migrate all of the hand-written tests to JUnit 5.

_**NOTE:** It was not possible to remove JUnit 4 completely due to the existence of the [ConformanceTestsSuite](https://github.com/real-logic/agrona/blob/1f170c2020d28ce42d5b3fcce130e7df9a31e184/agrona/src/test/java/org/agrona/collections/ConformanceTestsSuite.java) and related classes that rely on the `TestSuite` feature of JUnit 4._