### PR TITLE
[Java] Add `tryClaim` API to the RingBuffer

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
@@ -22,7 +22,7 @@ import org.agrona.BitUtil;
  * of a ring of messages which is a power of 2 in size, followed by a trailer section containing state
  * information for the producers and consumers of the ring.
  */
-public class RingBufferDescriptor
+public final class RingBufferDescriptor
 {
     /**
      * Offset within the trailer for where the tail value is stored.
@@ -74,6 +74,10 @@ public class RingBufferDescriptor
 
         offset += (BitUtil.CACHE_LINE_LENGTH * 2);
         TRAILER_LENGTH = offset;
+    }
+
+    private RingBufferDescriptor()
+    {
     }
 
     /**

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
@@ -19,12 +19,17 @@ import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
+
+import java.util.function.IntConsumer;
 
 import static java.lang.Boolean.TRUE;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer.PADDING_MSG_TYPE_ID;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
+import static org.agrona.concurrent.ringbuffer.RingBuffer.INSUFFICIENT_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -454,5 +459,222 @@ public class ManyToOneRingBufferTest
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[messageLength]);
 
         assertTrue(ringBuffer.write(MSG_TYPE_ID, srcBuffer, 0, messageLength));
+    }
+
+    @Test
+    public void tryClaimShouldThrowIllegalArgumentExceptionIfMessageTypeIsInvalid()
+    {
+        assertThrows(IllegalArgumentException.class, () -> ringBuffer.tryClaim(-1, 10));
+    }
+
+    @Test
+    public void tryClaimShouldThrowIllegalArgumentExceptionIfLengthExceedsMaxMessageSize()
+    {
+        assertThrows(IllegalArgumentException.class, () -> ringBuffer.tryClaim(3, CAPACITY));
+    }
+
+    @Test
+    public void tryClaimShouldThrowIllegalArgumentExceptionIfLengthIsNegative()
+    {
+        assertThrows(IllegalArgumentException.class, () -> ringBuffer.tryClaim(MSG_TYPE_ID, -6));
+    }
+
+    @Test
+    public void tryClaimReturnsIndexAtWhichEncodedMessageStarts()
+    {
+        final int length = 10;
+        final int recordLength = length + HEADER_LENGTH;
+        final int alignedRecordLength = align(recordLength, ALIGNMENT);
+        final long headPosition = 248L;
+        final long tailPosition = 320L;
+        final int recordIndex = (int)tailPosition;
+        when(buffer.getLongVolatile(HEAD_COUNTER_CACHE_INDEX)).thenReturn(headPosition);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tailPosition);
+        when(buffer.compareAndSetLong(TAIL_COUNTER_INDEX, tailPosition, tailPosition + alignedRecordLength))
+            .thenReturn(TRUE);
+
+        final int index = ringBuffer.tryClaim(MSG_TYPE_ID, length);
+
+        assertEquals(recordIndex + HEADER_LENGTH, index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_CACHE_INDEX);
+        inOrder.verify(buffer).getLongVolatile(TAIL_COUNTER_INDEX);
+        inOrder.verify(buffer).compareAndSetLong(TAIL_COUNTER_INDEX, tailPosition, tailPosition + alignedRecordLength);
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(recordIndex), -recordLength);
+        inOrder.verify(buffer).putInt(typeOffset(recordIndex), MSG_TYPE_ID);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void tryClaimReturnsIndexAtWhichEncodedMessageStartsAfterPadding()
+    {
+        final int length = 10;
+        final int recordLength = length + HEADER_LENGTH;
+        final int alignedRecordLength = align(recordLength, ALIGNMENT);
+        final long headPosition = 248L;
+        final int padding = 22;
+        final long tailPosition = CAPACITY - padding;
+        final int paddingIndex = (int)tailPosition;
+        final int recordIndex = 0;
+        when(buffer.getLongVolatile(HEAD_COUNTER_CACHE_INDEX)).thenReturn(headPosition);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tailPosition);
+        when(buffer.compareAndSetLong(TAIL_COUNTER_INDEX, tailPosition, tailPosition + alignedRecordLength + padding))
+            .thenReturn(TRUE);
+
+        final int index = ringBuffer.tryClaim(MSG_TYPE_ID, length);
+
+        assertEquals(recordIndex + HEADER_LENGTH, index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_CACHE_INDEX);
+        inOrder.verify(buffer).getLongVolatile(TAIL_COUNTER_INDEX);
+        inOrder.verify(buffer)
+            .compareAndSetLong(TAIL_COUNTER_INDEX, tailPosition, tailPosition + alignedRecordLength + padding);
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(paddingIndex), -padding);
+        inOrder.verify(buffer).putInt(typeOffset(paddingIndex), PADDING_MSG_TYPE_ID);
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(paddingIndex), padding);
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(recordIndex), -recordLength);
+        inOrder.verify(buffer).putInt(typeOffset(recordIndex), MSG_TYPE_ID);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void tryClaimReturnsInsufficientCapacityHead()
+    {
+        final int length = 10;
+        final long headPosition = 0;
+        final long tailPosition = CAPACITY - 10;
+        when(buffer.getLongVolatile(HEAD_COUNTER_CACHE_INDEX)).thenReturn(headPosition);
+        when(buffer.getLongVolatile(HEAD_COUNTER_INDEX)).thenReturn(headPosition);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tailPosition);
+
+        final int index = ringBuffer.tryClaim(MSG_TYPE_ID, length);
+
+        assertEquals(INSUFFICIENT_CAPACITY, index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_CACHE_INDEX);
+        inOrder.verify(buffer).getLongVolatile(TAIL_COUNTER_INDEX);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_INDEX);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void tryClaimReturnsInsufficientCapacityTail()
+    {
+        final int length = 10;
+        final long cachedHeadPosition = 0;
+        final long headPosition = CAPACITY + 8;
+        final long tailPosition = 2 * CAPACITY - 16;
+        when(buffer.getLongVolatile(HEAD_COUNTER_CACHE_INDEX)).thenReturn(cachedHeadPosition);
+        when(buffer.getLongVolatile(HEAD_COUNTER_INDEX)).thenReturn(headPosition);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tailPosition);
+
+        final int index = ringBuffer.tryClaim(MSG_TYPE_ID, length);
+
+        assertEquals(INSUFFICIENT_CAPACITY, index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_CACHE_INDEX);
+        inOrder.verify(buffer).getLongVolatile(TAIL_COUNTER_INDEX);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_INDEX);
+        inOrder.verify(buffer).putLongOrdered(HEAD_COUNTER_CACHE_INDEX, headPosition);
+        inOrder.verify(buffer).getLongVolatile(HEAD_COUNTER_INDEX);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -2, 0, 7, CAPACITY + 1 })
+    public void commitThrowsIllegalArgumentExceptionIfIndexIsOutOfBounds(final int index)
+    {
+        assertThrows(IllegalArgumentException.class, () -> ringBuffer.commit(index));
+    }
+
+    @Test
+    public void commitThrowsIllegalStateExceptionIfSpaceWasAlreadyCommitted()
+    {
+        testAlreadyCommitted(ringBuffer::commit);
+    }
+
+    @Test
+    public void commitThrowsIllegalStateExceptionIfSpaceWasAlreadyAborted()
+    {
+        testAlreadyAborted(ringBuffer::commit);
+    }
+
+    @Test
+    public void commitPublishesMessageByInvertingTheLengthValue()
+    {
+        final int index = 128;
+        final int recordIndex = index - HEADER_LENGTH;
+        final int recordLength = -19;
+        when(buffer.getInt(lengthOffset(recordIndex))).thenReturn(recordLength);
+
+        ringBuffer.commit(index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getInt(lengthOffset(recordIndex));
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(recordIndex), -recordLength);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 0, 7, CAPACITY + 1 })
+    public void abortThrowsIllegalArgumentExceptionIfOffsetIsInvalid(final int index)
+    {
+        assertThrows(IllegalArgumentException.class, () -> ringBuffer.abort(index));
+    }
+
+    @Test
+    public void abortThrowsIllegalStateExceptionIfSpaceWasAlreadyCommitted()
+    {
+        testAlreadyCommitted(ringBuffer::abort);
+    }
+
+    @Test
+    public void abortThrowsIllegalStateExceptionIfSpaceWasAlreadyAborted()
+    {
+        testAlreadyAborted(ringBuffer::abort);
+    }
+
+    @Test
+    public void abortMarksUnusedSpaceAsPadding()
+    {
+        final int index = 108;
+        final int recordIndex = index - HEADER_LENGTH;
+        final int recordLength = -11111;
+        when(buffer.getInt(lengthOffset(recordIndex))).thenReturn(recordLength);
+
+        ringBuffer.abort(index);
+
+        final InOrder inOrder = inOrder(buffer);
+        inOrder.verify(buffer).getInt(lengthOffset(recordIndex));
+        inOrder.verify(buffer).putInt(typeOffset(recordIndex), PADDING_MSG_TYPE_ID);
+        inOrder.verify(buffer).putIntOrdered(lengthOffset(recordIndex), -recordLength);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private void testAlreadyCommitted(final IntConsumer action)
+    {
+        final int index = HEADER_LENGTH;
+        final int recordIndex = index - HEADER_LENGTH;
+        when(buffer.getInt(lengthOffset(recordIndex))).thenReturn(0);
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> action.accept(index));
+        assertEquals("claimed space was already committed", exception.getMessage());
+    }
+
+    private void testAlreadyAborted(final IntConsumer action)
+    {
+        final int index = 128;
+        final int recordIndex = index - HEADER_LENGTH;
+        when(buffer.getInt(lengthOffset(recordIndex))).thenReturn(10);
+        when(buffer.getInt(typeOffset(recordIndex))).thenReturn(PADDING_MSG_TYPE_ID);
+
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> action.accept(index));
+        assertEquals("claimed space was already aborted", exception.getMessage());
     }
 }


### PR DESCRIPTION
With the new `tryClaim` API it is possible to implement zero-copy publication by writing directly to the underlying ring-buffer.

Implementation details:
- `tryClaim` - reserves space in the underlying buffer and writes a header with the given `msgTypeId` and a negative record length
- `commit` - flips the sign on the record length field
- `abort` - writes `PADDING_MSG_TYPE_ID` into the type field and flips the sign on the record length field

Example of API usage:
```
final RingBuffer ringBuffer = ...;

final int index = ringBuffer.tryClaim(msgTypeId, messageLength);
if (index >= 0)
{
    try
    {
         final AtomicBuffer buffer = ringBuffer.buffer();
         // Work with the buffer directly using the index
         ...
         ringBuffer.commit(index); // commit message
    }
    catch (final Throwable t)
    {
         ringBuffer.abort(index); // allow consumer to proceed
         ...
    }
}
```

Closes #197 