### PR TITLE
fix toArray() for Maps avoiding allocation

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -1107,9 +1107,9 @@ public class Int2IntHashMap implements Map<Integer, Integer>, Serializable
          * {@inheritDoc}
          */
         @Override
-        public Map.Entry<Integer, Integer>[] toArray()
+        public Object[] toArray()
         {
-            final Entry<Integer, Integer>[] array = new Map.Entry[size()];
+            final Object[] array = new Object[size()];
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -1102,5 +1102,21 @@ public class Int2IntHashMap implements Map<Integer, Integer>, Serializable
 
             return value != null && value.equals(entry.getValue());
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map.Entry<Integer, Integer>[] toArray()
+        {
+            final Entry<Integer, Integer>[] array = new Map.Entry[size()];
+            final EntryIterator it = iterator();
+            for (@DoNotSub int i = 0; i < array.length; i++)
+            {
+                it.next();
+                array[i] = it.allocateDuplicateEntry();
+            }
+            return array;
+        }
     }
 }

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -1110,11 +1110,30 @@ public class Int2IntHashMap implements Map<Integer, Integer>, Serializable
         public Object[] toArray()
         {
             final Object[] array = new Object[size()];
+            return toArray(array);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T[] toArray(final T[] a)
+        {
+            final T[] array = a.length >= size ? a : (T[])java.lang.reflect.Array
+                            .newInstance(a.getClass().getComponentType(), size);
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {
-                it.next();
-                array[i] = it.allocateDuplicateEntry();
+                if (it.hasNext())
+                {
+                    it.next();
+                    array[i] = (T)it.allocateDuplicateEntry();
+                }
+                else
+                {
+                    array[i] = null;
+                    break;
+                }
             }
             return array;
         }

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -782,11 +782,30 @@ public class Int2ObjectHashMap<V>
         public Object[] toArray()
         {
             final Object[] array = new Object[size()];
+            return toArray(array);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T[] toArray(final T[] a)
+        {
+            final T[] array = a.length >= size ? a : (T[])java.lang.reflect.Array
+                            .newInstance(a.getClass().getComponentType(), size);
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {
-                it.next();
-                array[i] = it.allocateDuplicateEntry();
+                if (it.hasNext())
+                {
+                    it.next();
+                    array[i] = (T)it.allocateDuplicateEntry();
+                }
+                else
+                {
+                    array[i] = null;
+                    break;
+                }
             }
             return array;
         }

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -774,6 +774,22 @@ public class Int2ObjectHashMap<V>
             final V value = getMapped(key);
             return value != null && value.equals(mapNullValue(entry.getValue()));
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map.Entry<Integer, V>[] toArray()
+        {
+            final Entry<Integer, V>[] array = new Map.Entry[size()];
+            final EntryIterator it = iterator();
+            for (@DoNotSub int i = 0; i < array.length; i++)
+            {
+                it.next();
+                array[i] = it.allocateDuplicateEntry();
+            }
+            return array;
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -779,9 +779,9 @@ public class Int2ObjectHashMap<V>
          * {@inheritDoc}
          */
         @Override
-        public Map.Entry<Integer, V>[] toArray()
+        public Object[] toArray()
         {
-            final Entry<Integer, V>[] array = new Map.Entry[size()];
+            final Object[] array = new Object[size()];
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {

--- a/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
@@ -805,15 +805,37 @@ public class Object2IntHashMap<K>
         /**
          * {@inheritDoc}
          */
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public Object[] toArray()
         {
             final Object[] array = new Object[size()];
+            return toArray(array);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T[] toArray(final T[] a)
+        {
+            final T[] array = a.length >= size ? a : (T[])java.lang.reflect.Array
+                            .newInstance(a.getClass().getComponentType(), size);
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {
-                it.next();
-                array[i] = it.allocateDuplicateEntry();
+                if (it.hasNext())
+                {
+                    it.next();
+                    array[i] = (T)it.allocateDuplicateEntry();
+                }
+                else
+                {
+                    array[i] = null;
+                    break;
+                }
             }
             return array;
         }

--- a/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
@@ -806,9 +806,9 @@ public class Object2IntHashMap<K>
          * {@inheritDoc}
          */
         @Override
-        public Map.Entry<K, Integer>[] toArray()
+        public Object[] toArray()
         {
-            final Entry<K, Integer>[] array = new Map.Entry[size()];
+            final Object[] array = new Object[size()];
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {

--- a/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2IntHashMap.java
@@ -801,6 +801,22 @@ public class Object2IntHashMap<K>
 
             return value != null && value.equals(entry.getValue());
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map.Entry<K, Integer>[] toArray()
+        {
+            final Entry<K, Integer>[] array = new Map.Entry[size()];
+            final EntryIterator it = iterator();
+            for (@DoNotSub int i = 0; i < array.length; i++)
+            {
+                it.next();
+                array[i] = it.allocateDuplicateEntry();
+            }
+            return array;
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
@@ -879,11 +879,30 @@ public class Object2ObjectHashMap<K, V> implements Map<K, V>, Serializable
         public Object[] toArray()
         {
             final Object[] array = new Object[size()];
+            return toArray(array);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <T> T[] toArray(final T[] a)
+        {
+            final T[] array = a.length >= size ? a : (T[])java.lang.reflect.Array
+                            .newInstance(a.getClass().getComponentType(), size);
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {
-                it.next();
-                array[i] = it.allocateDuplicateEntry();
+                if (it.hasNext())
+                {
+                    it.next();
+                    array[i] = (T)it.allocateDuplicateEntry();
+                }
+                else
+                {
+                    array[i] = null;
+                    break;
+                }
             }
             return array;
         }

--- a/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
 import static java.util.Objects.requireNonNull;
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
 import static org.agrona.collections.CollectionUtil.validateLoadFactor;
+import org.agrona.generation.DoNotSub;
 
 /**
  * A open addressing with linear probing hash map, same algorithm as {@link Int2IntHashMap}.
@@ -869,6 +870,22 @@ public class Object2ObjectHashMap<K, V> implements Map<K, V>, Serializable
             final Entry<?, ?> entry = (Entry<?, ?>)o;
             final V value = getMapped(entry.getKey());
             return value != null && value.equals(mapNullValue(entry.getValue()));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map.Entry<K, V>[] toArray()
+        {
+            final Entry<K, V>[] array = new Map.Entry[size()];
+            final EntryIterator it = iterator();
+            for (@DoNotSub int i = 0; i < array.length; i++)
+            {
+                it.next();
+                array[i] = it.allocateDuplicateEntry();
+            }
+            return array;
         }
     }
 }

--- a/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
@@ -876,9 +876,9 @@ public class Object2ObjectHashMap<K, V> implements Map<K, V>, Serializable
          * {@inheritDoc}
          */
         @Override
-        public Map.Entry<K, V>[] toArray()
+        public Object[] toArray()
         {
-            final Entry<K, V>[] array = new Map.Entry[size()];
+            final Object[] array = new Object[size()];
             final EntryIterator it = iterator();
             for (@DoNotSub int i = 0; i < array.length; i++)
             {

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -676,6 +676,23 @@ public class Int2IntHashMapTest
     }
 
     @Test
+    public void testToArrayTyped()
+    {
+        final Int2IntHashMap cut = new Int2IntHashMap(-127);
+        cut.put(1, 11);
+        cut.put(2, 12);
+        cut.put(3, 13);
+
+        final Entry[] type = new Entry[1];
+        final Entry[] array = cut.entrySet().toArray(type);
+        for (final Entry entry : array)
+        {
+            cut.remove(((Entry<Integer, Integer>)entry).getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
     public void testToArrayWithArrayListConstructor()
     {
         final Int2IntHashMap cut = new Int2IntHashMap(-127);

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -670,7 +670,7 @@ public class Int2IntHashMapTest
         final Object[] array = cut.entrySet().toArray();
         for (final Object entry : array)
         {
-            cut.remove(((Entry<Integer, Integer>) entry).getKey());
+            cut.remove(((Entry<Integer, Integer>)entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -659,6 +659,38 @@ public class Int2IntHashMapTest
         assertEquals(expected, map);
     }
 
+    @Test
+    public void testToArray()
+    {
+        final Int2IntHashMap cut = new Int2IntHashMap(-127);
+        cut.put(1, 11);
+        cut.put(2, 12);
+        cut.put(3, 13);
+
+        Map.Entry<Integer, Integer>[] array = cut.entrySet().toArray();
+        for (Map.Entry<Integer, Integer> entry : array)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
+    public void testToArrayWithArrayListConstructor()
+    {
+        final Int2IntHashMap cut = new Int2IntHashMap(-127);
+        cut.put(1, 11);
+        cut.put(2, 12);
+        cut.put(3, 13);
+
+        List<Map.Entry<Integer, Integer>> list = new ArrayList<>(cut.entrySet());
+        for (Map.Entry<Integer, Integer> entry : list)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
     private void assertEntryIs(final Entry<Integer, Integer> entry, final int expectedKey, final int expectedValue)
     {
         assertEquals(expectedKey, entry.getKey().intValue());

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -667,10 +667,10 @@ public class Int2IntHashMapTest
         cut.put(2, 12);
         cut.put(3, 13);
 
-        final Map.Entry<Integer, Integer>[] array = cut.entrySet().toArray();
-        for (final Map.Entry<Integer, Integer> entry : array)
+        final Object[] array = cut.entrySet().toArray();
+        for (final Object entry : array)
         {
-            cut.remove(entry.getKey());
+            cut.remove(((Entry<Integer, Integer>) entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -667,8 +667,8 @@ public class Int2IntHashMapTest
         cut.put(2, 12);
         cut.put(3, 13);
 
-        Map.Entry<Integer, Integer>[] array = cut.entrySet().toArray();
-        for (Map.Entry<Integer, Integer> entry : array)
+        final Map.Entry<Integer, Integer>[] array = cut.entrySet().toArray();
+        for (final Map.Entry<Integer, Integer> entry : array)
         {
             cut.remove(entry.getKey());
         }
@@ -683,8 +683,8 @@ public class Int2IntHashMapTest
         cut.put(2, 12);
         cut.put(3, 13);
 
-        List<Map.Entry<Integer, Integer>> list = new ArrayList<>(cut.entrySet());
-        for (Map.Entry<Integer, Integer> entry : list)
+        final List<Map.Entry<Integer, Integer>> list = new ArrayList<>(cut.entrySet());
+        for (final Map.Entry<Integer, Integer> entry : list)
         {
             cut.remove(entry.getKey());
         }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -435,8 +435,8 @@ public class Int2ObjectHashMapTest
         cut.put(2, "b");
         cut.put(3, "c");
 
-        Map.Entry<Integer, String>[] array = cut.entrySet().toArray();
-        for (Map.Entry<Integer, String> entry : array)
+        final Map.Entry<Integer, String>[] array = cut.entrySet().toArray();
+        for (final Map.Entry<Integer, String> entry : array)
         {
             cut.remove(entry.getKey());
         }
@@ -451,8 +451,8 @@ public class Int2ObjectHashMapTest
         cut.put(2, "b");
         cut.put(3, "c");
 
-        List<Map.Entry<Integer, String>> list = new ArrayList<>(cut.entrySet());
-        for (Map.Entry<Integer, String> entry : list)
+        final List<Map.Entry<Integer, String>> list = new ArrayList<>(cut.entrySet());
+        for (final Map.Entry<Integer, String> entry : list)
         {
             cut.remove(entry.getKey());
         }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -435,10 +435,10 @@ public class Int2ObjectHashMapTest
         cut.put(2, "b");
         cut.put(3, "c");
 
-        final Map.Entry<Integer, String>[] array = cut.entrySet().toArray();
-        for (final Map.Entry<Integer, String> entry : array)
+        final Object[] array = cut.entrySet().toArray();
+        for (final Object entry : array)
         {
-            cut.remove(entry.getKey());
+            cut.remove(((Map.Entry<Integer, String>) entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -15,11 +15,13 @@
  */
 package org.agrona.collections;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -423,5 +425,37 @@ public class Int2ObjectHashMapTest
         assertThat(map.containsKey(-1), is(false));
 
         assertThat(map.size(), is(1));
+    }
+
+    @Test
+    public void testToArray()
+    {
+        final Int2ObjectHashMap<String> cut = new Int2ObjectHashMap<>();
+        cut.put(1, "a");
+        cut.put(2, "b");
+        cut.put(3, "c");
+
+        Map.Entry<Integer, String>[] array = cut.entrySet().toArray();
+        for (Map.Entry<Integer, String> entry : array)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
+    public void testToArrayWithArrayListConstructor()
+    {
+        final Int2ObjectHashMap<String> cut = new Int2ObjectHashMap<>();
+        cut.put(1, "a");
+        cut.put(2, "b");
+        cut.put(3, "c");
+
+        List<Map.Entry<Integer, String>> list = new ArrayList<>(cut.entrySet());
+        for (Map.Entry<Integer, String> entry : list)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -444,6 +444,23 @@ public class Int2ObjectHashMapTest
     }
 
     @Test
+    public void testToArrayTyped()
+    {
+        final Int2ObjectHashMap<String> cut = new Int2ObjectHashMap<>();
+        cut.put(1, "a");
+        cut.put(2, "b");
+        cut.put(3, "c");
+
+        final Map.Entry[] type = new Map.Entry[1];
+        final Map.Entry[] array = cut.entrySet().toArray(type);
+        for (final Map.Entry entry : array)
+        {
+            cut.remove(((Map.Entry<Integer, String>)entry).getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
     public void testToArrayWithArrayListConstructor()
     {
         final Int2ObjectHashMap<String> cut = new Int2ObjectHashMap<>();

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -438,7 +438,7 @@ public class Int2ObjectHashMapTest
         final Object[] array = cut.entrySet().toArray();
         for (final Object entry : array)
         {
-            cut.remove(((Map.Entry<Integer, String>) entry).getKey());
+            cut.remove(((Map.Entry<Integer, String>)entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -15,11 +15,13 @@
  */
 package org.agrona.collections;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -437,5 +439,37 @@ public class Object2IntHashMapTest
 
         final Object2IntHashMap<String> mapCopy = new Object2IntHashMap<>(objectToIntMap);
         assertThat(mapCopy, is(objectToIntMap));
+    }
+
+    @Test
+    public void testToArray()
+    {
+        final Object2IntHashMap<String> cut = new Object2IntHashMap<>(-127);
+        cut.put("a", 1);
+        cut.put("b", 2);
+        cut.put("c", 3);
+
+        Map.Entry<String, Integer>[] array = cut.entrySet().toArray();
+        for (Map.Entry<String, Integer> entry : array)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
+    public void testToArrayWithArrayListConstructor()
+    {
+        final Object2IntHashMap<String> cut = new Object2IntHashMap<>(-127);
+        cut.put("a", 1);
+        cut.put("b", 2);
+        cut.put("c", 3);
+
+        List<Map.Entry<String, Integer>> list = new ArrayList<>(cut.entrySet());
+        for (Map.Entry<String, Integer> entry : list)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -453,7 +453,7 @@ public class Object2IntHashMapTest
         final Object[] array = cut.entrySet().toArray();
         for (final Object entry : array)
         {
-            cut.remove(((Entry<String, Integer>) entry).getKey());
+            cut.remove(((Entry<String, Integer>)entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -449,8 +449,8 @@ public class Object2IntHashMapTest
         cut.put("b", 2);
         cut.put("c", 3);
 
-        Map.Entry<String, Integer>[] array = cut.entrySet().toArray();
-        for (Map.Entry<String, Integer> entry : array)
+        final Map.Entry<String, Integer>[] array = cut.entrySet().toArray();
+        for (final Map.Entry<String, Integer> entry : array)
         {
             cut.remove(entry.getKey());
         }
@@ -465,8 +465,8 @@ public class Object2IntHashMapTest
         cut.put("b", 2);
         cut.put("c", 3);
 
-        List<Map.Entry<String, Integer>> list = new ArrayList<>(cut.entrySet());
-        for (Map.Entry<String, Integer> entry : list)
+        final List<Map.Entry<String, Integer>> list = new ArrayList<>(cut.entrySet());
+        for (final Map.Entry<String, Integer> entry : list)
         {
             cut.remove(entry.getKey());
         }

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -459,6 +459,23 @@ public class Object2IntHashMapTest
     }
 
     @Test
+    public void testToArrayTyped()
+    {
+        final Object2IntHashMap<String> cut = new Object2IntHashMap<>(-127);
+        cut.put("a", 1);
+        cut.put("b", 2);
+        cut.put("c", 3);
+
+        final Entry[] type = new Entry[1];
+        final Entry[] array = cut.entrySet().toArray(type);
+        for (final Entry entry : array)
+        {
+            cut.remove(((Entry<String, Integer>)entry).getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
     public void testToArrayWithArrayListConstructor()
     {
         final Object2IntHashMap<String> cut = new Object2IntHashMap<>(-127);

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
@@ -449,10 +450,10 @@ public class Object2IntHashMapTest
         cut.put("b", 2);
         cut.put("c", 3);
 
-        final Map.Entry<String, Integer>[] array = cut.entrySet().toArray();
-        for (final Map.Entry<String, Integer> entry : array)
+        final Object[] array = cut.entrySet().toArray();
+        for (final Object entry : array)
         {
-            cut.remove(entry.getKey());
+            cut.remove(((Entry<String, Integer>) entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -36,6 +36,23 @@ public class Object2ObjectHashMapTest
     }
 
     @Test
+    public void testToArrayTyped()
+    {
+        final Object2ObjectHashMap<String, String> cut = new Object2ObjectHashMap<>();
+        cut.put("a", "valA");
+        cut.put("b", "valA");
+        cut.put("c", "valA");
+
+        final Entry[] type = new Entry[1];
+        final Entry[] array = cut.entrySet().toArray(type);
+        for (final Entry entry : array)
+        {
+            cut.remove(((Entry<String, String>)entry).getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
     public void testToArrayWithArrayListConstructor()
     {
         final Object2ObjectHashMap<String, String> cut = new Object2ObjectHashMap<>();

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -27,10 +27,10 @@ public class Object2ObjectHashMapTest
         cut.put("b", "valA");
         cut.put("c", "valA");
 
-        final Map.Entry<String, String>[] array = cut.entrySet().toArray();
-        for (final Map.Entry<String, String> entry : array)
+        final Object[] array = cut.entrySet().toArray();
+        for (final Object entry : array)
         {
-            cut.remove(entry.getKey());
+            cut.remove(((Entry<String, String>) entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -30,7 +30,7 @@ public class Object2ObjectHashMapTest
         final Object[] array = cut.entrySet().toArray();
         for (final Object entry : array)
         {
-            cut.remove(((Entry<String, String>) entry).getKey());
+            cut.remove(((Entry<String, String>)entry).getKey());
         }
         assertTrue(cut.isEmpty());
     }

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -16,7 +16,8 @@ import org.junit.jupiter.api.Test;
  *
  * @author OmniBene, s.r.o.
  */
-public class Object2ObjectHashMapTest {
+public class Object2ObjectHashMapTest
+{
 
     @Test
     public void testToArray()
@@ -26,8 +27,8 @@ public class Object2ObjectHashMapTest {
         cut.put("b", "valA");
         cut.put("c", "valA");
 
-        Map.Entry<String, String>[] array = cut.entrySet().toArray();
-        for (Map.Entry<String, String> entry : array)
+        final Map.Entry<String, String>[] array = cut.entrySet().toArray();
+        for (final Map.Entry<String, String> entry : array)
         {
             cut.remove(entry.getKey());
         }
@@ -42,8 +43,8 @@ public class Object2ObjectHashMapTest {
         cut.put("b", "valA");
         cut.put("c", "valA");
 
-        List<Entry<String, String>> list = new ArrayList<>(cut.entrySet());
-        for (Map.Entry<String, String> entry : list)
+        final List<Entry<String, String>> list = new ArrayList<>(cut.entrySet());
+        for (final Map.Entry<String, String> entry : list)
         {
             cut.remove(entry.getKey());
         }

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -1,0 +1,53 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.agrona.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author OmniBene, s.r.o.
+ */
+public class Object2ObjectHashMapTest {
+
+    @Test
+    public void testToArray()
+    {
+        final Object2ObjectHashMap<String, String> cut = new Object2ObjectHashMap<>();
+        cut.put("a", "valA");
+        cut.put("b", "valA");
+        cut.put("c", "valA");
+
+        Map.Entry<String, String>[] array = cut.entrySet().toArray();
+        for (Map.Entry<String, String> entry : array)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+    @Test
+    public void testToArrayWithArrayListConstructor()
+    {
+        final Object2ObjectHashMap<String, String> cut = new Object2ObjectHashMap<>();
+        cut.put("a", "valA");
+        cut.put("b", "valA");
+        cut.put("c", "valA");
+
+        List<Entry<String, String>> list = new ArrayList<>(cut.entrySet());
+        for (Map.Entry<String, String> entry : list)
+        {
+            cut.remove(entry.getKey());
+        }
+        assertTrue(cut.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Fixes 4 out of the 5 Map implementations in org.agrona.collections. The remaining, `Int2ObjectCache` is missing the required `allocateDuplicateEntry()` method in the iterator.