### PR TITLE
[Java] AsciiEncoding parseIntAscii/parseLongAscii to throw NumberFormatException when detecting overflow

### DIFF
--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -34,6 +34,20 @@ public class AsciiEncodingTest
     }
 
     @Test
+    public void shouldParseMaxIntValue()
+    {
+        final String value = String.valueOf(Integer.MAX_VALUE);
+        assertThat(AsciiEncoding.parseIntAscii(value, 0, value.length()), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldParseMinIntValue()
+    {
+        final String value = String.valueOf(Integer.MIN_VALUE);
+        assertThat(AsciiEncoding.parseIntAscii(value, 0, value.length()), is(Integer.MIN_VALUE));
+    }
+
+    @Test
     public void shouldParseLong()
     {
         assertThat(AsciiEncoding.parseLongAscii("0", 0, 1), is(0L));
@@ -41,6 +55,20 @@ public class AsciiEncodingTest
         assertThat(AsciiEncoding.parseLongAscii("7", 0, 1), is(7L));
         assertThat(AsciiEncoding.parseLongAscii("-7", 0, 2), is(-7L));
         assertThat(AsciiEncoding.parseLongAscii("3333", 1, 2), is(33L));
+    }
+
+    @Test
+    public void shouldParseMaxLongValue()
+    {
+        final String value = String.valueOf(Long.MAX_VALUE);
+        assertThat(AsciiEncoding.parseLongAscii(value, 0, value.length()), is(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldParseMinLongValue()
+    {
+        final String value = String.valueOf(Long.MIN_VALUE);
+        assertThat(AsciiEncoding.parseLongAscii(value, 0, value.length()), is(Long.MIN_VALUE));
     }
 
     @Test
@@ -83,5 +111,49 @@ public class AsciiEncodingTest
     public void shouldThrowExceptionWhenParsingEmptyInteger()
     {
         assertThrows(IndexOutOfBoundsException.class, () -> AsciiEncoding.parseIntAscii("", 0, 0));
+    }
+
+    @Test
+    public void shouldThrowNumberFormatExceptionOnIntOverflow()
+    {
+        final String values[] =
+        {
+            "2147483648", // Integer.MAX_VALUE + 1
+            "10737418230", // (Integer.MAX_VALUE / 2) * 10
+            "9999999999",
+            "-2147483649", // Integer.MIN_VALUE - 1
+            "-10737418240", // (Integer.MIN_VALUE / 2) * 10
+            "-9999999999"
+        };
+        for (final String value : values)
+        {
+            assertThrows(
+                NumberFormatException.class,
+                () -> AsciiEncoding.parseIntAscii(value, 0, value.length()),
+                value
+            );
+        }
+    }
+
+    @Test
+    public void shouldThrowNumberFormatExceptionOnLongOverflow()
+    {
+        final String values[] =
+        {
+            "9223372036854775808", // Long.MAX_VALUE + 1
+            "46116860184273879030", // (Long.MAX_VALUE / 2) * 10
+            "9999999999999999999",
+            "-9223372036854775809", // LONG.MIN_VALUE - 1
+            "-46116860184273879040", // (Long.MIN_VALUE / 2) * 10
+            "-9999999999999999999"
+        };
+        for (final String value : values)
+        {
+            assertThrows(
+                NumberFormatException.class,
+                () -> AsciiEncoding.parseLongAscii(value, 0, value.length()),
+                value
+            );
+        }
     }
 }


### PR DESCRIPTION
Same behaviour as Integer::parseInt and Long::parseLong