### PR TITLE
[Java] Make AsciiEncoding throw exceptions similar to JDK parseInt/parseLong

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -127,20 +127,19 @@ public final class AsciiEncoding
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
      * @throws AsciiNumberFormatException if <code>cs</code> is not an int value
-     * @throws IndexOutOfBoundsException if <code>cs</code> is empty
+     * @throws IndexOutOfBoundsException if parsing results in access outside string boundaries, or length is negative
      * @return the parsed value.
      */
     public static int parseIntAscii(final CharSequence cs, final int index, final int length)
     {
-        final int endExclusive = index + length;
-        final int first = cs.charAt(index);
-        int i = index;
-        final boolean hasSign = first == MINUS_SIGN;
-
-        if (hasSign && length > 1)
+        if (length <= 1)
         {
-            i++;
+            return parseSingleDigit(cs, index, length);
         }
+
+        final boolean hasSign = cs.charAt(index) == MINUS_SIGN;
+        final int endExclusive = index + length;
+        int i = hasSign ? index + 1 : index;
 
         if (length >= 10)
         {
@@ -168,20 +167,19 @@ public final class AsciiEncoding
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
      * @throws AsciiNumberFormatException if <code>cs</code> is not a long value
-     * @throws IndexOutOfBoundsException if <code>cs</code> is empty
+     * @throws IndexOutOfBoundsException if parsing results in access outside string boundaries, or length is negative
      * @return the parsed value.
      */
     public static long parseLongAscii(final CharSequence cs, final int index, final int length)
     {
-        final int endExclusive = index + length;
-        final int first = cs.charAt(index);
-        int i = index;
-        final boolean hasSign = first == MINUS_SIGN;
-
-        if (hasSign && length > 1)
+        if (length <= 1)
         {
-            i++;
+            return parseSingleDigit(cs, index, length);
         }
+
+        final boolean hasSign = cs.charAt(index) == MINUS_SIGN;
+        final int endExclusive = index + length;
+        int i = hasSign ? index + 1 : index;
 
         if (length >= 19)
         {
@@ -200,6 +198,22 @@ public final class AsciiEncoding
         }
 
         return tally;
+    }
+
+    private static int parseSingleDigit(final CharSequence cs, final int index, final int length)
+    {
+        if (length == 1)
+        {
+            return AsciiEncoding.getDigit(index, cs.charAt(index));
+        }
+        else if (length == 0)
+        {
+            throw new AsciiNumberFormatException("'' is not a valid int @ " + index);
+        }
+        else
+        {
+            throw new IndexOutOfBoundsException("length=" + length);
+        }
     }
 
     private static void checkIntLimits(

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -151,12 +151,12 @@ public class AsciiEncodingTest
     @Test
     public void shouldThrowExceptionWhenParsingEmptyInteger()
     {
-        assertThrows(IndexOutOfBoundsException.class, () -> parseIntAscii("", 0, 0));
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("", 0, 0));
     }
 
     @Test
     public void shouldThrowExceptionWhenParsingEmptyLong()
     {
-        assertThrows(IndexOutOfBoundsException.class, () -> parseLongAscii("", 0, 0));
+        assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("", 0, 0));
     }
 }


### PR DESCRIPTION
Empty string results in NumberFormatException. Attempt to read outside string boundaries (or negative length) in IndexOutOfBoundsException.
This behaviour is consistent with Integer::parseInt / Long::parseLong, and makes a slightly more usable API which does not force callers to catch 2 exceptions for the same kind of error - non-numeric input value. Incorrect usage still results in IndexOutOfBoundsException.

As I understand this is performance-sensitive call, I've run some benchmarks to parse 1 million numbers and try to evaluate effect of the special-case for `length <=1`
 - mix of random 1- and 2- digit numbers (80/20)
 - random numbers which are multiple of 1 million in 1-50m range
 - random non-negative numbers
 - mix of random negative and non-negative numbers
On my machine first case actually shows slight improvement (~15%) - which I don't quite understand. The other 3 produce pretty consistent results on both original and updated code.

Benchmarks are not included in this PR, but are available from https://github.com/AndreyNudko/agrona/tree/ascii-encoding-benchmarks/agrona-benchmarks/src/main/java/org/agrona
