### PR TITLE
[Java] Fix map capacity calculation

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2IntCounterMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntCounterMap.java
@@ -100,7 +100,7 @@ public class Int2IntCounterMap implements Serializable
      */
     @DoNotSub public int capacity()
     {
-        return entries.length >> 2;
+        return entries.length >> 1;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -105,7 +105,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>, Serializable
      */
     @DoNotSub public int capacity()
     {
-        return entries.length >> 2;
+        return entries.length >> 1;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
@@ -95,7 +95,7 @@ public class Object2ObjectHashMap<K, V> implements Map<K, V>, Serializable
      */
     public int capacity()
     {
-        return entries.length >> 2;
+        return entries.length >> 1;
     }
 
     /**


### PR DESCRIPTION
I believe capacity should be equal to a half of the array length, not a quarter.