### PR TITLE
Infinity loop fix

### DIFF
--- a/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
+++ b/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
@@ -69,6 +69,24 @@ public class BufferAlignmentAgentTest
     }
 
     @Test
+    public void testInfinityLoopReproducer()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(1);
+        buffer.putByte(0, (byte)4);
+        buffer.putByte(1, (byte)2);
+
+        final ExpandableArrayBuffer buffer2 = new ExpandableArrayBuffer(0);
+        buffer2.putByte(0, (byte)4);
+    }
+
+    @Test
+    public void testFastExpansion()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(4);
+        buffer.putStringUtf8(0, "42_at_least_twice");
+    }
+
+    @Test
     public void testUnsafeBufferFromHeapByteBuffer()
     {
         testUnsafeBuffer(new UnsafeBuffer(ByteBuffer.allocate(256)), HEAP_BUFFER_ALIGNMENT_OFFSET);

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -1107,19 +1107,29 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
     private int calculateExpansion(final int currentLength, final int requiredLength)
     {
-        long value = currentLength;
+        if (requiredLength - currentLength > currentLength)
+        {
+            return fastCalculateExpansion(currentLength, requiredLength);
+        }
 
+        long value = currentLength;
         while (value < requiredLength)
         {
-            value = value + (value >> 1);
+            value = value + (value >> 1) + 1;
 
-            if (value > MAX_ARRAY_LENGTH)
+            if (value >= MAX_ARRAY_LENGTH)
             {
-                value = MAX_ARRAY_LENGTH;
+                return MAX_ARRAY_LENGTH;
             }
         }
 
         return (int)value;
+    }
+
+    private int fastCalculateExpansion(final int currentLength, final int requiredLength)
+    {
+        final long value = currentLength + requiredLength + (currentLength >> 1);
+        return value >= MAX_ARRAY_LENGTH ? MAX_ARRAY_LENGTH : (int)value;
     }
 
     private void boundsCheck0(final int index, final int length)


### PR DESCRIPTION
Fix infinity loop in ExpandableArrayBuffer.calculateExpansion, add reproducer. Fix a bit performance case when second "put" requires more than two iterations for "while", than greatest value passed than more iterations accrue