### PR TITLE
Coalescing Array Queue

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/CoalescingArrayQueue.java
+++ b/agrona/src/main/java/org/agrona/collections/CoalescingArrayQueue.java
@@ -42,7 +42,8 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      *
      * @param <V> type of the value.
      */
-    public interface KeySupplier<V> {
+    public interface KeySupplier<V>
+    {
         /**
          * key supplier.
          * @param v value instance.
@@ -70,7 +71,7 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      *
      * @param keySupplier required supplier of unique key for value instances.
      */
-    public CoalescingArrayQueue(KeySupplier<V> keySupplier)
+    public CoalescingArrayQueue(final KeySupplier<V> keySupplier)
     {
         this(keySupplier, MIN_CAPACITY);
     }
@@ -82,8 +83,8 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      * @param initialCapacity for the queue which will be rounded up to the nearest power of 2.
      */
     public CoalescingArrayQueue(
-            KeySupplier<V> keySupplier,
-            final int initialCapacity)
+        final KeySupplier<V> keySupplier,
+        final int initialCapacity)
     {
         this(keySupplier, initialCapacity, true);
     }
@@ -96,9 +97,9 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      * @param shouldAvoidAllocation true to cache the iterator otherwise false to allocate a new iterator each time.
      */
     public CoalescingArrayQueue(
-            final KeySupplier<V> keySupplier,
-            final int initialCapacity,
-            final boolean shouldAvoidAllocation)
+        final KeySupplier<V> keySupplier,
+        final int initialCapacity,
+        final boolean shouldAvoidAllocation)
     {
         if (keySupplier == null)
         {
@@ -178,7 +179,7 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      * {@inheritDoc}
      */
     @Override
-    public void forEach(Consumer<? super V> action)
+    public void forEach(final Consumer<? super V> action)
     {
         requireNonNull(action, "action cannot be null.");
         // Warn: a slow implementation
@@ -210,7 +211,7 @@ public class CoalescingArrayQueue<V> extends AbstractQueue<V>
      * {@inheritDoc}
      */
     @Override
-    public boolean offer(V v)
+    public boolean offer(final V v)
     {
         requireNonNull(v, "value cannot be null");
 

--- a/agrona/src/main/java/org/agrona/collections/CoalescingArrayQueue.java
+++ b/agrona/src/main/java/org/agrona/collections/CoalescingArrayQueue.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.agrona.BitUtil;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Basic queue that coalesces duplicate entries without loss of time priority.
+ * <p>
+ * The {@link ValueIterator} is cached by default to avoid allocation unless directed to do so in the constructor.
+ * <p>
+ * <b>Note:</b> This class is not threadsafe.
+ * <p>
+ * Implementation:
+ * Bulk of the code replicates {@link IntArrayQueue } to create an optimum queue implementation.
+ * The coalescing function is managed via queued keys from a key supplier mapped to the latest value instance.
+ *
+ * @param <V>
+ */
+public class CoalescingArrayQueue<V> extends AbstractQueue<V>
+{
+    /**
+     * Supplies a unique Key/Id for an instance of the queues object type.
+     *
+     * @param <V> type of the value.
+     */
+    public interface KeySupplier<V> {
+        /**
+         * key supplier.
+         * @param v value instance.
+         * @return unique id for instance.
+         */
+        int getKey(V v);
+    }
+
+    /**
+     * Minimum capacity for the queue which must also be a power of 2.
+     */
+    public static final int MIN_CAPACITY = 8;
+
+    private final KeySupplier<V> keySupplier;
+    private final boolean shouldAvoidAllocation;
+    private int head;
+    private int tail;
+    private final int nullValue;
+    private int[] values;
+    private final Int2ObjectHashMap<V> valueFromKey;
+    private ValueIterator iterator;
+
+    /**
+     * Construct a new queue defaulting to {@link #MIN_CAPACITY} capacity and cached iterator.
+     *
+     * @param keySupplier required supplier of unique key for value instances.
+     */
+    public CoalescingArrayQueue(KeySupplier<V> keySupplier)
+    {
+        this(keySupplier, MIN_CAPACITY);
+    }
+
+    /**
+     * Construct a new queue default to cached iterators.
+     *
+     * @param keySupplier required supplier of unique key for value instances.
+     * @param initialCapacity for the queue which will be rounded up to the nearest power of 2.
+     */
+    public CoalescingArrayQueue(
+            KeySupplier<V> keySupplier,
+            final int initialCapacity)
+    {
+        this(keySupplier, initialCapacity, true);
+    }
+
+    /**
+     * Construct a new queue providing all the config options.
+     *
+     * @param keySupplier required supplier of unique key for value instances.
+     * @param initialCapacity for the queue which will be rounded up to the nearest power of 2.
+     * @param shouldAvoidAllocation true to cache the iterator otherwise false to allocate a new iterator each time.
+     */
+    public CoalescingArrayQueue(
+            final KeySupplier<V> keySupplier,
+            final int initialCapacity,
+            final boolean shouldAvoidAllocation)
+    {
+        if (keySupplier == null)
+        {
+            throw new IllegalArgumentException("Key Supplier is missing");
+        }
+
+        this.keySupplier = keySupplier;
+        this.nullValue = IntArrayQueue.DEFAULT_NULL_VALUE;
+        this.shouldAvoidAllocation = shouldAvoidAllocation;
+
+        if (initialCapacity < MIN_CAPACITY)
+        {
+            throw new IllegalArgumentException("initial capacity < MIN_INITIAL_CAPACITY : " + initialCapacity);
+        }
+
+        final int capacity = BitUtil.findNextPositivePowerOfTwo(initialCapacity);
+        if (capacity < MIN_CAPACITY)
+        {
+            throw new IllegalArgumentException("invalid initial capacity: " + initialCapacity);
+        }
+
+        values = new int[capacity];
+        Arrays.fill(values, nullValue);
+
+        valueFromKey = new Int2ObjectHashMap<>(initialCapacity, Hashing.DEFAULT_LOAD_FACTOR, shouldAvoidAllocation);
+    }
+
+    /**
+     * The current capacity for the collection.
+     *
+     * @return the current capacity for the collection.
+     */
+    public int capacity()
+    {
+        return values.length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size()
+    {
+        return (tail - head) & (values.length - 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty()
+    {
+        return head == tail;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValueIterator iterator()
+    {
+        ValueIterator iterator = this.iterator;
+        if (null == iterator)
+        {
+            iterator = new ValueIterator();
+
+            if (shouldAvoidAllocation)
+            {
+                this.iterator = iterator;
+            }
+        }
+
+        return iterator.reset();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void forEach(Consumer<? super V> action)
+    {
+        requireNonNull(action, "action cannot be null.");
+        // Warn: a slow implementation
+        for (int i = head; i != tail; )
+        {
+            action.accept(valueFromKey.get(values[i]));
+            i = (i + 1) & (values.length - 1);
+        }
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear()
+    {
+        if (head != tail)
+        {
+            Arrays.fill(values, nullValue);
+            head = 0;
+            tail = 0;
+        }
+
+        valueFromKey.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean offer(V v)
+    {
+        requireNonNull(v, "value cannot be null");
+
+        final int key = keySupplier.getKey(v);
+
+        if (null == valueFromKey.put(key, v))
+        {
+            values[tail] = key;
+            tail = (tail + 1) & (values.length - 1);
+
+            if (tail == head)
+            {
+                increaseCapacity();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V poll()
+    {
+        final int key = values[head];
+
+        if (nullValue == key)
+        {
+            return null;
+        }
+
+        values[head] = nullValue;
+        head = (head + 1) & (values.length - 1);
+
+        return valueFromKey.remove(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V peek()
+    {
+        final int key = values[head];
+
+        return key == nullValue ? null : valueFromKey.get(key);
+    }
+
+    private void increaseCapacity()
+    {
+        final int oldHead = head;
+        final int oldCapacity = values.length;
+        final int toEndOfArray = oldCapacity - oldHead;
+        final int newCapacity = oldCapacity << 1;
+
+        if (newCapacity < MIN_CAPACITY)
+        {
+            throw new IllegalStateException("max capacity reached");
+        }
+
+        final int[] array = new int[newCapacity];
+        Arrays.fill(array, oldCapacity, newCapacity, nullValue);
+        System.arraycopy(values, oldHead, array, 0, toEndOfArray);
+        System.arraycopy(values, 0, array, toEndOfArray, oldHead);
+
+        values = array;
+        head = 0;
+        tail = oldCapacity;
+    }
+
+    public final class ValueIterator implements Iterator<V>
+    {
+        private int index;
+
+        ValueIterator reset()
+        {
+            index = CoalescingArrayQueue.this.head;
+            return this;
+        }
+
+        public boolean hasNext()
+        {
+            return index != tail;
+        }
+
+        public V next()
+        {
+            if (index == tail)
+            {
+                throw new NoSuchElementException();
+            }
+
+            final int key = values[index];
+            index = (index + 1) & (values.length - 1);
+
+            return valueFromKey.get(key);
+        }
+    }
+}

--- a/agrona/src/test/java/org/agrona/collections/CoalescingArrayQueueTest.java
+++ b/agrona/src/test/java/org/agrona/collections/CoalescingArrayQueueTest.java
@@ -147,7 +147,8 @@ class CoalescingArrayQueueTest
     }
 
     @Test
-    void shouldCoalesce() {
+    void shouldCoalesce()
+    {
         final CoalescingArrayQueue<Versioned> queue = create();
         final Versioned element = withKey(7);
         final Versioned updated = withKeyVersion(7, 1);
@@ -177,7 +178,7 @@ class CoalescingArrayQueueTest
         return new Versioned(key, version);
     }
 
-    private static class Versioned
+    private static final class Versioned
     {
         private final int key;
         private int version;
@@ -193,16 +194,18 @@ class CoalescingArrayQueueTest
             this.version = version;
         }
 
-        public int getKey() {
+        public int getKey()
+        {
             return key;
         }
 
-        public int getVersion() {
+        public int getVersion()
+        {
             return version;
         }
 
         @Override
-        public boolean equals(Object o)
+        public boolean equals(final Object o)
         {
             if (this == o)
             {
@@ -213,7 +216,7 @@ class CoalescingArrayQueueTest
                 return false;
             }
 
-            Versioned versioned = (Versioned) o;
+            final Versioned versioned = (Versioned)o;
 
             return key == versioned.key && version == versioned.version;
         }

--- a/agrona/src/test/java/org/agrona/collections/CoalescingArrayQueueTest.java
+++ b/agrona/src/test/java/org/agrona/collections/CoalescingArrayQueueTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CoalescingArrayQueueTest
+{
+    @Test
+    void shouldFailCreateWithInvalidKeySupplier()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new CoalescingArrayQueue<>(null));
+    }
+
+    @Test
+    void shouldFailCreateWithInvalidCapacity()
+    {
+        assertThrows(IllegalArgumentException.class, () -> new CoalescingArrayQueue<>(Versioned::getKey, 1));
+    }
+
+    @Test
+    public void shouldDefaultInitialise()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
+        assertEquals(IntArrayQueue.MIN_CAPACITY, queue.capacity());
+    }
+
+    @Test
+    public void shouldOfferThenPoll()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+        final Versioned element = withKey(7);
+
+        queue.offer(element);
+        assertEquals(1, queue.size());
+
+        assertEquals(element, queue.poll());
+        assertNull(queue.poll());
+    }
+
+    @Test
+    public void shouldForEach()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+        final ArrayList<Versioned> expected = new ArrayList<>();
+
+        for (int i = 0; i < 20; i++)
+        {
+            queue.offer(withKey(i));
+            expected.add(withKey(i));
+        }
+
+        final ArrayList<Versioned> actual = new ArrayList<>();
+        queue.forEach(actual::add);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldClear()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+
+        for (int i = 0; i < 7; i++)
+        {
+            queue.offer(withKey(i));
+        }
+
+        queue.clear();
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void shouldPeek()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+        assertNull(queue.peek());
+
+        final Versioned element = withKey(7);
+        queue.offer(element);
+        assertEquals(element, queue.peek());
+    }
+
+    @Test
+    public void shouldIterate()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+        final int count = 20;
+
+        for (int i = 0; i < count; i++)
+        {
+            queue.offer(withKey(i));
+        }
+
+        final CoalescingArrayQueue<Versioned>.ValueIterator iterator = queue.iterator();
+        for (int i = 0; i < count; i++)
+        {
+            assertTrue(iterator.hasNext());
+            assertEquals(withKey(i), iterator.next());
+        }
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void shouldIterateEmptyQueue()
+    {
+        final CoalescingArrayQueue<Versioned> queue = create();
+
+        for (final Versioned ignore : queue)
+        {
+            fail("Should be empty");
+        }
+
+        final int count = 20;
+        for (int i = 0; i < count; i++)
+        {
+            queue.offer(withKey(i));
+            queue.poll();
+        }
+
+        for (final Versioned ignore : queue)
+        {
+            fail("Should be empty");
+        }
+    }
+
+    @Test
+    void shouldCoalesce() {
+        final CoalescingArrayQueue<Versioned> queue = create();
+        final Versioned element = withKey(7);
+        final Versioned updated = withKeyVersion(7, 1);
+
+        queue.offer(element);
+        assertEquals(1, queue.size());
+
+        queue.offer(updated);
+        assertEquals(1, queue.size());
+
+        assertEquals(updated, queue.poll());
+        assertNull(queue.poll());
+    }
+
+    private CoalescingArrayQueue<Versioned> create()
+    {
+        return new CoalescingArrayQueue<>(Versioned::getKey);
+    }
+
+    private Versioned withKey(final int key)
+    {
+        return new Versioned(key);
+    }
+
+    private Versioned withKeyVersion(final int key, final int version)
+    {
+        return new Versioned(key, version);
+    }
+
+    private static class Versioned
+    {
+        private final int key;
+        private int version;
+
+        private Versioned(final int key)
+        {
+            this(key, 0);
+        }
+
+        private Versioned(final int key, final int version)
+        {
+            this.key = key;
+            this.version = version;
+        }
+
+        public int getKey() {
+            return key;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+
+            Versioned versioned = (Versioned) o;
+
+            return key == versioned.key && version == versioned.version;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(key, version);
+        }
+    }
+}


### PR DESCRIPTION
Implements a coalescing queue where a duplicate offer will update an existing entry preserving the time priority of the original offer.

A typical use-case is in a constrained resource environment with a queue used to orchestrate requests.  One would wish to only use the resource with the latest updates and not waste computation on stale data when a resource becomes available.

The implementation follows IntArrayQueue but instead of queueing integers it enqueues the key of an instance via a call to a supplied KeySupplier.  The key is then mapped using a Int2ObjectHashMap to the latest value. 