### PR TITLE
[Java] Create RingBuffers as empty, i.e. pre-zero first record header and reset metadata section.

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
@@ -16,7 +16,9 @@
 package org.agrona.concurrent.ringbuffer;
 
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.ControlledMessageHandler;
+import org.agrona.concurrent.MessageHandler;
 
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ControlledMessageHandler.Action.*;
@@ -41,9 +43,12 @@ public final class OneToOneRingBuffer implements RingBuffer
     private final AtomicBuffer buffer;
 
     /**
-     * Construct a new {@link RingBuffer} based on an underlying {@link AtomicBuffer}.
+     * Construct an empty {@link RingBuffer} based on an underlying {@link AtomicBuffer}.
      * The underlying buffer must a power of 2 in size plus sufficient space
      * for the {@link RingBufferDescriptor#TRAILER_LENGTH}.
+     *
+     * <p>Note: Existing data in the buffer will be ignored and the ring buffer will be created as empty, i.e. upon
+     * construction the {@link #size()} and {@link #read(MessageHandler, int)} methods will return zero.</p>
      *
      * @param buffer via which events will be exchanged.
      * @throws IllegalStateException if the buffer capacity is not a power of 2 plus
@@ -51,11 +56,14 @@ public final class OneToOneRingBuffer implements RingBuffer
      */
     public OneToOneRingBuffer(final AtomicBuffer buffer)
     {
-        this.buffer = buffer;
         checkCapacity(buffer.capacity());
+        buffer.verifyAlignment();
+
+        this.buffer = buffer;
         capacity = buffer.capacity() - TRAILER_LENGTH;
 
-        buffer.verifyAlignment();
+        buffer.putLong(0, 0); // pre-zero first record header
+        buffer.setMemory(capacity, TRAILER_LENGTH, (byte)0); // reset metadata
 
         maxMsgLength = capacity >> 3;
         tailPositionIndex = capacity + TAIL_POSITION_OFFSET;

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
@@ -31,6 +31,8 @@ import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer.PADDING_MSG_TYPE_ID;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
 import static org.agrona.concurrent.ringbuffer.RingBuffer.INSUFFICIENT_CAPACITY;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.*;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.HEAD_POSITION_OFFSET;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -764,6 +766,36 @@ public class ManyToOneRingBufferTest
         assertEquals(2, counter.get());
         assertEquals(2, messagesRead);
         assertEquals(ringBuffer.producerPosition(), ringBuffer.consumerPosition());
+    }
+
+    @Test
+    void shouldVerifyAlignment()
+    {
+        final IllegalStateException exception = new IllegalStateException("alignment error");
+        doThrow(exception).when(buffer).verifyAlignment();
+
+        final IllegalStateException thrown =
+            assertThrows(IllegalStateException.class, () -> new ManyToOneRingBuffer(buffer));
+        assertSame(exception, thrown);
+    }
+
+
+    @Test
+    void shouldResetMetadataAndPreZeroFirstRecordHeader()
+    {
+        final int capacity = 1024;
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[capacity + TRAILER_LENGTH]);
+        buffer.setMemory(0, buffer.capacity(), (byte)127);
+        buffer.putInt(lengthOffset(0), 100);
+        buffer.putInt(typeOffset(0), 3);
+        buffer.putInt(capacity + TAIL_POSITION_OFFSET, 1200);
+        buffer.putInt(capacity + HEAD_CACHE_POSITION_OFFSET, 1000);
+        buffer.putInt(capacity + HEAD_POSITION_OFFSET, 1000);
+
+        final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(buffer);
+
+        assertEquals(0, ringBuffer.size());
+        assertEquals(0, ringBuffer.read((msgTypeId, buffer1, index, length) -> fail()));
     }
 
     private void testAlreadyCommitted(final IntConsumer action)


### PR DESCRIPTION
The `RingBuffer` is always created empty disregarding the content of the underlying `AtomicBuffer`. This is necessary to ensure correctness of the read/write operations.