### PR TITLE
[Java] Make nodeIdBits and sequenceBits configurable.

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
+++ b/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
@@ -53,11 +53,6 @@ abstract class AbstractSnowflakeIdGeneratorPaddingRhs extends AbstractSnowflakeI
  */
 public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorPaddingRhs implements IdGenerator
 {
-    byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
-    byte p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030, p031;
-    byte p032, p033, p034, p035, p036, p037, p038, p039, p040, p041, p042, p043, p044, p045, p046, p047;
-    byte p048, p049, p050, p051, p052, p053, p054, p055, p056, p057, p058, p059, p060, p061, p062, p063;
-
     /**
      * High order 2's compliment bit which is unused.
      */

--- a/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
+++ b/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
@@ -19,7 +19,7 @@ import org.agrona.hints.ThreadHints;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
-abstract class AbstractSnowflakeIdGeneratorPadding
+abstract class AbstractSnowflakeIdGeneratorPaddingLhs
 {
     byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
     byte p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030, p031;
@@ -27,12 +27,20 @@ abstract class AbstractSnowflakeIdGeneratorPadding
     byte p048, p049, p050, p051, p052, p053, p054, p055, p056, p057, p058, p059, p060, p061, p062, p063;
 }
 
-abstract class AbstractSnowflakeIdGeneratorValue extends AbstractSnowflakeIdGeneratorPadding
+abstract class AbstractSnowflakeIdGeneratorValue extends AbstractSnowflakeIdGeneratorPaddingLhs
 {
     static final AtomicLongFieldUpdater<AbstractSnowflakeIdGeneratorValue> TIMESTAMP_SEQUENCE_UPDATER =
         AtomicLongFieldUpdater.newUpdater(AbstractSnowflakeIdGeneratorValue.class, "timestampSequence");
 
     volatile long timestampSequence;
+}
+
+abstract class AbstractSnowflakeIdGeneratorPaddingRhs extends AbstractSnowflakeIdGeneratorValue
+{
+    byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
+    byte p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030, p031;
+    byte p032, p033, p034, p035, p036, p037, p038, p039, p040, p041, p042, p043, p044, p045, p046, p047;
+    byte p048, p049, p050, p051, p052, p053, p054, p055, p056, p057, p058, p059, p060, p061, p062, p063;
 }
 
 /**
@@ -43,7 +51,7 @@ abstract class AbstractSnowflakeIdGeneratorValue extends AbstractSnowflakeIdGene
  * <p>
  * <b>Note:</b> ntpd, or alternative clock source, should be setup correctly to ensure the clock does not go backwards.
  */
-public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValue implements IdGenerator
+public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorPaddingRhs implements IdGenerator
 {
     byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
     byte p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030, p031;

--- a/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
+++ b/agrona/src/main/java/org/agrona/concurrent/SnowflakeIdGenerator.java
@@ -63,86 +63,24 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
     /**
      * Total number of bits used to represent the distributed node and the sequence within a millisecond.
      */
-    public static final int NODE_ID_AND_SEQUENCE_BITS = 22;
+    public static final int MAX_NODE_ID_AND_SEQUENCE_BITS = 22;
 
     /**
-     * Name of the system property that can be used to set number of bits used to represent the distributed node or
-     * application. Default value is {@code 10} bits allowing for 1024 nodes (0-1023). Minimal value is {@code 0}
-     * allowing a single node (0).
-     *
-     * <p>
-     * Note: The total number of bits defined by this property and {@link #SEQUENCE_BITS_PROP_NAME} cannot exceed
-     * {@link #NODE_ID_AND_SEQUENCE_BITS}.
-     * </p>
-     *
-     * @see #SEQUENCE_BITS_PROP_NAME
+     * Default number of bits used to represent the distributed node or application which is {@code 10} bits allowing
+     * for 1024 nodes (0-1023).
      */
-    public static final String NODE_ID_BITS_PROP_NAME = "agrona.snowflake.nodeIdBits";
+    public static final int NODE_ID_BITS_DEFAULT = 10;
 
     /**
-     * Number of bits used to represent the distributed node or application.
-     *
-     * @see #NODE_ID_BITS_PROP_NAME
+     * Default number of bits used to represent the sequence within a millisecond which is {@code 12} bits supporting
+     * 4,096,000 ids per second per node.
      */
-    public static final int NODE_ID_BITS;
+    public static final int SEQUENCE_BITS_DEFAULT = 12;
 
-    /**
-     * Name of the system property that can be used to set number of bits used to represent the sequence within a
-     * millisecond. Default value is {@code 12} bits supporting 4,096,000 ids per second per node. Minimal value
-     * is {@code 0} which supports only 1 id per second per node.
-     *
-     * <p>
-     * Note: The total number of bits defined by this property and {@link #NODE_ID_BITS_PROP_NAME} cannot exceed
-     * {@link #NODE_ID_AND_SEQUENCE_BITS}.
-     * </p>
-     *
-     * @see #NODE_ID_BITS_PROP_NAME
-     */
-    public static final String SEQUENCE_BITS_PROP_NAME = "agrona.snowflake.sequenceBits";
-
-    /**
-     * Number of bits used to represent the sequence within a millisecond.
-     *
-     * @see #SEQUENCE_BITS_PROP_NAME
-     */
-    public static final int SEQUENCE_BITS;
-
-    static
-    {
-        final int nodeIdBits = Integer.getInteger(NODE_ID_BITS_PROP_NAME, 10);
-        if (nodeIdBits < 0)
-        {
-            throw new IllegalArgumentException("must be >= 0: " + NODE_ID_BITS_PROP_NAME + "=" + nodeIdBits);
-        }
-
-        final int sequenceBits = Integer.getInteger(SEQUENCE_BITS_PROP_NAME, 12);
-        if (sequenceBits < 0)
-        {
-            throw new IllegalArgumentException("must be >= 0: " + SEQUENCE_BITS_PROP_NAME + "=" + sequenceBits);
-        }
-
-        if ((nodeIdBits + sequenceBits) > NODE_ID_AND_SEQUENCE_BITS)
-        {
-            throw new IllegalArgumentException("too many bits used, must not exceed " + NODE_ID_AND_SEQUENCE_BITS +
-                ": " + NODE_ID_BITS_PROP_NAME + "=" + nodeIdBits + ", " + SEQUENCE_BITS_PROP_NAME + "=" + sequenceBits);
-        }
-
-        NODE_ID_BITS = nodeIdBits;
-        SEQUENCE_BITS = sequenceBits;
-    }
-
-    /**
-     * Maximum number of nodes given {@link #NODE_ID_BITS}.
-     */
-    public static final long MAX_NODE_ID = (long)(Math.pow(2, NODE_ID_BITS) - 1);
-
-    /**
-     * Maximum sequence within a given millisecond given {@link #SEQUENCE_BITS}.
-     */
-    public static final long MAX_SEQUENCE = (long)(Math.pow(2, SEQUENCE_BITS) - 1);
-
-    private static final long SEQUENCE_MASK = MAX_SEQUENCE;
-
+    private final int payloadBits;
+    private final int sequenceBits;
+    private final long maxNodeId;
+    private final long maxSequence;
     private final long nodeBits;
     private final long timestampOffsetMs;
     private final EpochClock clock;
@@ -150,15 +88,40 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
     /**
      * Construct a new Snowflake id generator for a given node with a provided offset and {@link EpochClock}.
      *
+     * @param nodeIdBits        number of bits used to represent the distributed node or application.
+     * @param sequenceBits      number of bits used to represent the sequence within a millisecond.
      * @param nodeId            for the node generating ids.
      * @param timestampOffsetMs to adjust the base offset from 1 Jan 1970 UTC to extend the 69 year range.
      * @param clock             to provide timestamps.
      */
-    public SnowflakeIdGenerator(final long nodeId, final long timestampOffsetMs, final EpochClock clock)
+    public SnowflakeIdGenerator(
+        final int nodeIdBits,
+        final int sequenceBits,
+        final long nodeId,
+        final long timestampOffsetMs,
+        final EpochClock clock)
     {
-        if (nodeId < 0 || nodeId > MAX_NODE_ID)
+        if (nodeIdBits < 0)
         {
-            throw new IllegalArgumentException("must be >= 0 && <= " + MAX_NODE_ID + ": nodeId=" + nodeId);
+            throw new IllegalArgumentException("must be >= 0: nodeIdBits=" + nodeIdBits);
+        }
+
+        if (sequenceBits < 0)
+        {
+            throw new IllegalArgumentException("must be >= 0: sequenceBits=" + sequenceBits);
+        }
+
+        final int payloadBits = (nodeIdBits + sequenceBits);
+        if (payloadBits > MAX_NODE_ID_AND_SEQUENCE_BITS)
+        {
+            throw new IllegalArgumentException("too many bits used for payload, must not exceed " +
+                MAX_NODE_ID_AND_SEQUENCE_BITS + ": nodeIdBits=" + nodeIdBits + ", sequenceBits=" + sequenceBits);
+        }
+
+        final long maxNodeId = (long)(Math.pow(2, nodeIdBits) - 1);
+        if (nodeId < 0 || nodeId > maxNodeId)
+        {
+            throw new IllegalArgumentException("must be >= 0 && <= " + maxNodeId + ": nodeId=" + nodeId);
         }
 
         if (timestampOffsetMs < 0)
@@ -172,30 +135,35 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
             throw new IllegalArgumentException("timestampOffsetMs=" + timestampOffsetMs + " > nowMs=" + nowMs);
         }
 
-        this.nodeBits = nodeId << SEQUENCE_BITS;
+        this.payloadBits = payloadBits;
+        this.maxNodeId = maxNodeId;
+        this.sequenceBits = sequenceBits;
+        maxSequence = (long)(Math.pow(2, sequenceBits) - 1);
+        this.nodeBits = nodeId << sequenceBits;
         this.timestampOffsetMs = timestampOffsetMs;
         this.clock = clock;
     }
 
     /**
      * Construct a new Snowflake id generator for a given node with a 0 offset from 1 Jan 1970 UTC and use
-     * {@link SystemEpochClock#INSTANCE}.
+     * {@link SystemEpochClock#INSTANCE} with {@link #NODE_ID_BITS_DEFAULT} node ID bits and
+     * {@link #SEQUENCE_BITS_DEFAULT} sequence bits.
      *
      * @param nodeId for the node generating ids.
      */
     public SnowflakeIdGenerator(final long nodeId)
     {
-        this(nodeId, 0, SystemEpochClock.INSTANCE);
+        this(NODE_ID_BITS_DEFAULT, SEQUENCE_BITS_DEFAULT, nodeId, 0, SystemEpochClock.INSTANCE);
     }
 
     /**
-     * Node identity which scopes the id generation. This is limited to {@link #MAX_NODE_ID}.
+     * Node identity which scopes the id generation. This is limited to {@link #maxNodeId()}.
      *
      * @return the node identity which scopes the id generation.
      */
     public long nodeId()
     {
-        return nodeBits >>> SEQUENCE_BITS;
+        return nodeBits >>> sequenceBits;
     }
 
     /**
@@ -211,7 +179,27 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
     }
 
     /**
-     * Generate the next id in sequence. If {@link #MAX_SEQUENCE} is reached within the same millisecond then this
+     * The max node identity value given the configured number for the node ID bits.
+     *
+     * @return max node identity value.
+     */
+    public long maxNodeId()
+    {
+        return maxNodeId;
+    }
+
+    /**
+     * The max sequence value given the configured number for the sequence bits.
+     *
+     * @return max sequence value.
+     */
+    public long maxSequence()
+    {
+        return maxSequence;
+    }
+
+    /**
+     * Generate the next id in sequence. If {@link #maxSequence()} is reached within the same millisecond then this
      * implementation will busy spin until the next millisecond using {@link ThreadHints#onSpinWait()}.
      *
      * @return the next unique id for this node.
@@ -222,11 +210,11 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
         {
             final long oldTimestampSequence = timestampSequence;
             final long timestampMs = clock.time() - timestampOffsetMs;
-            final long oldTimestampMs = oldTimestampSequence >>> (NODE_ID_BITS + SEQUENCE_BITS);
+            final long oldTimestampMs = oldTimestampSequence >>> payloadBits;
 
             if (timestampMs > oldTimestampMs)
             {
-                final long newTimestampSequence = timestampMs << (NODE_ID_BITS + SEQUENCE_BITS);
+                final long newTimestampSequence = timestampMs << payloadBits;
                 if (TIMESTAMP_SEQUENCE_UPDATER.compareAndSet(this, oldTimestampSequence, newTimestampSequence))
                 {
                     return newTimestampSequence | nodeBits;
@@ -234,8 +222,8 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
             }
             else if (timestampMs == oldTimestampMs)
             {
-                final long oldSequence = oldTimestampSequence & SEQUENCE_MASK;
-                if (oldSequence < MAX_SEQUENCE)
+                final long oldSequence = oldTimestampSequence & maxSequence;
+                if (oldSequence < maxSequence)
                 {
                     final long newTimestampSequence = oldTimestampSequence + 1;
                     if (TIMESTAMP_SEQUENCE_UPDATER.compareAndSet(this, oldTimestampSequence, newTimestampSequence))
@@ -257,5 +245,20 @@ public final class SnowflakeIdGenerator extends AbstractSnowflakeIdGeneratorValu
 
             ThreadHints.onSpinWait();
         }
+    }
+
+    long extractTimestamp(final long id)
+    {
+        return id >>> payloadBits;
+    }
+
+    long extractNodeId(final long id)
+    {
+        return (id >>> sequenceBits) & maxNodeId;
+    }
+
+    long extractSequence(final long id)
+    {
+        return id & maxSequence;
     }
 }

--- a/agrona/src/test/java/org/agrona/concurrent/SnowflakeIdGeneratorTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/SnowflakeIdGeneratorTest.java
@@ -274,8 +274,8 @@ class SnowflakeIdGeneratorTest
     {
         return Arrays.asList(
             Arguments.arguments(NODE_ID_BITS_DEFAULT, SEQUENCE_BITS_DEFAULT, 16L, 0L, 10, 2, 50_000),
-            Arguments.arguments(0, MAX_NODE_ID_AND_SEQUENCE_BITS, 0, SystemEpochClock.INSTANCE.time(), 10, 3, 150_000),
-            Arguments.arguments(2, 0, 3L, 0L, 3, 2, 100)
+            Arguments.arguments(0, MAX_NODE_ID_AND_SEQUENCE_BITS, 0, SystemEpochClock.INSTANCE.time(), 5, 2, 100_000),
+            Arguments.arguments(2, 0, 3L, 0L, 3, 3, 100)
         );
     }
 


### PR DESCRIPTION
Both `nodeIdBits` and `sequenceBits` can be set to zero but a combination of these values must not exceeds twenty two bits.

I've also moved rhs padding to a separate class:
- Before:
  ```
  ***** Hotspot Layout Simulation (JDK 8, 64-bit model, compressed references, compressed class pointers, 8-byte aligned)
  org.agrona.concurrent.SnowflakeIdGenerator object internals:
  OFF  SZ                               TYPE DESCRIPTION                                           VALUE
    0   8                                    (object header: mark)                                 N/A
    8   4                                    (object header: class)                                N/A
   12   1                               byte AbstractSnowflakeIdGeneratorPadding.p000              N/A
   13   1                               byte AbstractSnowflakeIdGeneratorPadding.p001              N/A
   14   1                               byte AbstractSnowflakeIdGeneratorPadding.p002              N/A
   15   1                               byte AbstractSnowflakeIdGeneratorPadding.p003              N/A
   16   1                               byte AbstractSnowflakeIdGeneratorPadding.p004              N/A
   17   1                               byte AbstractSnowflakeIdGeneratorPadding.p005              N/A
   18   1                               byte AbstractSnowflakeIdGeneratorPadding.p006              N/A
   19   1                               byte AbstractSnowflakeIdGeneratorPadding.p007              N/A
   20   1                               byte AbstractSnowflakeIdGeneratorPadding.p008              N/A
   21   1                               byte AbstractSnowflakeIdGeneratorPadding.p009              N/A
   22   1                               byte AbstractSnowflakeIdGeneratorPadding.p010              N/A
   23   1                               byte AbstractSnowflakeIdGeneratorPadding.p011              N/A
   24   1                               byte AbstractSnowflakeIdGeneratorPadding.p012              N/A
   25   1                               byte AbstractSnowflakeIdGeneratorPadding.p013              N/A
   26   1                               byte AbstractSnowflakeIdGeneratorPadding.p014              N/A
   27   1                               byte AbstractSnowflakeIdGeneratorPadding.p015              N/A
   28   1                               byte AbstractSnowflakeIdGeneratorPadding.p016              N/A
   29   1                               byte AbstractSnowflakeIdGeneratorPadding.p017              N/A
   30   1                               byte AbstractSnowflakeIdGeneratorPadding.p018              N/A
   31   1                               byte AbstractSnowflakeIdGeneratorPadding.p019              N/A
   32   1                               byte AbstractSnowflakeIdGeneratorPadding.p020              N/A
   33   1                               byte AbstractSnowflakeIdGeneratorPadding.p021              N/A
   34   1                               byte AbstractSnowflakeIdGeneratorPadding.p022              N/A
   35   1                               byte AbstractSnowflakeIdGeneratorPadding.p023              N/A
   36   1                               byte AbstractSnowflakeIdGeneratorPadding.p024              N/A
   37   1                               byte AbstractSnowflakeIdGeneratorPadding.p025              N/A
   38   1                               byte AbstractSnowflakeIdGeneratorPadding.p026              N/A
   39   1                               byte AbstractSnowflakeIdGeneratorPadding.p027              N/A
   40   1                               byte AbstractSnowflakeIdGeneratorPadding.p028              N/A
   41   1                               byte AbstractSnowflakeIdGeneratorPadding.p029              N/A
   42   1                               byte AbstractSnowflakeIdGeneratorPadding.p030              N/A
   43   1                               byte AbstractSnowflakeIdGeneratorPadding.p031              N/A
   44   1                               byte AbstractSnowflakeIdGeneratorPadding.p032              N/A
   45   1                               byte AbstractSnowflakeIdGeneratorPadding.p033              N/A
   46   1                               byte AbstractSnowflakeIdGeneratorPadding.p034              N/A
   47   1                               byte AbstractSnowflakeIdGeneratorPadding.p035              N/A
   48   1                               byte AbstractSnowflakeIdGeneratorPadding.p036              N/A
   49   1                               byte AbstractSnowflakeIdGeneratorPadding.p037              N/A
   50   1                               byte AbstractSnowflakeIdGeneratorPadding.p038              N/A
   51   1                               byte AbstractSnowflakeIdGeneratorPadding.p039              N/A
   52   1                               byte AbstractSnowflakeIdGeneratorPadding.p040              N/A
   53   1                               byte AbstractSnowflakeIdGeneratorPadding.p041              N/A
   54   1                               byte AbstractSnowflakeIdGeneratorPadding.p042              N/A
   55   1                               byte AbstractSnowflakeIdGeneratorPadding.p043              N/A
   56   1                               byte AbstractSnowflakeIdGeneratorPadding.p044              N/A
   57   1                               byte AbstractSnowflakeIdGeneratorPadding.p045              N/A
   58   1                               byte AbstractSnowflakeIdGeneratorPadding.p046              N/A
   59   1                               byte AbstractSnowflakeIdGeneratorPadding.p047              N/A
   60   1                               byte AbstractSnowflakeIdGeneratorPadding.p048              N/A
   61   1                               byte AbstractSnowflakeIdGeneratorPadding.p049              N/A
   62   1                               byte AbstractSnowflakeIdGeneratorPadding.p050              N/A
   63   1                               byte AbstractSnowflakeIdGeneratorPadding.p051              N/A
   64   1                               byte AbstractSnowflakeIdGeneratorPadding.p052              N/A
   65   1                               byte AbstractSnowflakeIdGeneratorPadding.p053              N/A
   66   1                               byte AbstractSnowflakeIdGeneratorPadding.p054              N/A
   67   1                               byte AbstractSnowflakeIdGeneratorPadding.p055              N/A
   68   1                               byte AbstractSnowflakeIdGeneratorPadding.p056              N/A
   69   1                               byte AbstractSnowflakeIdGeneratorPadding.p057              N/A
   70   1                               byte AbstractSnowflakeIdGeneratorPadding.p058              N/A
   71   1                               byte AbstractSnowflakeIdGeneratorPadding.p059              N/A
   72   1                               byte AbstractSnowflakeIdGeneratorPadding.p060              N/A
   73   1                               byte AbstractSnowflakeIdGeneratorPadding.p061              N/A
   74   1                               byte AbstractSnowflakeIdGeneratorPadding.p062              N/A
   75   1                               byte AbstractSnowflakeIdGeneratorPadding.p063              N/A
   76   4                                    (alignment/padding gap)                               
   80   8                               long AbstractSnowflakeIdGeneratorValue.timestampSequence   N/A
   88   8                               long SnowflakeIdGenerator.maxNodeId                        N/A
   96   8                               long SnowflakeIdGenerator.maxSequence                      N/A
  104   8                               long SnowflakeIdGenerator.nodeBits                         N/A
  112   8                               long SnowflakeIdGenerator.timestampOffsetMs                N/A
  120   4                                int SnowflakeIdGenerator.payloadBits                      N/A
  124   4                                int SnowflakeIdGenerator.sequenceBits                     N/A
  128   1                               byte SnowflakeIdGenerator.p000                             N/A
  129   1                               byte SnowflakeIdGenerator.p001                             N/A
  130   1                               byte SnowflakeIdGenerator.p002                             N/A
  131   1                               byte SnowflakeIdGenerator.p003                             N/A
  132   1                               byte SnowflakeIdGenerator.p004                             N/A
  133   1                               byte SnowflakeIdGenerator.p005                             N/A
  134   1                               byte SnowflakeIdGenerator.p006                             N/A
  135   1                               byte SnowflakeIdGenerator.p007                             N/A
  136   1                               byte SnowflakeIdGenerator.p008                             N/A
  137   1                               byte SnowflakeIdGenerator.p009                             N/A
  138   1                               byte SnowflakeIdGenerator.p010                             N/A
  139   1                               byte SnowflakeIdGenerator.p011                             N/A
  140   1                               byte SnowflakeIdGenerator.p012                             N/A
  141   1                               byte SnowflakeIdGenerator.p013                             N/A
  142   1                               byte SnowflakeIdGenerator.p014                             N/A
  143   1                               byte SnowflakeIdGenerator.p015                             N/A
  144   1                               byte SnowflakeIdGenerator.p016                             N/A
  145   1                               byte SnowflakeIdGenerator.p017                             N/A
  146   1                               byte SnowflakeIdGenerator.p018                             N/A
  147   1                               byte SnowflakeIdGenerator.p019                             N/A
  148   1                               byte SnowflakeIdGenerator.p020                             N/A
  149   1                               byte SnowflakeIdGenerator.p021                             N/A
  150   1                               byte SnowflakeIdGenerator.p022                             N/A
  151   1                               byte SnowflakeIdGenerator.p023                             N/A
  152   1                               byte SnowflakeIdGenerator.p024                             N/A
  153   1                               byte SnowflakeIdGenerator.p025                             N/A
  154   1                               byte SnowflakeIdGenerator.p026                             N/A
  155   1                               byte SnowflakeIdGenerator.p027                             N/A
  156   1                               byte SnowflakeIdGenerator.p028                             N/A
  157   1                               byte SnowflakeIdGenerator.p029                             N/A
  158   1                               byte SnowflakeIdGenerator.p030                             N/A
  159   1                               byte SnowflakeIdGenerator.p031                             N/A
  160   1                               byte SnowflakeIdGenerator.p032                             N/A
  161   1                               byte SnowflakeIdGenerator.p033                             N/A
  162   1                               byte SnowflakeIdGenerator.p034                             N/A
  163   1                               byte SnowflakeIdGenerator.p035                             N/A
  164   1                               byte SnowflakeIdGenerator.p036                             N/A
  165   1                               byte SnowflakeIdGenerator.p037                             N/A
  166   1                               byte SnowflakeIdGenerator.p038                             N/A
  167   1                               byte SnowflakeIdGenerator.p039                             N/A
  168   1                               byte SnowflakeIdGenerator.p040                             N/A
  169   1                               byte SnowflakeIdGenerator.p041                             N/A
  170   1                               byte SnowflakeIdGenerator.p042                             N/A
  171   1                               byte SnowflakeIdGenerator.p043                             N/A
  172   1                               byte SnowflakeIdGenerator.p044                             N/A
  173   1                               byte SnowflakeIdGenerator.p045                             N/A
  174   1                               byte SnowflakeIdGenerator.p046                             N/A
  175   1                               byte SnowflakeIdGenerator.p047                             N/A
  176   1                               byte SnowflakeIdGenerator.p048                             N/A
  177   1                               byte SnowflakeIdGenerator.p049                             N/A
  178   1                               byte SnowflakeIdGenerator.p050                             N/A
  179   1                               byte SnowflakeIdGenerator.p051                             N/A
  180   1                               byte SnowflakeIdGenerator.p052                             N/A
  181   1                               byte SnowflakeIdGenerator.p053                             N/A
  182   1                               byte SnowflakeIdGenerator.p054                             N/A
  183   1                               byte SnowflakeIdGenerator.p055                             N/A
  184   1                               byte SnowflakeIdGenerator.p056                             N/A
  185   1                               byte SnowflakeIdGenerator.p057                             N/A
  186   1                               byte SnowflakeIdGenerator.p058                             N/A
  187   1                               byte SnowflakeIdGenerator.p059                             N/A
  188   1                               byte SnowflakeIdGenerator.p060                             N/A
  189   1                               byte SnowflakeIdGenerator.p061                             N/A
  190   1                               byte SnowflakeIdGenerator.p062                             N/A
  191   1                               byte SnowflakeIdGenerator.p063                             N/A
  192   4   org.agrona.concurrent.EpochClock SnowflakeIdGenerator.clock                            N/A
  196   4                                    (object alignment gap)                                
  Instance size: 200 bytes
  Space losses: 4 bytes internal + 4 bytes external = 8 bytes total
  ```
- After:
  ```
  ***** Hotspot Layout Simulation (JDK 8, 64-bit model, compressed references, compressed class pointers, 8-byte aligned)
  org.agrona.concurrent.SnowflakeIdGenerator object internals:
  OFF  SZ                               TYPE DESCRIPTION                                           VALUE
    0   8                                    (object header: mark)                                 N/A
    8   4                                    (object header: class)                                N/A
   12   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p000           N/A
   13   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p001           N/A
   14   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p002           N/A
   15   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p003           N/A
   16   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p004           N/A
   17   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p005           N/A
   18   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p006           N/A
   19   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p007           N/A
   20   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p008           N/A
   21   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p009           N/A
   22   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p010           N/A
   23   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p011           N/A
   24   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p012           N/A
   25   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p013           N/A
   26   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p014           N/A
   27   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p015           N/A
   28   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p016           N/A
   29   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p017           N/A
   30   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p018           N/A
   31   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p019           N/A
   32   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p020           N/A
   33   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p021           N/A
   34   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p022           N/A
   35   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p023           N/A
   36   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p024           N/A
   37   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p025           N/A
   38   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p026           N/A
   39   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p027           N/A
   40   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p028           N/A
   41   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p029           N/A
   42   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p030           N/A
   43   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p031           N/A
   44   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p032           N/A
   45   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p033           N/A
   46   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p034           N/A
   47   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p035           N/A
   48   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p036           N/A
   49   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p037           N/A
   50   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p038           N/A
   51   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p039           N/A
   52   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p040           N/A
   53   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p041           N/A
   54   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p042           N/A
   55   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p043           N/A
   56   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p044           N/A
   57   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p045           N/A
   58   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p046           N/A
   59   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p047           N/A
   60   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p048           N/A
   61   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p049           N/A
   62   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p050           N/A
   63   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p051           N/A
   64   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p052           N/A
   65   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p053           N/A
   66   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p054           N/A
   67   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p055           N/A
   68   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p056           N/A
   69   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p057           N/A
   70   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p058           N/A
   71   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p059           N/A
   72   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p060           N/A
   73   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p061           N/A
   74   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p062           N/A
   75   1                               byte AbstractSnowflakeIdGeneratorPaddingLhs.p063           N/A
   76   4                                    (alignment/padding gap)                               
   80   8                               long AbstractSnowflakeIdGeneratorValue.timestampSequence   N/A
   88   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p000           N/A
   89   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p001           N/A
   90   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p002           N/A
   91   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p003           N/A
   92   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p004           N/A
   93   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p005           N/A
   94   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p006           N/A
   95   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p007           N/A
   96   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p008           N/A
   97   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p009           N/A
   98   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p010           N/A
   99   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p011           N/A
  100   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p012           N/A
  101   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p013           N/A
  102   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p014           N/A
  103   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p015           N/A
  104   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p016           N/A
  105   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p017           N/A
  106   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p018           N/A
  107   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p019           N/A
  108   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p020           N/A
  109   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p021           N/A
  110   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p022           N/A
  111   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p023           N/A
  112   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p024           N/A
  113   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p025           N/A
  114   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p026           N/A
  115   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p027           N/A
  116   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p028           N/A
  117   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p029           N/A
  118   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p030           N/A
  119   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p031           N/A
  120   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p032           N/A
  121   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p033           N/A
  122   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p034           N/A
  123   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p035           N/A
  124   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p036           N/A
  125   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p037           N/A
  126   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p038           N/A
  127   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p039           N/A
  128   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p040           N/A
  129   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p041           N/A
  130   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p042           N/A
  131   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p043           N/A
  132   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p044           N/A
  133   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p045           N/A
  134   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p046           N/A
  135   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p047           N/A
  136   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p048           N/A
  137   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p049           N/A
  138   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p050           N/A
  139   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p051           N/A
  140   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p052           N/A
  141   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p053           N/A
  142   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p054           N/A
  143   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p055           N/A
  144   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p056           N/A
  145   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p057           N/A
  146   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p058           N/A
  147   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p059           N/A
  148   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p060           N/A
  149   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p061           N/A
  150   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p062           N/A
  151   1                               byte AbstractSnowflakeIdGeneratorPaddingRhs.p063           N/A
  152   8                               long SnowflakeIdGenerator.maxNodeId                        N/A
  160   8                               long SnowflakeIdGenerator.maxSequence                      N/A
  168   8                               long SnowflakeIdGenerator.nodeBits                         N/A
  176   8                               long SnowflakeIdGenerator.timestampOffsetMs                N/A
  184   4                                int SnowflakeIdGenerator.payloadBits                      N/A
  188   4                                int SnowflakeIdGenerator.sequenceBits                     N/A
  192   4   org.agrona.concurrent.EpochClock SnowflakeIdGenerator.clock                            N/A
  196   4                                    (object alignment gap)                                
  Instance size: 200 bytes
  Space losses: 4 bytes internal + 4 bytes external = 8 bytes total
  ```  