### PR TITLE
[Java] Optimize putIntAscii/putLongAscii methods

### DIFF
--- a/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutIntAsciiBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutIntAsciiBenchmark.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for the {@link UnsafeBuffer#putIntAscii(int, int)} method.
+ */
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@State(Scope.Benchmark)
+public class UnsafeBufferPutIntAsciiBenchmark
+{
+    @Param({ "-2147483648", "0", "-9182", "27085146", "-123456789", "2147483647" })
+    private int value;
+
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+
+    /**
+     * Benchmark {@link UnsafeBuffer#putIntAscii(int, int)} method.s
+     *
+     * @return length in bytes of the written value.
+     */
+    @Benchmark
+    public int benchmark()
+    {
+        return buffer.putIntAscii(0, value);
+    }
+}

--- a/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutLongAsciiBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutLongAsciiBenchmark.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for the {@link UnsafeBuffer#putLongAscii(int, long)} method.
+ */
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@State(Scope.Benchmark)
+public class UnsafeBufferPutLongAsciiBenchmark
+{
+    @Param({ "-9223372036854775808", "0", "-9182", "97385146", "-6180362504315475", "9223372036854775807" })
+    private long value;
+
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+
+    /**
+     * Benchmark {@link UnsafeBuffer#putLongAscii(int, long)} method.s
+     *
+     * @return length in bytes of the written value.
+     */
+    @Benchmark
+    public int benchmark()
+    {
+        return buffer.putLongAscii(0, value);
+    }
+}

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -42,6 +42,23 @@ public final class AsciiEncoding
      */
     public static final byte ZERO = '0';
 
+    /**
+     * Lookup table used for encoding ints/longs as ASCII characters.
+     */
+    public static final byte[] ASCII_DIGITS = new String(new char[]
+    {
+        '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9',
+        '1', '0', '1', '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9',
+        '2', '0', '2', '1', '2', '2', '2', '3', '2', '4', '2', '5', '2', '6', '2', '7', '2', '8', '2', '9',
+        '3', '0', '3', '1', '3', '2', '3', '3', '3', '4', '3', '5', '3', '6', '3', '7', '3', '8', '3', '9',
+        '4', '0', '4', '1', '4', '2', '4', '3', '4', '4', '4', '5', '4', '6', '4', '7', '4', '8', '4', '9',
+        '5', '0', '5', '1', '5', '2', '5', '3', '5', '4', '5', '5', '5', '6', '5', '7', '5', '8', '5', '9',
+        '6', '0', '6', '1', '6', '2', '6', '3', '6', '4', '6', '5', '6', '6', '6', '7', '6', '8', '6', '9',
+        '7', '0', '7', '1', '7', '2', '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9',
+        '8', '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
+        '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
+    }).getBytes(US_ASCII);
+
     private static final byte[] MIN_INT_DIGITS = "2147483648".getBytes(US_ASCII);
     private static final byte[] MAX_INT_DIGITS = "2147483647".getBytes(US_ASCII);
 
@@ -141,9 +158,9 @@ public final class AsciiEncoding
      * @param cs     to parse.
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
-     * @throws AsciiNumberFormatException if <code>cs</code> is not an int value
-     * @throws IndexOutOfBoundsException if parsing results in access outside string boundaries, or length is negative
      * @return the parsed value.
+     * @throws AsciiNumberFormatException if <code>cs</code> is not an int value
+     * @throws IndexOutOfBoundsException  if parsing results in access outside string boundaries, or length is negative
      */
     public static int parseIntAscii(final CharSequence cs, final int index, final int length)
     {
@@ -181,9 +198,9 @@ public final class AsciiEncoding
      * @param cs     to parse.
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
-     * @throws AsciiNumberFormatException if <code>cs</code> is not a long value
-     * @throws IndexOutOfBoundsException if parsing results in access outside string boundaries, or length is negative
      * @return the parsed value.
+     * @throws AsciiNumberFormatException if <code>cs</code> is not a long value
+     * @throws IndexOutOfBoundsException  if parsing results in access outside string boundaries, or length is negative
      */
     public static long parseLongAscii(final CharSequence cs, final int index, final int length)
     {

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -45,7 +45,7 @@ public final class AsciiEncoding
     /**
      * Lookup table used for encoding ints/longs as ASCII characters.
      */
-    public static final byte[] ASCII_DIGITS = new String(new char[]
+    public static final byte[] ASCII_DIGITS = new byte[]
     {
         '0', '0', '0', '1', '0', '2', '0', '3', '0', '4', '0', '5', '0', '6', '0', '7', '0', '8', '0', '9',
         '1', '0', '1', '1', '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9',
@@ -57,7 +57,7 @@ public final class AsciiEncoding
         '7', '0', '7', '1', '7', '2', '7', '3', '7', '4', '7', '5', '7', '6', '7', '7', '7', '8', '7', '9',
         '8', '0', '8', '1', '8', '2', '8', '3', '8', '4', '8', '5', '8', '6', '8', '7', '8', '8', '8', '9',
         '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
-    }).getBytes(US_ASCII);
+    };
 
     private static final byte[] MIN_INT_DIGITS = "2147483648".getBytes(US_ASCII);
     private static final byte[] MAX_INT_DIGITS = "2147483647".getBytes(US_ASCII);

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -1174,12 +1174,25 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
         ensureCapacity(index, length);
 
-        while (i >= 0)
+        final byte[] dest = byteArray;
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteArray[i + start] = (byte)(ZERO + remainder);
-            i--;
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            dest[i + start] = ASCII_DIGITS[position + 1];
+            dest[i - 1 + start] = ASCII_DIGITS[position];
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest[i + start] = (byte)(ZERO + quotient);
+        }
+        else
+        {
+            final int position = quotient << 1;
+            dest[i + start] = ASCII_DIGITS[position + 1];
+            dest[i - 1 + start] = ASCII_DIGITS[position];
         }
 
         return length;
@@ -1202,13 +1215,25 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         ensureCapacity(index, length);
 
         int quotient = value;
-        while (i >= 0)
+        final byte[] dest = byteArray;
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteArray[i + index] = (byte)(ZERO + remainder);
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            dest[i + index] = ASCII_DIGITS[position + 1];
+            dest[i - 1 + index] = ASCII_DIGITS[position];
+            i -= 2;
+        }
 
-            i--;
+        if (quotient < 10)
+        {
+            dest[i + index] = (byte)(ZERO + quotient);
+        }
+        else
+        {
+            final int position = quotient << 1;
+            dest[i + index] = ASCII_DIGITS[position + 1];
+            dest[i - 1 + index] = ASCII_DIGITS[position];
         }
 
         return length;
@@ -1269,13 +1294,50 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         ensureCapacity(index, length);
 
         long quotient = value;
-        while (i >= 0)
+        final byte[] dest = byteArray;
+        while (quotient >= 100000000)
         {
-            final long remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteArray[i + index] = (byte)(ZERO + remainder);
+            final int lastEightDigits = (int)(quotient % 100000000);
+            quotient /= 100000000;
 
-            i--;
+            final int upperPart = lastEightDigits / 10000;
+            final int lowerPart = lastEightDigits % 10000;
+
+            final int u1 = (upperPart / 100) << 1;
+            final int u2 = (upperPart % 100) << 1;
+            final int l1 = (lowerPart / 100) << 1;
+            final int l2 = (lowerPart % 100) << 1;
+
+            i -= 8;
+
+            dest[index + i + 1] = ASCII_DIGITS[u1];
+            dest[index + i + 2] = ASCII_DIGITS[u1 + 1];
+            dest[index + i + 3] = ASCII_DIGITS[u2];
+            dest[index + i + 4] = ASCII_DIGITS[u2 + 1];
+            dest[index + i + 5] = ASCII_DIGITS[l1];
+            dest[index + i + 6] = ASCII_DIGITS[l1 + 1];
+            dest[index + i + 7] = ASCII_DIGITS[l2];
+            dest[index + i + 8] = ASCII_DIGITS[l2 + 1];
+        }
+
+        while (quotient >= 100)
+        {
+            final int position = (int)((quotient % 100) << 1);
+            quotient /= 100;
+            dest[index + i] = ASCII_DIGITS[position + 1];
+            dest[index + i - 1] = ASCII_DIGITS[position];
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest[index + i] = (byte)(ZERO + quotient);
+        }
+        else
+        {
+            final int position = (int)(quotient << 1);
+            dest[index + i] = ASCII_DIGITS[position + 1];
+            dest[index + i - 1] = ASCII_DIGITS[position];
         }
 
         return length;
@@ -1314,12 +1376,50 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
         ensureCapacity(index, length);
 
-        while (i >= 0)
+        final byte[] dest = byteArray;
+        while (quotient >= 100000000)
         {
-            final long remainder = quotient % 10L;
-            quotient = quotient / 10L;
-            byteArray[i + start] = (byte)(ZERO + remainder);
-            i--;
+            final int lastEightDigits = (int)(quotient % 100000000);
+            quotient /= 100000000;
+
+            final int upperPart = lastEightDigits / 10000;
+            final int lowerPart = lastEightDigits % 10000;
+
+            final int u1 = (upperPart / 100) << 1;
+            final int u2 = (upperPart % 100) << 1;
+            final int l1 = (lowerPart / 100) << 1;
+            final int l2 = (lowerPart % 100) << 1;
+
+            i -= 8;
+
+            dest[start + i + 1] = ASCII_DIGITS[u1];
+            dest[start + i + 2] = ASCII_DIGITS[u1 + 1];
+            dest[start + i + 3] = ASCII_DIGITS[u2];
+            dest[start + i + 4] = ASCII_DIGITS[u2 + 1];
+            dest[start + i + 5] = ASCII_DIGITS[l1];
+            dest[start + i + 6] = ASCII_DIGITS[l1 + 1];
+            dest[start + i + 7] = ASCII_DIGITS[l2];
+            dest[start + i + 8] = ASCII_DIGITS[l2 + 1];
+        }
+
+        while (quotient >= 100)
+        {
+            final int position = (int)((quotient % 100) << 1);
+            quotient /= 100;
+            dest[start + i] = ASCII_DIGITS[position + 1];
+            dest[start + i - 1] = ASCII_DIGITS[position];
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest[start + i] = (byte)(ZERO + quotient);
+        }
+        else
+        {
+            final int position = (int)(quotient << 1);
+            dest[start + i] = ASCII_DIGITS[position + 1];
+            dest[start + i - 1] = ASCII_DIGITS[position];
         }
 
         return length;

--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -1225,12 +1225,25 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
 
         ensureCapacity(index, length);
 
-        while (i >= 0)
+        final ByteBuffer dest = byteBuffer;
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteBuffer.put(i + start, (byte)(ZERO + remainder));
-            i--;
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            dest.put(i + start, ASCII_DIGITS[position + 1]);
+            dest.put(i - 1 + start, ASCII_DIGITS[position]);
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest.put(i + start, (byte)(ZERO + quotient));
+        }
+        else
+        {
+            final int position = quotient << 1;
+            dest.put(i + start, ASCII_DIGITS[position + 1]);
+            dest.put(i - 1 + start, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1253,13 +1266,25 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         ensureCapacity(index, length);
 
         int quotient = value;
-        while (i >= 0)
+        final ByteBuffer dest = byteBuffer;
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteBuffer.put(i + index, (byte)(ZERO + remainder));
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            dest.put(i + index, ASCII_DIGITS[position + 1]);
+            dest.put(i - 1 + index, ASCII_DIGITS[position]);
+            i -= 2;
+        }
 
-            i--;
+        if (quotient < 10)
+        {
+            dest.put(i + index, (byte)(ZERO + quotient));
+        }
+        else
+        {
+            final int position = quotient << 1;
+            dest.put(i + index, ASCII_DIGITS[position + 1]);
+            dest.put(i - 1 + index, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1320,13 +1345,50 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         ensureCapacity(index, length);
 
         long quotient = value;
-        while (i >= 0)
+        final ByteBuffer dest = byteBuffer;
+        while (quotient >= 100000000)
         {
-            final long remainder = quotient % 10;
-            quotient = quotient / 10;
-            byteBuffer.put(i + index, (byte)(ZERO + remainder));
+            final int lastEightDigits = (int)(quotient % 100000000);
+            quotient /= 100000000;
 
-            i--;
+            final int upperPart = lastEightDigits / 10000;
+            final int lowerPart = lastEightDigits % 10000;
+
+            final int u1 = (upperPart / 100) << 1;
+            final int u2 = (upperPart % 100) << 1;
+            final int l1 = (lowerPart / 100) << 1;
+            final int l2 = (lowerPart % 100) << 1;
+
+            i -= 8;
+
+            dest.put(index + i + 1, ASCII_DIGITS[u1]);
+            dest.put(index + i + 2, ASCII_DIGITS[u1 + 1]);
+            dest.put(index + i + 3, ASCII_DIGITS[u2]);
+            dest.put(index + i + 4, ASCII_DIGITS[u2 + 1]);
+            dest.put(index + i + 5, ASCII_DIGITS[l1]);
+            dest.put(index + i + 6, ASCII_DIGITS[l1 + 1]);
+            dest.put(index + i + 7, ASCII_DIGITS[l2]);
+            dest.put(index + i + 8, ASCII_DIGITS[l2 + 1]);
+        }
+
+        while (quotient >= 100)
+        {
+            final int position = (int)((quotient % 100) << 1);
+            quotient /= 100;
+            dest.put(index + i, ASCII_DIGITS[position + 1]);
+            dest.put(index + i - 1, ASCII_DIGITS[position]);
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest.put(index + i, (byte)(ZERO + quotient));
+        }
+        else
+        {
+            final int position = (int)(quotient << 1);
+            dest.put(index + i, ASCII_DIGITS[position + 1]);
+            dest.put(index + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1365,12 +1427,50 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
 
         ensureCapacity(index, length);
 
-        while (i >= 0)
+        final ByteBuffer dest = byteBuffer;
+        while (quotient >= 100000000)
         {
-            final long remainder = quotient % 10L;
-            quotient = quotient / 10L;
-            byteBuffer.put(i + start, (byte)(ZERO + remainder));
-            i--;
+            final int lastEightDigits = (int)(quotient % 100000000);
+            quotient /= 100000000;
+
+            final int upperPart = lastEightDigits / 10000;
+            final int lowerPart = lastEightDigits % 10000;
+
+            final int u1 = (upperPart / 100) << 1;
+            final int u2 = (upperPart % 100) << 1;
+            final int l1 = (lowerPart / 100) << 1;
+            final int l2 = (lowerPart % 100) << 1;
+
+            i -= 8;
+
+            dest.put(start + i + 1, ASCII_DIGITS[u1]);
+            dest.put(start + i + 2, ASCII_DIGITS[u1 + 1]);
+            dest.put(start + i + 3, ASCII_DIGITS[u2]);
+            dest.put(start + i + 4, ASCII_DIGITS[u2 + 1]);
+            dest.put(start + i + 5, ASCII_DIGITS[l1]);
+            dest.put(start + i + 6, ASCII_DIGITS[l1 + 1]);
+            dest.put(start + i + 7, ASCII_DIGITS[l2]);
+            dest.put(start + i + 8, ASCII_DIGITS[l2 + 1]);
+        }
+
+        while (quotient >= 100)
+        {
+            final int position = (int)((quotient % 100) << 1);
+            quotient /= 100;
+            dest.put(start + i, ASCII_DIGITS[position + 1]);
+            dest.put(start + i - 1, ASCII_DIGITS[position]);
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            dest.put(start + i, (byte)(ZERO + quotient));
+        }
+        else
+        {
+            final int position = (int)(quotient << 1);
+            dest.put(start + i, ASCII_DIGITS[position + 1]);
+            dest.put(start + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1842,12 +1842,24 @@ public class UnsafeBuffer implements AtomicBuffer
             boundsCheck0(index, length);
         }
 
-        while (i >= 0)
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + remainder));
-            i--;
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + (byte)quotient));
+        }
+        else
+        {
+            final int position = quotient << 1;
+            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
         }
 
         return length;

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1885,12 +1885,24 @@ public class UnsafeBuffer implements AtomicBuffer
         }
 
         int quotient = value;
-        while (i >= 0)
+        while (quotient >= 100)
         {
-            final int remainder = quotient % 10;
-            quotient = quotient / 10;
-            UNSAFE.putByte(byteArray, addressOffset + i + index, (byte)(ZERO + remainder));
-            i--;
+            final int position = (quotient % 100) << 1;
+            quotient /= 100;
+            UNSAFE.putByte(byteArray, addressOffset + i + index, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i - 1 + index, ASCII_DIGITS[position]);
+            i -= 2;
+        }
+
+        if (quotient < 10)
+        {
+            UNSAFE.putByte(byteArray, addressOffset + i + index, (byte)(ZERO + quotient));
+        }
+        else
+        {
+            final int position = quotient << 1;
+            UNSAFE.putByte(byteArray, addressOffset + i + index, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i - 1 + index, ASCII_DIGITS[position]);
         }
 
         return length;

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -2015,46 +2015,45 @@ public class UnsafeBuffer implements AtomicBuffer
 
         while (quotient >= 100000000)
         {
-            final int a = (int)(quotient % 100000000);
+            final int lastEightDigits = (int)(quotient % 100000000);
             quotient /= 100000000;
 
-            final int b = a / 10000;
-            final int c = a % 10000;
+            final int upperPart = lastEightDigits / 10000;
+            final int lowerPart = lastEightDigits % 10000;
 
-            final int b1 = (b / 100) << 1;
-            final int b2 = (b % 100) << 1;
-            final int c1 = (c / 100) << 1;
-            final int c2 = (c % 100) << 1;
-
-            UNSAFE.putByte(byteArray, addressOffset + i - 7 + start, ASCII_DIGITS[b1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 6 + start, ASCII_DIGITS[b1 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 5 + start, ASCII_DIGITS[b2]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 4 + start, ASCII_DIGITS[b2 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 3 + start, ASCII_DIGITS[c1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 2 + start, ASCII_DIGITS[c1 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[c2]);
-            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[c2 + 1]);
+            final int u1 = (upperPart / 100) << 1;
+            final int u2 = (upperPart % 100) << 1;
+            final int l1 = (lowerPart / 100) << 1;
+            final int l2 = (lowerPart % 100) << 1;
 
             i -= 8;
+
+            UNSAFE.putByte(byteArray, addressOffset + i + 1 + start, ASCII_DIGITS[u1]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 2 + start, ASCII_DIGITS[u1 + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 3 + start, ASCII_DIGITS[u2]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 4 + start, ASCII_DIGITS[u2 + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 5 + start, ASCII_DIGITS[l1]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 6 + start, ASCII_DIGITS[l1 + 1]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 7 + start, ASCII_DIGITS[l2]);
+            UNSAFE.putByte(byteArray, addressOffset + i + 8 + start, ASCII_DIGITS[l2 + 1]);
         }
 
-        int quotient32 = (int)quotient;
-        while (quotient32 >= 100)
+        while (quotient >= 100)
         {
-            final int position = (quotient32 % 100) << 1;
-            quotient32 /= 100;
+            final int position = (int)((quotient % 100) << 1);
+            quotient /= 100;
             UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
             UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
             i -= 2;
         }
 
-        if (quotient32 < 10)
+        if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + quotient32));
+            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + quotient));
         }
         else
         {
-            final int position = quotient32 << 1;
+            final int position = (int)(quotient << 1);
             UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
             UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
         }

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1842,24 +1842,25 @@ public class UnsafeBuffer implements AtomicBuffer
             boundsCheck0(index, length);
         }
 
+        final long offset = addressOffset + start;
         while (quotient >= 100)
         {
             final int position = (quotient % 100) << 1;
             quotient /= 100;
-            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + quotient));
+            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = quotient << 1;
-            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1885,24 +1886,25 @@ public class UnsafeBuffer implements AtomicBuffer
         }
 
         int quotient = value;
+        final long offset = addressOffset + index;
         while (quotient >= 100)
         {
             final int position = (quotient % 100) << 1;
             quotient /= 100;
-            UNSAFE.putByte(byteArray, addressOffset + i + index, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + index, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, addressOffset + i + index, (byte)(ZERO + quotient));
+            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = quotient << 1;
-            UNSAFE.putByte(byteArray, addressOffset + i + index, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + index, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -2013,6 +2015,7 @@ public class UnsafeBuffer implements AtomicBuffer
             boundsCheck0(index, length);
         }
 
+        final long offset = addressOffset + start;
         while (quotient >= 100000000)
         {
             final int lastEightDigits = (int)(quotient % 100000000);
@@ -2028,34 +2031,34 @@ public class UnsafeBuffer implements AtomicBuffer
 
             i -= 8;
 
-            UNSAFE.putByte(byteArray, addressOffset + i + 1 + start, ASCII_DIGITS[u1]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 2 + start, ASCII_DIGITS[u1 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 3 + start, ASCII_DIGITS[u2]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 4 + start, ASCII_DIGITS[u2 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 5 + start, ASCII_DIGITS[l1]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 6 + start, ASCII_DIGITS[l1 + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 7 + start, ASCII_DIGITS[l2]);
-            UNSAFE.putByte(byteArray, addressOffset + i + 8 + start, ASCII_DIGITS[l2 + 1]);
+            UNSAFE.putByte(byteArray, offset + i + 1, ASCII_DIGITS[u1]);
+            UNSAFE.putByte(byteArray, offset + i + 2, ASCII_DIGITS[u1 + 1]);
+            UNSAFE.putByte(byteArray, offset + i + 3, ASCII_DIGITS[u2]);
+            UNSAFE.putByte(byteArray, offset + i + 4, ASCII_DIGITS[u2 + 1]);
+            UNSAFE.putByte(byteArray, offset + i + 5, ASCII_DIGITS[l1]);
+            UNSAFE.putByte(byteArray, offset + i + 6, ASCII_DIGITS[l1 + 1]);
+            UNSAFE.putByte(byteArray, offset + i + 7, ASCII_DIGITS[l2]);
+            UNSAFE.putByte(byteArray, offset + i + 8, ASCII_DIGITS[l2 + 1]);
         }
 
         while (quotient >= 100)
         {
             final int position = (int)((quotient % 100) << 1);
             quotient /= 100;
-            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, addressOffset + i + start, (byte)(ZERO + quotient));
+            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = (int)(quotient << 1);
-            UNSAFE.putByte(byteArray, addressOffset + i + start, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, addressOffset + i - 1 + start, ASCII_DIGITS[position]);
+            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1843,24 +1843,25 @@ public class UnsafeBuffer implements AtomicBuffer
         }
 
         final long offset = addressOffset + start;
+        final byte[] dest = byteArray;
         while (quotient >= 100)
         {
             final int position = (quotient % 100) << 1;
             quotient /= 100;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
+            UNSAFE.putByte(dest, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = quotient << 1;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1887,24 +1888,25 @@ public class UnsafeBuffer implements AtomicBuffer
 
         int quotient = value;
         final long offset = addressOffset + index;
+        final byte[] dest = byteArray;
         while (quotient >= 100)
         {
             final int position = (quotient % 100) << 1;
             quotient /= 100;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
+            UNSAFE.putByte(dest, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = quotient << 1;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -1969,6 +1971,7 @@ public class UnsafeBuffer implements AtomicBuffer
 
         long quotient = value;
         final long offset = addressOffset + index;
+        final byte[] dest = byteArray;
         while (quotient >= 100000000)
         {
             final int lastEightDigits = (int)(quotient % 100000000);
@@ -1984,34 +1987,34 @@ public class UnsafeBuffer implements AtomicBuffer
 
             i -= 8;
 
-            UNSAFE.putByte(byteArray, offset + i + 1, ASCII_DIGITS[u1]);
-            UNSAFE.putByte(byteArray, offset + i + 2, ASCII_DIGITS[u1 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 3, ASCII_DIGITS[u2]);
-            UNSAFE.putByte(byteArray, offset + i + 4, ASCII_DIGITS[u2 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 5, ASCII_DIGITS[l1]);
-            UNSAFE.putByte(byteArray, offset + i + 6, ASCII_DIGITS[l1 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 7, ASCII_DIGITS[l2]);
-            UNSAFE.putByte(byteArray, offset + i + 8, ASCII_DIGITS[l2 + 1]);
+            UNSAFE.putByte(dest, offset + i + 1, ASCII_DIGITS[u1]);
+            UNSAFE.putByte(dest, offset + i + 2, ASCII_DIGITS[u1 + 1]);
+            UNSAFE.putByte(dest, offset + i + 3, ASCII_DIGITS[u2]);
+            UNSAFE.putByte(dest, offset + i + 4, ASCII_DIGITS[u2 + 1]);
+            UNSAFE.putByte(dest, offset + i + 5, ASCII_DIGITS[l1]);
+            UNSAFE.putByte(dest, offset + i + 6, ASCII_DIGITS[l1 + 1]);
+            UNSAFE.putByte(dest, offset + i + 7, ASCII_DIGITS[l2]);
+            UNSAFE.putByte(dest, offset + i + 8, ASCII_DIGITS[l2 + 1]);
         }
 
         while (quotient >= 100)
         {
             final int position = (int)((quotient % 100) << 1);
             quotient /= 100;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
+            UNSAFE.putByte(dest, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = (int)(quotient << 1);
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;
@@ -2054,6 +2057,7 @@ public class UnsafeBuffer implements AtomicBuffer
         }
 
         final long offset = addressOffset + start;
+        final byte[] dest = byteArray;
         while (quotient >= 100000000)
         {
             final int lastEightDigits = (int)(quotient % 100000000);
@@ -2069,34 +2073,34 @@ public class UnsafeBuffer implements AtomicBuffer
 
             i -= 8;
 
-            UNSAFE.putByte(byteArray, offset + i + 1, ASCII_DIGITS[u1]);
-            UNSAFE.putByte(byteArray, offset + i + 2, ASCII_DIGITS[u1 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 3, ASCII_DIGITS[u2]);
-            UNSAFE.putByte(byteArray, offset + i + 4, ASCII_DIGITS[u2 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 5, ASCII_DIGITS[l1]);
-            UNSAFE.putByte(byteArray, offset + i + 6, ASCII_DIGITS[l1 + 1]);
-            UNSAFE.putByte(byteArray, offset + i + 7, ASCII_DIGITS[l2]);
-            UNSAFE.putByte(byteArray, offset + i + 8, ASCII_DIGITS[l2 + 1]);
+            UNSAFE.putByte(dest, offset + i + 1, ASCII_DIGITS[u1]);
+            UNSAFE.putByte(dest, offset + i + 2, ASCII_DIGITS[u1 + 1]);
+            UNSAFE.putByte(dest, offset + i + 3, ASCII_DIGITS[u2]);
+            UNSAFE.putByte(dest, offset + i + 4, ASCII_DIGITS[u2 + 1]);
+            UNSAFE.putByte(dest, offset + i + 5, ASCII_DIGITS[l1]);
+            UNSAFE.putByte(dest, offset + i + 6, ASCII_DIGITS[l1 + 1]);
+            UNSAFE.putByte(dest, offset + i + 7, ASCII_DIGITS[l2]);
+            UNSAFE.putByte(dest, offset + i + 8, ASCII_DIGITS[l2 + 1]);
         }
 
         while (quotient >= 100)
         {
             final int position = (int)((quotient % 100) << 1);
             quotient /= 100;
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
             i -= 2;
         }
 
         if (quotient < 10)
         {
-            UNSAFE.putByte(byteArray, offset + i, (byte)(ZERO + quotient));
+            UNSAFE.putByte(dest, offset + i, (byte)(ZERO + quotient));
         }
         else
         {
             final int position = (int)(quotient << 1);
-            UNSAFE.putByte(byteArray, offset + i, ASCII_DIGITS[position + 1]);
-            UNSAFE.putByte(byteArray, offset + i - 1, ASCII_DIGITS[position]);
+            UNSAFE.putByte(dest, offset + i, ASCII_DIGITS[position + 1]);
+            UNSAFE.putByte(dest, offset + i - 1, ASCII_DIGITS[position]);
         }
 
         return length;

--- a/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExpandableArrayBufferTest
+{
+    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
+
+    @Test
+    void putIntAsciiRoundTrip()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final int value = random.nextInt();
+            final int length = buffer.putIntAscii(0, value);
+            final int parsedValue = buffer.parseIntAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
+    }
+
+    @Test
+    void putLongAsciiRoundTrip()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final long value = random.nextLong();
+            final int length = buffer.putLongAscii(0, value);
+            final long parsedValue = buffer.parseLongAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
+    }
+
+    @Test
+    void putNaturalIntAsciiRoundTrip()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalIntAscii(0, value);
+                final int parsedValue = buffer.parseNaturalIntAscii(0, length);
+                assertEquals(value, parsedValue);
+            });
+    }
+
+    @Test
+    void putNaturalLongAsciiRoundTrip()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalLongAscii(0, value);
+                final long parsedValue = buffer.parseNaturalLongAscii(0, length);
+                assertEquals(value, parsedValue);
+            }
+        );
+    }
+
+}

--- a/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ExpandableArrayBufferTest
 {
-    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
+    private static final int ROUND_TRIP_ITERATIONS = 10_000_000;
 
     @Test
     void putIntAsciiRoundTrip()

--- a/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
@@ -17,7 +17,6 @@ package org.agrona;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,11 +29,9 @@ class ExpandableArrayBufferTest
     void putIntAsciiRoundTrip()
     {
         final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final int value = random.nextInt();
+            final int value = ThreadLocalRandom.current().nextInt();
             final int length = buffer.putIntAscii(0, value);
             final int parsedValue = buffer.parseIntAscii(0, length);
             assertEquals(value, parsedValue);
@@ -45,11 +42,9 @@ class ExpandableArrayBufferTest
     void putLongAsciiRoundTrip()
     {
         final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final long value = random.nextLong();
+            final long value = ThreadLocalRandom.current().nextLong();
             final int length = buffer.putLongAscii(0, value);
             final long parsedValue = buffer.parseLongAscii(0, length);
             assertEquals(value, parsedValue);
@@ -60,9 +55,7 @@ class ExpandableArrayBufferTest
     void putNaturalIntAsciiRoundTrip()
     {
         final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalIntAscii(0, value);
@@ -75,9 +68,7 @@ class ExpandableArrayBufferTest
     void putNaturalLongAsciiRoundTrip()
     {
         final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalLongAscii(0, value);

--- a/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ExpandableDirectByteBufferTest
 {
-    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
+    private static final int ROUND_TRIP_ITERATIONS = 10_000_000;
 
     @Test
     void putIntAsciiRoundTrip()

--- a/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
@@ -17,7 +17,6 @@ package org.agrona;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,11 +29,9 @@ class ExpandableDirectByteBufferTest
     void putIntAsciiRoundTrip()
     {
         final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final int value = random.nextInt();
+            final int value = ThreadLocalRandom.current().nextInt();
             final int length = buffer.putIntAscii(0, value);
             final int parsedValue = buffer.parseIntAscii(0, length);
             assertEquals(value, parsedValue);
@@ -45,11 +42,9 @@ class ExpandableDirectByteBufferTest
     void putLongAsciiRoundTrip()
     {
         final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final long value = random.nextLong();
+            final long value = ThreadLocalRandom.current().nextLong();
             final int length = buffer.putLongAscii(0, value);
             final long parsedValue = buffer.parseLongAscii(0, length);
             assertEquals(value, parsedValue);
@@ -60,9 +55,7 @@ class ExpandableDirectByteBufferTest
     void putNaturalIntAsciiRoundTrip()
     {
         final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalIntAscii(0, value);
@@ -75,9 +68,7 @@ class ExpandableDirectByteBufferTest
     void putNaturalLongAsciiRoundTrip()
     {
         final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalLongAscii(0, value);

--- a/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableDirectByteBufferTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExpandableDirectByteBufferTest
+{
+    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
+
+    @Test
+    void putIntAsciiRoundTrip()
+    {
+        final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final int value = random.nextInt();
+            final int length = buffer.putIntAscii(0, value);
+            final int parsedValue = buffer.parseIntAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
+    }
+
+    @Test
+    void putLongAsciiRoundTrip()
+    {
+        final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final long value = random.nextLong();
+            final int length = buffer.putLongAscii(0, value);
+            final long parsedValue = buffer.parseLongAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
+    }
+
+    @Test
+    void putNaturalIntAsciiRoundTrip()
+    {
+        final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalIntAscii(0, value);
+                final int parsedValue = buffer.parseNaturalIntAscii(0, length);
+                assertEquals(value, parsedValue);
+            });
+    }
+
+    @Test
+    void putNaturalLongAsciiRoundTrip()
+    {
+        final ExpandableDirectByteBuffer buffer = new ExpandableDirectByteBuffer(64);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalLongAscii(0, value);
+                final long parsedValue = buffer.parseNaturalLongAscii(0, length);
+                assertEquals(value, parsedValue);
+            }
+        );
+    }
+
+}

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeBufferTest
 {
-    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
+    private static final int ROUND_TRIP_ITERATIONS = 10_000_000;
     private static final byte VALUE = 42;
     private static final int INDEX = 1;
     private static final int ADJUSTMENT_OFFSET = 3;

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -276,11 +275,9 @@ public class UnsafeBufferTest
     void putIntAsciiRoundTrip()
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final int value = random.nextInt();
+            final int value = ThreadLocalRandom.current().nextInt();
             final int length = buffer.putIntAscii(0, value);
             final int parsedValue = buffer.parseIntAscii(0, length);
             assertEquals(value, parsedValue);
@@ -291,11 +288,9 @@ public class UnsafeBufferTest
     void putLongAsciiRoundTrip()
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
         for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
         {
-            final long value = random.nextLong();
+            final long value = ThreadLocalRandom.current().nextLong();
             final int length = buffer.putLongAscii(0, value);
             final long parsedValue = buffer.parseLongAscii(0, length);
             assertEquals(value, parsedValue);
@@ -306,9 +301,7 @@ public class UnsafeBufferTest
     void putNaturalIntAsciiRoundTrip()
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalIntAscii(0, value);
@@ -321,9 +314,7 @@ public class UnsafeBufferTest
     void putNaturalLongAsciiRoundTrip()
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
-        final long seed = ThreadLocalRandom.current().nextLong();
-        final Random random = new Random(seed);
-        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+        ThreadLocalRandom.current().longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
             value ->
             {
                 final int length = buffer.putNaturalLongAscii(0, value);

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -333,13 +333,6 @@ public class UnsafeBufferTest
         );
     }
 
-    @Test
-    void foo()
-    {
-        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
-        buffer.putLongAscii(0, 123456789);
-    }
-
     private void assertContainsString(final UnsafeBuffer buffer, final String value, final int length)
     {
         assertEquals(value, buffer.getStringWithoutLengthAscii(INDEX, length));

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeBufferTest
 {
-    private static final int ROUND_TRIP_ITERATIONS = 10_000_000;
+    private static final int ROUND_TRIP_ITERATIONS = 25_000_000;
     private static final byte VALUE = 42;
     private static final int INDEX = 1;
     private static final int ADJUSTMENT_OFFSET = 3;
@@ -331,6 +331,13 @@ public class UnsafeBufferTest
                 assertEquals(value, parsedValue);
             }
         );
+    }
+
+    @Test
+    void foo()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+        buffer.putLongAscii(0, 123456789);
     }
 
     private void assertContainsString(final UnsafeBuffer buffer, final String value, final int length)

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeBufferTest
 {
+    private static final int ROUND_TRIP_ITERATIONS = 100_000_000;
     private static final byte VALUE = 42;
     private static final int INDEX = 1;
     private static final int ADJUSTMENT_OFFSET = 3;
@@ -267,6 +270,36 @@ public class UnsafeBufferTest
         assertThrows(IllegalArgumentException.class, () -> slice.wrap(buffer, 0, -1));
         assertThrows(IllegalArgumentException.class, () -> slice.wrap(buffer, 8, 1));
         assertThrows(IllegalArgumentException.class, () -> slice.wrap(buffer, 7, 3));
+    }
+
+    @Test
+    void putIntAsciiRoundTrip()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final int value = random.nextInt();
+            final int length = buffer.putIntAscii(0, value);
+            final int parsedValue = buffer.parseIntAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
+    }
+
+    @Test
+    void putLongAsciiRoundTrip()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        for (int i = 0; i < ROUND_TRIP_ITERATIONS; i++)
+        {
+            final long value = random.nextLong();
+            final int length = buffer.putLongAscii(0, value);
+            final long parsedValue = buffer.parseLongAscii(0, length);
+            assertEquals(value, parsedValue);
+        }
     }
 
     private void assertContainsString(final UnsafeBuffer buffer, final String value, final int length)

--- a/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/UnsafeBufferTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeBufferTest
 {
-    private static final int ROUND_TRIP_ITERATIONS = 100_000_000;
+    private static final int ROUND_TRIP_ITERATIONS = 10_000_000;
     private static final byte VALUE = 42;
     private static final int INDEX = 1;
     private static final int ADJUSTMENT_OFFSET = 3;
@@ -300,6 +300,37 @@ public class UnsafeBufferTest
             final long parsedValue = buffer.parseLongAscii(0, length);
             assertEquals(value, parsedValue);
         }
+    }
+
+    @Test
+    void putNaturalIntAsciiRoundTrip()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.ints(ROUND_TRIP_ITERATIONS, 0, Integer.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalIntAscii(0, value);
+                final int parsedValue = buffer.parseNaturalIntAscii(0, length);
+                assertEquals(value, parsedValue);
+            });
+    }
+
+    @Test
+    void putNaturalLongAsciiRoundTrip()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[64]);
+        final long seed = ThreadLocalRandom.current().nextLong();
+        final Random random = new Random(seed);
+        random.longs(ROUND_TRIP_ITERATIONS, 0, Long.MAX_VALUE).forEach(
+            value ->
+            {
+                final int length = buffer.putNaturalLongAscii(0, value);
+                final long parsedValue = buffer.parseNaturalLongAscii(0, length);
+                assertEquals(value, parsedValue);
+            }
+        );
     }
 
     private void assertContainsString(final UnsafeBuffer buffer, final String value, final int length)


### PR DESCRIPTION
This PR uses lookup table approach to optimize `putIntAscii`, `putNaturalIntAscii`, `putLongAscii` and `putNaturalLongAscii` methods by dividing by `100` and looking up two digits at a time. I'm see up to **23%** performance improvement.

This work was inspired by https://github.com/miloyip/itoa-benchmark and https://www.slideshare.net/andreialexandrescu1/three-optimization-tips-for-c?next_slideshow=1.

Here is the results I got:
- Before:
```
Benchmark                                       (value)  Mode  Cnt   Score   Error  Units
UnsafeBufferPutIntAsciiBenchmark            -2147483648  avgt   30   6.543 ± 0.018  ns/op
UnsafeBufferPutIntAsciiBenchmark                      0  avgt   30   3.268 ± 0.015  ns/op
UnsafeBufferPutIntAsciiBenchmark                  -9182  avgt   30   7.612 ± 0.040  ns/op
UnsafeBufferPutIntAsciiBenchmark               27085146  avgt   30  11.929 ± 0.010  ns/op
UnsafeBufferPutIntAsciiBenchmark             -123456789  avgt   30  13.511 ± 0.043  ns/op
UnsafeBufferPutIntAsciiBenchmark             2147483647  avgt   30  14.069 ± 0.028  ns/op
UnsafeBufferPutLongAsciiBenchmark  -9223372036854775808  avgt   30   6.699 ± 0.027  ns/op
UnsafeBufferPutLongAsciiBenchmark                     0  avgt   30   2.490 ± 0.010  ns/op
UnsafeBufferPutLongAsciiBenchmark                 -9182  avgt   30   8.620 ± 0.013  ns/op
UnsafeBufferPutLongAsciiBenchmark              97385146  avgt   30  12.600 ± 0.042  ns/op
UnsafeBufferPutLongAsciiBenchmark     -6180362504315475  avgt   30  24.890 ± 0.065  ns/op
UnsafeBufferPutLongAsciiBenchmark   9223372036854775807  avgt   30  28.601 ± 0.129  ns/op
```
- After:
```
Benchmark                                       (value)  Mode  Cnt   Score   Error  Units
UnsafeBufferPutIntAsciiBenchmark            -2147483648  avgt   30   6.564 ± 0.035  ns/op
UnsafeBufferPutIntAsciiBenchmark                      0  avgt   30   3.162 ± 0.007  ns/op
UnsafeBufferPutIntAsciiBenchmark                  -9182  avgt   30   6.114 ± 0.013  ns/op
UnsafeBufferPutIntAsciiBenchmark               27085146  avgt   30   9.443 ± 0.035  ns/op
UnsafeBufferPutIntAsciiBenchmark             -123456789  avgt   30  11.573 ± 0.040  ns/op
UnsafeBufferPutIntAsciiBenchmark             2147483647  avgt   30  11.244 ± 0.024  ns/op
UnsafeBufferPutLongAsciiBenchmark  -9223372036854775808  avgt   30   8.089 ± 0.027  ns/op
UnsafeBufferPutLongAsciiBenchmark                     0  avgt   30   3.280 ± 0.013  ns/op
UnsafeBufferPutLongAsciiBenchmark                 -9182  avgt   30   8.206 ± 0.038  ns/op
UnsafeBufferPutLongAsciiBenchmark              97385146  avgt   30  11.116 ± 0.027  ns/op
UnsafeBufferPutLongAsciiBenchmark     -6180362504315475  avgt   30  19.083 ± 0.054  ns/op
UnsafeBufferPutLongAsciiBenchmark   9223372036854775807  avgt   30  21.832 ± 0.050  ns/op
```

Here are also the intermediate results:
<details><summary>Lookup table</summary>

```
Benchmark                                       (value)  Mode  Cnt   Score   Error  Units
UnsafeBufferPutIntAsciiBenchmark            -2147483648  avgt   30   6.555 ± 0.029  ns/op
UnsafeBufferPutIntAsciiBenchmark                      0  avgt   30   3.257 ± 0.024  ns/op
UnsafeBufferPutIntAsciiBenchmark                  -9182  avgt   30   7.220 ± 0.012  ns/op
UnsafeBufferPutIntAsciiBenchmark               27085146  avgt   30  10.538 ± 0.021  ns/op
UnsafeBufferPutIntAsciiBenchmark             -123456789  avgt   30  11.048 ± 0.016  ns/op
UnsafeBufferPutIntAsciiBenchmark             2147483647  avgt   30  11.497 ± 0.057  ns/op
UnsafeBufferPutLongAsciiBenchmark  -9223372036854775808  avgt   30   8.134 ± 0.039  ns/op
UnsafeBufferPutLongAsciiBenchmark                     0  avgt   30   3.275 ± 0.023  ns/op
UnsafeBufferPutLongAsciiBenchmark                 -9182  avgt   30   8.337 ± 0.031  ns/op
UnsafeBufferPutLongAsciiBenchmark              97385146  avgt   30  11.314 ± 0.060  ns/op
UnsafeBufferPutLongAsciiBenchmark     -6180362504315475  avgt   30  19.583 ± 0.207  ns/op
UnsafeBufferPutLongAsciiBenchmark   9223372036854775807  avgt   30  22.412 ± 0.268  ns/op
```
</details>

<details><summary>Lookup table + pre-computed base offset</summary>

```
Benchmark                                       (value)  Mode  Cnt   Score   Error  Units
UnsafeBufferPutIntAsciiBenchmark            -2147483648  avgt   30   6.550 ± 0.021  ns/op
UnsafeBufferPutIntAsciiBenchmark                      0  avgt   30   3.278 ± 0.008  ns/op
UnsafeBufferPutIntAsciiBenchmark                  -9182  avgt   30   7.968 ± 0.039  ns/op
UnsafeBufferPutIntAsciiBenchmark               27085146  avgt   30   9.990 ± 0.040  ns/op
UnsafeBufferPutIntAsciiBenchmark             -123456789  avgt   30  11.646 ± 0.078  ns/op
UnsafeBufferPutIntAsciiBenchmark             2147483647  avgt   30  11.617 ± 0.079  ns/op
UnsafeBufferPutLongAsciiBenchmark  -9223372036854775808  avgt   30   8.065 ± 0.016  ns/op
UnsafeBufferPutLongAsciiBenchmark                     0  avgt   30   3.290 ± 0.010  ns/op
UnsafeBufferPutLongAsciiBenchmark                 -9182  avgt   30   8.597 ± 0.091  ns/op
UnsafeBufferPutLongAsciiBenchmark              97385146  avgt   30  11.165 ± 0.067  ns/op
UnsafeBufferPutLongAsciiBenchmark     -6180362504315475  avgt   30  19.266 ± 0.061  ns/op
UnsafeBufferPutLongAsciiBenchmark   9223372036854775807  avgt   30  22.187 ± 0.074  ns/op
```
</details>