### PR TITLE
[Java] RingBuffer capacity validation and fixes.

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBuffer.java
@@ -35,7 +35,7 @@ public final class ManyToOneRingBuffer implements RingBuffer
     /**
      * Minimal required capacity of the ring buffer excluding {@link RingBufferDescriptor#TRAILER_LENGTH}.
      */
-    static final int MIN_CAPACITY = HEADER_LENGTH;
+    public static final int MIN_CAPACITY = HEADER_LENGTH;
     private final int capacity;
     private final int maxMsgLength;
     private final int tailPositionIndex;

--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
@@ -38,7 +38,7 @@ public final class OneToOneRingBuffer implements RingBuffer
     /**
      * Minimal required capacity of the ring buffer excluding {@link RingBufferDescriptor#TRAILER_LENGTH}.
      */
-    static final int MIN_CAPACITY = HEADER_LENGTH * 2;
+    public static final int MIN_CAPACITY = HEADER_LENGTH * 2;
     private final int capacity;
     private final int maxMsgLength;
     private final int tailPositionIndex;

--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
@@ -17,8 +17,11 @@ package org.agrona.concurrent.ringbuffer;
 
 import org.agrona.DirectBuffer;
 import org.agrona.UnsafeAccess;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.ControlledMessageHandler;
+import org.agrona.concurrent.MessageHandler;
 
+import static java.lang.Math.max;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ControlledMessageHandler.Action.*;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
@@ -32,6 +35,10 @@ import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.*;
  */
 public final class OneToOneRingBuffer implements RingBuffer
 {
+    /**
+     * Minimal required capacity of the ring buffer excluding {@link RingBufferDescriptor#TRAILER_LENGTH}.
+     */
+    static final int MIN_CAPACITY = HEADER_LENGTH * 2;
     private final int capacity;
     private final int maxMsgLength;
     private final int tailPositionIndex;
@@ -47,18 +54,18 @@ public final class OneToOneRingBuffer implements RingBuffer
      * for the {@link RingBufferDescriptor#TRAILER_LENGTH}.
      *
      * @param buffer via which events will be exchanged.
-     * @throws IllegalStateException if the buffer capacity is not a power of 2 plus
-     *                               {@link RingBufferDescriptor#TRAILER_LENGTH} in capacity.
+     * @throws IllegalArgumentException if the buffer capacity is not a power of 2 plus
+     *                                  {@link RingBufferDescriptor#TRAILER_LENGTH} or if capacity is less than
+     *                                  {@link #MIN_CAPACITY}.
      */
     public OneToOneRingBuffer(final AtomicBuffer buffer)
     {
-        this.buffer = buffer;
-        checkCapacity(buffer.capacity());
-        capacity = buffer.capacity() - TRAILER_LENGTH;
+        capacity = checkCapacity(buffer.capacity(), MIN_CAPACITY);
 
         buffer.verifyAlignment();
 
-        maxMsgLength = capacity >> 3;
+        this.buffer = buffer;
+        maxMsgLength = MIN_CAPACITY == capacity ? 0 : max(HEADER_LENGTH, capacity >> 3);
         tailPositionIndex = capacity + TAIL_POSITION_OFFSET;
         headCachePositionIndex = capacity + HEAD_CACHE_POSITION_OFFSET;
         headPositionIndex = capacity + HEAD_POSITION_OFFSET;

--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/RingBufferDescriptor.java
@@ -81,17 +81,27 @@ public final class RingBufferDescriptor
     }
 
     /**
-     * Check the the buffer capacity is the correct size (a power of 2 + {@link RingBufferDescriptor#TRAILER_LENGTH}).
+     * Check the the buffer capacity is the correct size (a power of 2 + {@link RingBufferDescriptor#TRAILER_LENGTH})
+     * and that it satisfies minimum capacity size.
      *
-     * @param capacity to be checked.
-     * @throws IllegalStateException if the buffer capacity is incorrect.
+     * @param capacity    to be checked.
+     * @param minCapacity minimum required capacity of the ring buffer.
+     * @return the capacity to store the data in the ring buffer, i.e. {@code capacity - TRAILER_LENGTH}.
+     * @throws IllegalArgumentException if the buffer capacity is incorrect.
      */
-    public static void checkCapacity(final int capacity)
+    public static int checkCapacity(final int capacity, final int minCapacity)
     {
-        if (!BitUtil.isPowerOfTwo(capacity - TRAILER_LENGTH))
+        final int dataCapacity = capacity - TRAILER_LENGTH;
+        if (!BitUtil.isPowerOfTwo(dataCapacity))
         {
-            final String msg = "capacity must be a positive power of 2 + TRAILER_LENGTH: capacity=" + capacity;
-            throw new IllegalStateException(msg);
+            throw new IllegalArgumentException(
+                "capacity must be a positive power of 2 + TRAILER_LENGTH: capacity=" + capacity);
         }
+        if (dataCapacity < minCapacity)
+        {
+            throw new IllegalArgumentException(
+                "insufficient capacity: minCapacity=" + (minCapacity + TRAILER_LENGTH) + ", capacity=" + capacity);
+        }
+        return dataCapacity;
     }
 }

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
@@ -17,19 +17,27 @@ package org.agrona.concurrent.ringbuffer;
 
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.collections.MutableInteger;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.ControlledMessageHandler;
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.IntConsumer;
 
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer.PADDING_MSG_TYPE_ID;
+import static org.agrona.concurrent.ringbuffer.OneToOneRingBuffer.MIN_CAPACITY;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
 import static org.agrona.concurrent.ringbuffer.RingBuffer.INSUFFICIENT_CAPACITY;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,10 +47,10 @@ public class OneToOneRingBufferTest
 {
     private static final int MSG_TYPE_ID = 7;
     private static final int CAPACITY = 4096;
-    private static final int TOTAL_BUFFER_LENGTH = CAPACITY + RingBufferDescriptor.TRAILER_LENGTH;
-    private static final int TAIL_COUNTER_INDEX = CAPACITY + RingBufferDescriptor.TAIL_POSITION_OFFSET;
-    private static final int HEAD_COUNTER_INDEX = CAPACITY + RingBufferDescriptor.HEAD_POSITION_OFFSET;
-    private static final int HEAD_COUNTER_CACHE_INDEX = CAPACITY + RingBufferDescriptor.HEAD_CACHE_POSITION_OFFSET;
+    private static final int TOTAL_BUFFER_LENGTH = CAPACITY + TRAILER_LENGTH;
+    private static final int TAIL_COUNTER_INDEX = CAPACITY + TAIL_POSITION_OFFSET;
+    private static final int HEAD_COUNTER_INDEX = CAPACITY + HEAD_POSITION_OFFSET;
+    private static final int HEAD_COUNTER_CACHE_INDEX = CAPACITY + HEAD_CACHE_POSITION_OFFSET;
 
     private final UnsafeBuffer buffer = mock(UnsafeBuffer.class);
     private OneToOneRingBuffer ringBuffer;
@@ -53,6 +61,30 @@ public class OneToOneRingBufferTest
         when(buffer.capacity()).thenReturn(TOTAL_BUFFER_LENGTH);
 
         ringBuffer = new OneToOneRingBuffer(buffer);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 2, 4, 8 })
+    void shouldThrowExceptionIfCapacityIsBelowMinCapacity(final int capacity)
+    {
+        when(buffer.capacity()).thenReturn(TRAILER_LENGTH + capacity);
+
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> new OneToOneRingBuffer(buffer));
+
+        assertEquals("insufficient capacity: minCapacity=" + (TRAILER_LENGTH + MIN_CAPACITY) +
+            ", capacity=" + (TRAILER_LENGTH + capacity),
+            exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("maxMessageLengths")
+    void shouldComputeMaxMessageLength(final int capacity, final int maxMessageLength)
+    {
+        when(buffer.capacity()).thenReturn(TRAILER_LENGTH + capacity);
+
+        final OneToOneRingBuffer ringBuffer = new OneToOneRingBuffer(buffer);
+        assertEquals(maxMessageLength, ringBuffer.maxMsgLength());
     }
 
     @Test
@@ -335,8 +367,8 @@ public class OneToOneRingBufferTest
     public void shouldThrowExceptionForCapacityThatIsNotPowerOfTwo()
     {
         final int capacity = 777;
-        final int totalBufferLength = capacity + RingBufferDescriptor.TRAILER_LENGTH;
-        assertThrows(IllegalStateException.class,
+        final int totalBufferLength = capacity + TRAILER_LENGTH;
+        assertThrows(IllegalArgumentException.class,
             () -> new OneToOneRingBuffer(new UnsafeBuffer(new byte[totalBufferLength])));
     }
 
@@ -646,5 +678,15 @@ public class OneToOneRingBufferTest
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class, () -> action.accept(index));
         assertEquals("claimed space previously aborted", exception.getMessage());
+    }
+
+    private static List<Arguments> maxMessageLengths()
+    {
+        return Arrays.asList(
+            Arguments.arguments(MIN_CAPACITY, 0),
+            Arguments.arguments(MIN_CAPACITY * 2, HEADER_LENGTH),
+            Arguments.arguments(MIN_CAPACITY * MIN_CAPACITY, 32),
+            Arguments.arguments(1024, 128)
+        );
     }
 }


### PR DESCRIPTION
This PR contains the following changes:
- Validate minimum allowed capacity.
- Compute max message length based on the capacity:
  * `0` if min capacity.
  * `HEADER_LENGTH` if buffer is small.
  * `1/8 of the buffer size` - for buffers bigger than `HEADER_LENGTH * 8`.
- `ManyToOneRingBuffer` - handle a case where there is not enough contiguous space in the buffer by inserting padding which once consumed by the consumer allows producer to write again.
- `OneToOneRingBuffer` - handle a case where there is not enough contiguous space in the buffer + directly write a message at the buffer end if it fits and pre-zero start of the buffer.
The latter is only needed to allow writer to proceed immediately once the reader got a previous message, i.e. allows ping pong messages in case of a buffer with min capacity.

_**Note:** The validation exception was changed from `IllegalStateException` to `IllegalArgumentExceeption` which is technically an API change._