### PR TITLE
MutableDirectBuffer methods to put string could accept CharSequence

### DIFF
--- a/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
+++ b/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
@@ -38,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class BufferAlignmentAgentTest
 {
     private static final String TEST_STRING = "BufferAlignmentTest";
+    private static final CharSequence TEST_CHAR_SEQUENCE = new StringBuilder("BufferAlignmentTest");
+
     //on 32-bits JVMs, array content is not 8-byte aligned => need to add 4 bytes offset
     private static final int HEAP_BUFFER_ALIGNMENT_OFFSET = UnsafeAccess.ARRAY_BYTE_BASE_OFFSET % 8;
     private static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("-?\\d+");
@@ -223,12 +225,15 @@ public class BufferAlignmentAgentTest
         buffer.putStringUtf8(offset + SIZE_OF_INT, TEST_STRING, Integer.MAX_VALUE);
         buffer.putStringUtf8(offset + SIZE_OF_INT, TEST_STRING, BIG_ENDIAN, Integer.MAX_VALUE);
         buffer.putStringAscii(offset + SIZE_OF_INT, TEST_STRING);
+        buffer.putStringAscii(offset + SIZE_OF_INT, TEST_CHAR_SEQUENCE);
         buffer.putStringAscii(offset + SIZE_OF_INT, TEST_STRING, BIG_ENDIAN);
+        buffer.putStringAscii(offset + SIZE_OF_INT, TEST_CHAR_SEQUENCE, BIG_ENDIAN);
 
         // string size is not read for these method => no need for 4-bytes
         // alignment
         buffer.putStringWithoutLengthUtf8(offset + SIZE_OF_BYTE, TEST_STRING);
         buffer.putStringWithoutLengthAscii(offset + SIZE_OF_BYTE, TEST_STRING);
+        buffer.putStringWithoutLengthAscii(offset + SIZE_OF_BYTE, TEST_CHAR_SEQUENCE);
     }
 
     private void testUnAlignedWriteMethods(final MutableDirectBuffer buffer, final int offset)
@@ -252,7 +257,9 @@ public class BufferAlignmentAgentTest
         assertUnaligned(offset + SIZE_OF_BYTE, (i) -> buffer.putChar(i, Character.MAX_VALUE, BIG_ENDIAN));
 
         assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringAscii(i, TEST_STRING));
+        assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringAscii(i, TEST_CHAR_SEQUENCE));
         assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringAscii(i, TEST_STRING, BIG_ENDIAN));
+        assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringAscii(i, TEST_CHAR_SEQUENCE, BIG_ENDIAN));
         assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringUtf8(i, TEST_STRING));
         assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringUtf8(i, TEST_STRING, BIG_ENDIAN));
         assertUnaligned(offset + SIZE_OF_SHORT, (i) -> buffer.putStringUtf8(i, TEST_STRING, Integer.MAX_VALUE));

--- a/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
@@ -35,10 +35,8 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 1)
 @State(Scope.Benchmark)
-@SuppressWarnings("FieldCanBeLocal")
 public class UnsafeBufferPutCharSequenceBenchmark
 {
-
     private static final int BUFFER_CAPACITY = 128;
 
     private final UnsafeBuffer unsafeArrayBuffer = new UnsafeBuffer(new byte[BUFFER_CAPACITY]);

--- a/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
@@ -36,62 +36,119 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 1)
 @State(Scope.Benchmark)
 @SuppressWarnings("FieldCanBeLocal")
-public class UnsafeBufferPutCharSequenceBenchmark {
+public class UnsafeBufferPutCharSequenceBenchmark
+{
 
     private static final int BUFFER_CAPACITY = 128;
 
     private final UnsafeBuffer unsafeArrayBuffer = new UnsafeBuffer(new byte[BUFFER_CAPACITY]);
     private final UnsafeBuffer unsafeDirectBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(BUFFER_CAPACITY));
     private final ExpandableArrayBuffer expandableArrayBuffer = new ExpandableArrayBuffer(BUFFER_CAPACITY);
-    private final ExpandableDirectByteBuffer expandableDirectByteBuffer = new ExpandableDirectByteBuffer(BUFFER_CAPACITY);
+    private final ExpandableDirectByteBuffer expandableDirectByteBuffer
+        = new ExpandableDirectByteBuffer(BUFFER_CAPACITY);
 
-    private final CharSequence charSequence = new StringBuilder("Cupcake ipsum dolor sit amet chupa chups sweet jelly topping.");
+    private final CharSequence charSequence = new StringBuilder(
+        "Cupcake ipsum dolor sit amet chupa chups sweet jelly topping.");
     private final String string = charSequence.toString();
 
+    /**
+     * Benchmark {@link UnsafeBuffer#putStringAscii(int, String)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int unsafeArrayBuffer_string() {
+    public int unsafeArrayBufferString()
+    {
         return unsafeArrayBuffer.putStringAscii(0, string);
     }
 
+    /**
+     * Benchmark {@link UnsafeBuffer#putStringAscii(int, CharSequence)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int unsafeArrayBuffer_charSequence() {
+    public int unsafeArrayBufferCharSequence()
+    {
         return unsafeArrayBuffer.putStringAscii(0, charSequence);
     }
 
+    /**
+     * Benchmark {@link UnsafeBuffer#putStringAscii(int, String)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int unsafeDirectBuffer_string() {
+    public int unsafeDirectBufferString()
+    {
         return unsafeDirectBuffer.putStringAscii(0, string);
     }
 
+    /**
+     * Benchmark {@link UnsafeBuffer#putStringAscii(int, CharSequence)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int unsafeDirectBuffer_charSequence() {
+    public int unsafeDirectBufferCharSequence()
+    {
         return unsafeDirectBuffer.putStringAscii(0, charSequence);
     }
 
+    /**
+     * Benchmark {@link ExpandableArrayBuffer#putStringAscii(int, String)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int expandableArrayBuffer_string() {
+    public int expandableArrayBufferString()
+    {
         return expandableArrayBuffer.putStringAscii(0, string);
     }
 
+    /**
+     * Benchmark {@link ExpandableArrayBuffer#putStringAscii(int, CharSequence)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int expandableArrayBuffer_charSequence() {
+    public int expandableArrayBufferCharSequence()
+    {
         return expandableArrayBuffer.putStringAscii(0, charSequence);
     }
 
+    /**
+     * Benchmark {@link ExpandableDirectByteBuffer#putStringAscii(int, String)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int expandableDirectByteBuffer_string() {
+    public int expandableDirectByteBufferString()
+    {
         return expandableDirectByteBuffer.putStringAscii(0, string);
     }
 
+    /**
+     * Benchmark {@link ExpandableDirectByteBuffer#putStringAscii(int, CharSequence)} method.
+     *
+     * @return length in bytes of the written value.
+     */
     @Benchmark
-    public int expandableDirectByteBuffer_charSequence() {
+    public int expandableDirectByteBufferCharSequence()
+    {
         return expandableDirectByteBuffer.putStringAscii(0, charSequence);
     }
 
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-                .include(".*" + UnsafeBufferPutCharSequenceBenchmark.class.getSimpleName() + ".*")
-                .build();
+    /**
+     * Benchmark entry point.
+     *
+     * @param args program arguments (ignored)
+     */
+    public static void main(final String[] args) throws RunnerException
+    {
+        final Options opt = new OptionsBuilder()
+            .include(".*" + UnsafeBufferPutCharSequenceBenchmark.class.getSimpleName() + ".*")
+            .build();
 
         new Runner(opt).run();
     }

--- a/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
+++ b/agrona-benchmarks/src/main/java/org/agrona/concurrent/UnsafeBufferPutCharSequenceBenchmark.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.ExpandableDirectByteBuffer;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for the {@link UnsafeBuffer#putStringAscii(int, CharSequence)} method.
+ */
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@State(Scope.Benchmark)
+@SuppressWarnings("FieldCanBeLocal")
+public class UnsafeBufferPutCharSequenceBenchmark {
+
+    private static final int BUFFER_CAPACITY = 128;
+
+    private final UnsafeBuffer unsafeArrayBuffer = new UnsafeBuffer(new byte[BUFFER_CAPACITY]);
+    private final UnsafeBuffer unsafeDirectBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(BUFFER_CAPACITY));
+    private final ExpandableArrayBuffer expandableArrayBuffer = new ExpandableArrayBuffer(BUFFER_CAPACITY);
+    private final ExpandableDirectByteBuffer expandableDirectByteBuffer = new ExpandableDirectByteBuffer(BUFFER_CAPACITY);
+
+    private final CharSequence charSequence = new StringBuilder("Cupcake ipsum dolor sit amet chupa chups sweet jelly topping.");
+    private final String string = charSequence.toString();
+
+    @Benchmark
+    public int unsafeArrayBuffer_string() {
+        return unsafeArrayBuffer.putStringAscii(0, string);
+    }
+
+    @Benchmark
+    public int unsafeArrayBuffer_charSequence() {
+        return unsafeArrayBuffer.putStringAscii(0, charSequence);
+    }
+
+    @Benchmark
+    public int unsafeDirectBuffer_string() {
+        return unsafeDirectBuffer.putStringAscii(0, string);
+    }
+
+    @Benchmark
+    public int unsafeDirectBuffer_charSequence() {
+        return unsafeDirectBuffer.putStringAscii(0, charSequence);
+    }
+
+    @Benchmark
+    public int expandableArrayBuffer_string() {
+        return expandableArrayBuffer.putStringAscii(0, string);
+    }
+
+    @Benchmark
+    public int expandableArrayBuffer_charSequence() {
+        return expandableArrayBuffer.putStringAscii(0, charSequence);
+    }
+
+    @Benchmark
+    public int expandableDirectByteBuffer_string() {
+        return expandableDirectByteBuffer.putStringAscii(0, string);
+    }
+
+    @Benchmark
+    public int expandableDirectByteBuffer_charSequence() {
+        return expandableDirectByteBuffer.putStringAscii(0, charSequence);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + UnsafeBufferPutCharSequenceBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -787,7 +787,63 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length + STR_HEADER_LEN);
+
+        UNSAFE.putInt(byteArray, ARRAY_BASE_OFFSET + index, length);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, ARRAY_BASE_OFFSET + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringAscii(final int index, final String value, final ByteOrder byteOrder)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length + STR_HEADER_LEN);
+
+        int bits = length;
+        if (NATIVE_BYTE_ORDER != byteOrder)
+        {
+            bits = Integer.reverseBytes(bits);
+        }
+
+        UNSAFE.putInt(byteArray, ARRAY_BASE_OFFSET + index, bits);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, ARRAY_BASE_OFFSET + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringAscii(final int index, final CharSequence value, final ByteOrder byteOrder)
     {
         final int length = value != null ? value.length() : 0;
 
@@ -873,7 +929,54 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, ARRAY_BASE_OFFSET + index + i, (byte)c);
+        }
+
+        return length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringWithoutLengthAscii(final int index, final String value, final int valueOffset, final int length)
+    {
+        final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
+
+        ensureCapacity(index, len);
+
+        for (int i = 0; i < len; i++)
+        {
+            char c = value.charAt(valueOffset + i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, ARRAY_BASE_OFFSET + index + i, (byte)c);
+        }
+
+        return len;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value, final int valueOffset,
+        final int length)
     {
         final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
 

--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -819,7 +819,63 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length + STR_HEADER_LEN);
+
+        UNSAFE.putInt(null, address + index, length);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(null, address + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringAscii(final int index, final String value, final ByteOrder byteOrder)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length + STR_HEADER_LEN);
+
+        int bits = length;
+        if (NATIVE_BYTE_ORDER != byteOrder)
+        {
+            bits = Integer.reverseBytes(bits);
+        }
+
+        UNSAFE.putInt(null, address + index, bits);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(null, address + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringAscii(final int index, final CharSequence value, final ByteOrder byteOrder)
     {
         final int length = value != null ? value.length() : 0;
 
@@ -909,7 +965,54 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        ensureCapacity(index, length);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(null, address + index + i, (byte)c);
+        }
+
+        return length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringWithoutLengthAscii(final int index, final String value, final int valueOffset, final int length)
+    {
+        final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
+
+        ensureCapacity(index, len);
+
+        for (int i = 0; i < len; i++)
+        {
+            char c = value.charAt(valueOffset + i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(null, address + index + i, (byte)c);
+        }
+
+        return len;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value, final int valueOffset,
+        final int length)
     {
         final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
 

--- a/agrona/src/main/java/org/agrona/MutableDirectBuffer.java
+++ b/agrona/src/main/java/org/agrona/MutableDirectBuffer.java
@@ -274,6 +274,15 @@ public interface MutableDirectBuffer extends DirectBuffer
     int putStringAscii(int index, String value);
 
     /**
+     * Encode a CharSequence as ASCII bytes to the buffer with a length prefix.
+     *
+     * @param index at which the CharSequence should be encoded.
+     * @param value of the CharSequence to be encoded.
+     * @return the number of bytes put to the buffer.
+     */
+    int putStringAscii(int index, CharSequence value);
+
+    /**
      * Encode a String as ASCII bytes to the buffer with a length prefix.
      *
      * @param index     at which the String should be encoded.
@@ -284,6 +293,16 @@ public interface MutableDirectBuffer extends DirectBuffer
     int putStringAscii(int index, String value, ByteOrder byteOrder);
 
     /**
+     * Encode a CharSequence as ASCII bytes to the buffer with a length prefix.
+     *
+     * @param index     at which the CharSequence should be encoded.
+     * @param value     of the CharSequence to be encoded.
+     * @param byteOrder for the length prefix.
+     * @return the number of bytes put to the buffer.
+     */
+    int putStringAscii(int index, CharSequence value, ByteOrder byteOrder);
+
+    /**
      * Encode a String as ASCII bytes in the buffer without a length prefix.
      *
      * @param index at which the String begins.
@@ -291,6 +310,15 @@ public interface MutableDirectBuffer extends DirectBuffer
      * @return the number of bytes encoded.
      */
     int putStringWithoutLengthAscii(int index, String value);
+
+    /**
+     * Encode a CharSequence as ASCII bytes in the buffer without a length prefix.
+     *
+     * @param index at which the CharSequence begins.
+     * @param value of the CharSequence to be encoded.
+     * @return the number of bytes encoded.
+     */
+    int putStringWithoutLengthAscii(int index, CharSequence value);
 
     /**
      * Encode a String as ASCII bytes in the buffer without a length prefix taking a range of the value.
@@ -303,6 +331,18 @@ public interface MutableDirectBuffer extends DirectBuffer
      * @return the number of bytes encoded.
      */
     int putStringWithoutLengthAscii(int index, String value, int valueOffset, int length);
+
+    /**
+     * Encode a CharSequence as ASCII bytes in the buffer without a length prefix taking a range of the value.
+     *
+     * @param index       at which the CharSequence begins.
+     * @param value       of the CharSequence to be encoded.
+     * @param valueOffset in the value CharSequence to begin.
+     * @param length      of the value CharSequence to encode. If this is greater than valueOffset - value length then the
+     *                    lesser will be used.
+     * @return the number of bytes encoded.
+     */
+    int putStringWithoutLengthAscii(int index, CharSequence value, int valueOffset, int length);
 
     /**
      * Encode a String as UTF-8 bytes to the buffer with a length prefix.

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1393,7 +1393,69 @@ public class UnsafeBuffer implements AtomicBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, length + STR_HEADER_LEN);
+        }
+
+        UNSAFE.putInt(byteArray, addressOffset + index, length);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, addressOffset + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringAscii(final int index, final String value, final ByteOrder byteOrder)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, length + STR_HEADER_LEN);
+        }
+
+        int bits = length;
+        if (NATIVE_BYTE_ORDER != byteOrder)
+        {
+            bits = Integer.reverseBytes(bits);
+        }
+
+        UNSAFE.putInt(byteArray, addressOffset + index, bits);
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, addressOffset + STR_HEADER_LEN + index + i, (byte)c);
+        }
+
+        return STR_HEADER_LEN + length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringAscii(final int index, final CharSequence value, final ByteOrder byteOrder)
     {
         final int length = value != null ? value.length() : 0;
 
@@ -1495,7 +1557,60 @@ public class UnsafeBuffer implements AtomicBuffer
     /**
      * {@inheritDoc}
      */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value)
+    {
+        final int length = value != null ? value.length() : 0;
+
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, length);
+        }
+
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, addressOffset + index + i, (byte)c);
+        }
+
+        return length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public int putStringWithoutLengthAscii(final int index, final String value, final int valueOffset, final int length)
+    {
+        final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
+
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, len);
+        }
+
+        for (int i = 0; i < len; i++)
+        {
+            char c = value.charAt(valueOffset + i);
+            if (c > 127)
+            {
+                c = '?';
+            }
+
+            UNSAFE.putByte(byteArray, addressOffset + index + i, (byte)c);
+        }
+
+        return len;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int putStringWithoutLengthAscii(final int index, final CharSequence value, final int valueOffset,
+        final int length)
     {
         final int len = value != null ? Math.min(value.length() - valueOffset, length) : 0;
 

--- a/agrona/src/test/java/org/agrona/BufferCharSequenceOperationsTest.java
+++ b/agrona/src/test/java/org/agrona/BufferCharSequenceOperationsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.stream.Stream;
+
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BufferCharSequenceOperationsTest
+{
+    private static final int BUFFER_CAPACITY = 256;
+    private static final int INDEX = 8;
+
+    private static Stream<MutableDirectBuffer> buffers()
+    {
+        return Stream.of(
+            new UnsafeBuffer(new byte[BUFFER_CAPACITY]),
+            new UnsafeBuffer(ByteBuffer.allocateDirect(BUFFER_CAPACITY)),
+            new ExpandableArrayBuffer(BUFFER_CAPACITY),
+            new ExpandableDirectByteBuffer(BUFFER_CAPACITY));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buffers")
+    public void shouldInsertNonAsciiAsQuestionMark(final MutableDirectBuffer buffer)
+    {
+        final CharSequence value = new StringBuilder("Hello World £");
+        final CharSequence expected = "Hello World ?";
+
+        buffer.putStringAscii(INDEX, value);
+        assertThat(buffer.getStringAscii(INDEX), is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buffers")
+    public void shouldAppendAsciiStringInParts(final MutableDirectBuffer buffer)
+    {
+        final CharSequence value = new StringBuilder("Hello World Test");
+        final String expected = "Hello World Test";
+
+        int stringIndex = 0;
+        int bufferIndex = INDEX + SIZE_OF_INT;
+
+        bufferIndex += buffer.putStringWithoutLengthAscii(bufferIndex, value, stringIndex, 5);
+
+        stringIndex += 5;
+        bufferIndex += buffer.putStringWithoutLengthAscii(bufferIndex, value, stringIndex, 5);
+
+        stringIndex += 5;
+        bufferIndex += buffer.putStringWithoutLengthAscii(
+            bufferIndex, value, stringIndex, value.length() - stringIndex);
+
+        assertThat(bufferIndex, is(expected.length() + INDEX + SIZE_OF_INT));
+        buffer.putInt(INDEX, expected.length());
+
+        assertThat(buffer.getStringWithoutLengthAscii(INDEX + SIZE_OF_INT, expected.length()), is(expected));
+        assertThat(buffer.getStringAscii(INDEX), is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buffers")
+    public void shouldRoundTripAsciiStringNativeLength(final MutableDirectBuffer buffer)
+    {
+        final CharSequence value = new StringBuilder("Hello World");
+        final String expected = "Hello World";
+
+        buffer.putStringAscii(INDEX, value);
+
+        assertThat(buffer.getStringAscii(INDEX), is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buffers")
+    public void shouldRoundTripAsciiStringBigEndianLength(final MutableDirectBuffer buffer)
+    {
+        final CharSequence value = new StringBuilder("Hello World");
+        final String expected = "Hello World";
+
+        buffer.putStringAscii(INDEX, value, ByteOrder.BIG_ENDIAN);
+
+        assertThat(buffer.getStringAscii(INDEX, ByteOrder.BIG_ENDIAN), is(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buffers")
+    public void shouldRoundTripAsciiStringWithoutLength(final MutableDirectBuffer buffer)
+    {
+        final CharSequence value = new StringBuilder("Hello World");
+        final String expected = "Hello World";
+
+        buffer.putStringWithoutLengthAscii(INDEX, value);
+
+        assertThat(buffer.getStringWithoutLengthAscii(INDEX, value.length()), is(expected));
+    }
+}


### PR DESCRIPTION
This PR addresses #238 and contains following changes:

1. Modified `MutableDirectBuffer` class. Added `putStringAscii` and `putStringWithoutLengthAscii` versions that accept `CharSequence` instead of `String`.
1. Implemented them in all subclasses: `UnsafeBuffer`, `ExpandableArrayBuffer`, `ExpandableDirectByteBuffer`.
1. Implementations are copied from String versions verbatim.
1. Added tests in places that contained tests for string versions.
1. Added `BufferCharSequenceOperationsTest` that is based on `BufferStringOperationsTest`.
1. Added simple JMH microbenchmark.

I don't want to seem lazy but these are all changes I was able to come up with to support `CharSequence`-s.