### PR TITLE
Additional message decoder flyweight methods.

### DIFF
--- a/agrona/src/main/java/org/agrona/sbe/MessageDecoderFlyweight.java
+++ b/agrona/src/main/java/org/agrona/sbe/MessageDecoderFlyweight.java
@@ -40,4 +40,35 @@ public interface MessageDecoderFlyweight extends MessageFlyweight, DecoderFlywei
      * @return the supplied builder for a fluent API.
      */
     StringBuilder appendTo(StringBuilder builder);
+
+    /**
+     * Gets the total length of this flyweight by moving from the end of the block though all of the variable
+     * length fields.
+     *
+     * @return the total decoded length for the flyweight.
+     */
+    default int sbeDecodedLength()
+    {
+        throw new UnsupportedOperationException("not implemented by this version of SBE");
+    }
+
+    /**
+     * Gets the current limit for this decoder flyweight.
+     *
+     * @return the current limit.
+     */
+    default int sbeLimit()
+    {
+        throw new UnsupportedOperationException("not implemented by this version of SBE");
+    }
+
+    /**
+     * Sets the current limit for this flyweight.
+     *
+     * @param limit the new limit for this flyweight.
+     */
+    default void sbeLimit(int limit)
+    {
+        throw new UnsupportedOperationException("not implemented by this version of SBE");
+    }
 }


### PR DESCRIPTION
I've put them with default implementations, so using a newer version of agrona with an older version of SBE won't cause compilation errors.