### PR TITLE
[Java] Count digits in a number without using branches.

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -78,6 +78,31 @@ public final class AsciiEncoding
         999999999_999999999L, Long.MAX_VALUE
     };
 
+    private static final long[] INT_DIGITS =
+        {
+        4294967295L, 8589934582L, 8589934582L, 8589934582L, 12884901788L, 12884901788L, 12884901788L, 17179868184L,
+        17179868184L, 17179868184L, 21474826480L, 21474826480L, 21474826480L, 21474826480L, 25769703776L, 25769703776L,
+        25769703776L, 30063771072L, 30063771072L, 30063771072L, 34349738368L, 34349738368L, 34349738368L, 34349738368L,
+        38554705664L, 38554705664L, 38554705664L, 41949672960L, 41949672960L, 41949672960L, 42949672960L, 42949672960L
+        };
+
+    private static final long[] LONG_DIGITS =
+        {
+        4503599627370495L, 9007199254740982L, 9007199254740982L, 9007199254740982L, 13510798882111438L,
+        13510798882111438L, 13510798882111438L, 18014398509481484L, 18014398509481734L, 18014398509481734L,
+        22517998136849980L, 22517998136849980L, 22517998136851230L, 22517998136851230L, 27021597764210476L,
+        27021597764210476L, 27021597764216726L, 31525197391530972L, 31525197391530972L, 31525197391530972L,
+        36028797018651468L, 36028797018651468L, 36028797018651468L, 36028797018651468L, 40532396644771964L,
+        40532396644771964L, 40532396644771964L, 45035996258079960L, 45035996265892460L, 45035996265892460L,
+        49539595822950456L, 49539595822950456L, 49539595862012956L, 49539595862012956L, 54043195137820952L,
+        54043195137820952L, 54043195333133452L, 58546793202691448L, 58546793202691448L, 58546793202691448L,
+        63050385017561944L, 63050385017561944L, 63050385017561944L, 63050385017561944L, 67553945582432440L,
+        67553945582432440L, 67553945582432440L, 72057105756677936L, 72057349897302936L, 72057349897302936L,
+        76558752259048432L, 76558752259048432L, 76559972962173432L, 76559972962173432L, 81052586261418928L,
+        81052586261418928L, 81058689777043928L, 85507357763789424L, 85507357763789424L, 85507357763789424L,
+        89766816766159920L, 89766816766159920L, 89766816766159920L, 89766816766159920L
+        };
+
     private AsciiEncoding()
     {
     }
@@ -114,6 +139,44 @@ public final class AsciiEncoding
                 return i;
             }
         }
+    }
+
+    /**
+     * Count number of digits in a positive {@code int} value.
+     *
+     * <p>Implementation is based on the Kendall Willets' idea as presented in the
+     * <a href="https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster/"
+     * target="_blank">Computing the number of digits of an integer even faster</a> blog post.
+     *
+     * <p>
+     * Use {@code org.agrona.AsciiEncodingTest#printDigitCountIntTable()} to regenerate lookup table.
+     *
+     * @param value to count number of digits int.
+     * @return number of digits in a number, e.g. if input value is {@code 123} then the result will be {@code 3}.
+     */
+    public static int digitCount(final int value)
+    {
+        return (int)((value + INT_DIGITS[31 - Integer.numberOfLeadingZeros(value | 1)]) >> 32);
+    }
+
+    /**
+     * Count number of digits in a positive {@code long} value.
+     *
+     * <p>Implementation is based on the Kendall Willets' idea as presented in the
+     * <a href="https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster/"
+     * target="_blank">Computing the number of digits of an integer even faster</a> blog post.
+     *
+     * <p>
+     * Use {@code org.agrona.AsciiEncodingTest#printDigitCountLongTable()} to regenerate lookup table.
+     *
+     * @param value to count number of digits int.
+     * @return number of digits in a number, e.g. if input value is {@code 12345678909876} then the result will be
+     * {@code 14}.
+     */
+    public static int digitCount(final long value)
+    {
+        final int floorLog2 = 63 ^ Long.numberOfLeadingZeros(value);
+        return (int)((LONG_DIGITS[floorLog2] + (value >> (floorLog2 >> 2))) >> 52);
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -65,19 +65,6 @@ public final class AsciiEncoding
     private static final byte[] MIN_LONG_DIGITS = "9223372036854775808".getBytes(US_ASCII);
     private static final byte[] MAX_LONG_DIGITS = "9223372036854775807".getBytes(US_ASCII);
 
-    private static final int[] INT_ROUNDS =
-    {
-        9, 99, 999, 9999, 99999, 999999, 9999999, 99999999, 999999999, Integer.MAX_VALUE
-    };
-
-    private static final long[] LONG_ROUNDS =
-    {
-        9L, 99L, 999L, 9999L, 99999L, 999999L, 9999999L, 99999999L, 999999999L,
-        9_999999999L, 99_999999999L, 999_999999999L, 9999_999999999L,
-        99999_999999999L, 999999_999999999L, 9999999_999999999L, 99999999_999999999L,
-        999999999_999999999L, Long.MAX_VALUE
-    };
-
     private static final long[] INT_DIGITS =
         {
         4294967295L, 8589934582L, 8589934582L, 8589934582L, 12884901788L, 12884901788L, 12884901788L, 17179868184L,
@@ -108,37 +95,37 @@ public final class AsciiEncoding
     }
 
     /**
-     * Get the end offset of an ASCII encoded value.
+     * Calling this method is equivalent of doing:
+     * <pre>
+     * {@code digitCount(value) - 1}
+     * </pre>
      *
      * @param value to find the end encoded character offset.
      * @return the offset at which the encoded value will end.
+     * @deprecated Use {@link #digitCount(int)} instead.
+     * @see #digitCount(int)
      */
+    @Deprecated
     public static int endOffset(final int value)
     {
-        for (int i = 0; true; i++)
-        {
-            if (value <= INT_ROUNDS[i])
-            {
-                return i;
-            }
-        }
+        return digitCount(value) - 1;
     }
 
     /**
-     * Get the end offset of an ASCII encoded value.
+     * Calling this method is equivalent of doing:
+     * <pre>
+     * {@code digitCount(value) - 1}
+     * </pre>
      *
      * @param value to find the end encoded character offset.
      * @return the offset at which the encoded value will end.
+     * @deprecated Use {@link #digitCount(long)} instead.
+     * @see #digitCount(long)
      */
+    @Deprecated
     public static int endOffset(final long value)
     {
-        for (int i = 0; true; i++)
-        {
-            if (value <= LONG_ROUNDS[i])
-            {
-                return i;
-            }
-        }
+        return digitCount(value) - 1;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -22,10 +22,10 @@ import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.agrona.BitUtil.*;
-import static org.agrona.UnsafeAccess.UNSAFE;
-import static org.agrona.BufferUtil.*;
 import static org.agrona.AsciiEncoding.*;
+import static org.agrona.BitUtil.*;
+import static org.agrona.BufferUtil.*;
+import static org.agrona.UnsafeAccess.UNSAFE;
 
 /**
  * Expandable {@link MutableDirectBuffer} that is backed by an array. When values are put into the buffer beyond its
@@ -1263,17 +1263,21 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
         int start = index;
         int quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte0(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         ensureCapacity(index, length);
 
@@ -1312,11 +1316,11 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         ensureCapacity(index, length);
 
+        int i = length - 1;
         int quotient = value;
         final byte[] dest = byteArray;
         while (quotient >= 100)
@@ -1391,11 +1395,11 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         ensureCapacity(index, length);
 
+        int i = length - 1;
         long quotient = value;
         final byte[] dest = byteArray;
         while (quotient >= 100000000)
@@ -1465,17 +1469,21 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
         int start = index;
         long quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte0(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         ensureCapacity(index, length);
 

--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -21,9 +21,9 @@ import java.nio.ByteOrder;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.agrona.AsciiEncoding.*;
 import static org.agrona.BitUtil.*;
 import static org.agrona.BufferUtil.*;
-import static org.agrona.AsciiEncoding.*;
 import static org.agrona.UnsafeAccess.UNSAFE;
 
 /**
@@ -1314,17 +1314,21 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
 
         int start = index;
         int quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte0(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         ensureCapacity(index, length);
 
@@ -1363,11 +1367,11 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         ensureCapacity(index, length);
 
+        int i = length - 1;
         int quotient = value;
         final ByteBuffer dest = byteBuffer;
         while (quotient >= 100)
@@ -1442,11 +1446,11 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         ensureCapacity(index, length);
 
+        int i = length - 1;
         long quotient = value;
         final ByteBuffer dest = byteBuffer;
         while (quotient >= 100000000)
@@ -1516,17 +1520,21 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
 
         int start = index;
         long quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte0(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         ensureCapacity(index, length);
 

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -1941,17 +1941,21 @@ public class UnsafeBuffer implements AtomicBuffer
 
         int start = index;
         int quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         if (SHOULD_BOUNDS_CHECK)
         {
@@ -1994,14 +1998,14 @@ public class UnsafeBuffer implements AtomicBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         if (SHOULD_BOUNDS_CHECK)
         {
             boundsCheck0(index, length);
         }
 
+        int i = length - 1;
         int quotient = value;
         final long offset = addressOffset + index;
         final byte[] dest = byteArray;
@@ -2077,14 +2081,14 @@ public class UnsafeBuffer implements AtomicBuffer
             return 1;
         }
 
-        int i = endOffset(value);
-        final int length = i + 1;
+        final int length = digitCount(value);
 
         if (SHOULD_BOUNDS_CHECK)
         {
             boundsCheck0(index, length);
         }
 
+        int i = length - 1;
         long quotient = value;
         final long offset = addressOffset + index;
         final byte[] dest = byteArray;
@@ -2155,17 +2159,21 @@ public class UnsafeBuffer implements AtomicBuffer
 
         int start = index;
         long quotient = value;
-        int length = 1;
+        final int length;
+        int i;
         if (value < 0)
         {
             putByte(index, MINUS_SIGN);
             start++;
-            length++;
             quotient = -quotient;
+            length = digitCount(quotient) + 1;
+            i = length - 2;
         }
-
-        int i = endOffset(quotient);
-        length += i;
+        else
+        {
+            length = digitCount(quotient);
+            i = length - 1;
+        }
 
         if (SHOULD_BOUNDS_CHECK)
         {

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -15,17 +15,20 @@
  */
 package org.agrona;
 
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
-import static org.agrona.AsciiEncoding.parseIntAscii;
-import static org.agrona.AsciiEncoding.parseLongAscii;
+import java.math.BigInteger;
+import java.util.stream.IntStream;
+
+import static org.agrona.AsciiEncoding.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AsciiEncodingTest
+class AsciiEncodingTest
 {
     @Test
-    public void shouldParseInt()
+    void shouldParseInt()
     {
         assertEquals(0, parseIntAscii("0", 0, 1));
         assertEquals(0, parseIntAscii("-0", 0, 2));
@@ -48,7 +51,7 @@ public class AsciiEncodingTest
     }
 
     @Test
-    public void shouldParseLong()
+    void shouldParseLong()
     {
         assertEquals(0L, parseLongAscii("0", 0, 1));
         assertEquals(0L, parseLongAscii("-0", 0, 2));
@@ -71,7 +74,7 @@ public class AsciiEncodingTest
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingIntegerWhichCanOverFlow()
+    void shouldThrowExceptionWhenParsingIntegerWhichCanOverFlow()
     {
         final String maxValuePlusOneDigit = Integer.MAX_VALUE + "1";
         assertThrows(AsciiNumberFormatException.class,
@@ -95,7 +98,7 @@ public class AsciiEncodingTest
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingLongWhichCanOverFlow()
+    void shouldThrowExceptionWhenParsingLongWhichCanOverFlow()
     {
         final String maxValuePlusOneDigit = Long.MAX_VALUE + "1";
         assertThrows(AsciiNumberFormatException.class,
@@ -119,44 +122,114 @@ public class AsciiEncodingTest
     }
 
     @Test
-    public void shouldThrowExceptionWhenDecodingCharNonNumericValue()
+    void shouldThrowExceptionWhenDecodingCharNonNumericValue()
     {
         assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.getDigit(0, 'a'));
     }
 
     @Test
-    public void shouldThrowExceptionWhenDecodingByteNonNumericValue()
+    void shouldThrowExceptionWhenDecodingByteNonNumericValue()
     {
         assertThrows(AsciiNumberFormatException.class, () -> AsciiEncoding.getDigit(0, (byte)'a'));
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingIntegerContainingLoneMinusSign()
+    void shouldThrowExceptionWhenParsingIntegerContainingLoneMinusSign()
     {
         assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("-", 0, 1));
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingLongContainingLoneMinusSign()
+    void shouldThrowExceptionWhenParsingLongContainingLoneMinusSign()
     {
         assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("-", 0, 1));
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingLongContainingLonePlusSign()
+    void shouldThrowExceptionWhenParsingLongContainingLonePlusSign()
     {
         assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("+", 0, 1));
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingEmptyInteger()
+    void shouldThrowExceptionWhenParsingEmptyInteger()
     {
         assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("", 0, 0));
     }
 
     @Test
-    public void shouldThrowExceptionWhenParsingEmptyLong()
+    void shouldThrowExceptionWhenParsingEmptyLong()
     {
         assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("", 0, 0));
+    }
+
+    @Test
+    void digitCountIntValue()
+    {
+        final int[] values =
+            { 9, 99, 999, 9_999, 99_999, 999_999, 9_999_999, 99_999_999, 999_999_999, Integer.MAX_VALUE };
+        for (int i = 0; i < values.length; i++)
+        {
+            assertEquals(i + 1, digitCount(values[i]));
+        }
+    }
+
+    @Test
+    void digitCountLongValue()
+    {
+        final long[] values =
+            {
+            9, 99, 999, 9_999, 99_999, 999_999, 9_999_999, 99_999_999, 999_999_999, 9_999_999_999L,
+            99_999_999_999L, 999_999_999_999L, 9_999_999_999_999L, 99_999_999_999_999L, 999999_999999999L,
+            9_999_999_999_999_999L, 99_999_999_999_999_999L, 999_999_999_999_999_999L, Long.MAX_VALUE
+            };
+        for (int i = 0; i < values.length; i++)
+        {
+            final int iter = i;
+            assertEquals(i + 1, digitCount(values[i]), () -> iter + " -> " + values[iter]);
+        }
+    }
+
+    // prints a lookup table for org.agrona.AsciiEncoding.digitCount(int)
+    @Test
+    @Ignore
+    void printDigitCountIntTable()
+    {
+        for (int i = 1; i < 33; i++)
+        {
+            final double smallest = Math.pow(2, i - 1);
+            final long log10 = (long)Math.ceil(Math.log10(smallest));
+            final long value = (long)((i < 31 ? (Math.pow(2, 32) - Math.pow(10, log10)) : 0) + (log10 << 32));
+            if (i != 1)
+            {
+                System.out.println(",");
+            }
+            System.out.print(value);
+            System.out.print("L");
+        }
+        System.out.println();
+    }
+
+    // prints a lookup table for org.agrona.AsciiEncoding.digitCount(long)
+    @Test
+    @Ignore
+    void printDigitCountLongTable()
+    {
+        final BigInteger[] pow10 = IntStream.rangeClosed(0, 19)
+            .mapToObj(BigInteger.TEN::pow)
+            .toArray(BigInteger[]::new);
+
+        for (int i = 0; i < 64; i++)
+        {
+            final int upper = i == 0 ? 0 : ((i * 1262611) >> 22) + 1;
+            final long value = ((long)(upper + 1) << 52) - pow10[upper].shiftRight(i / 4).longValue();
+            if (i != 0)
+            {
+                System.out.println(",");
+            }
+            System.out.print(value);
+            System.out.print("L");
+        }
+        System.out.println();
     }
 }


### PR DESCRIPTION
This PR based on the algorithm by Kendall Willets presented in [Computing the number of digits of an integer even faster](https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster/). It replaces existing `endOffset` methods with new `digitCount` methods that are branchless.

Here are the results of running `UnsafeBufferPutLongAsciiBenchmark`:
- Before
  ```
  JDK 8:
  Benchmark                                                 (value)  Mode  Cnt   Score   Error  Units
  UnsafeBufferPutLongAsciiBenchmark.benchmark  -9223372036854775808  avgt   30   5.728 ± 0.009  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                     0  avgt   30   3.154 ± 0.011  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                 -9182  avgt   30   6.683 ± 0.009  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark              97385146  avgt   30  10.186 ± 0.009  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark     -6180362504315475  avgt   30  18.686 ± 0.307  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark   9223372036854775807  avgt   30  20.517 ± 0.045  ns/op

  
  JDK 17:
  Benchmark                                                 (value)  Mode  Cnt   Score   Error  Units
  UnsafeBufferPutLongAsciiBenchmark.benchmark  -9223372036854775808  avgt   30   5.734 ± 0.010  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                     0  avgt   30   2.872 ± 0.007  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                 -9182  avgt   30   7.156 ± 0.006  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark              97385146  avgt   30  10.447 ± 0.019  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark     -6180362504315475  avgt   30  20.174 ± 0.060  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark   9223372036854775807  avgt   30  21.328 ± 0.362  ns/op
  ```
- After
  ```
  JDK 8:
  Benchmark                                                 (value)  Mode  Cnt   Score   Error  Units
  UnsafeBufferPutLongAsciiBenchmark.benchmark  -9223372036854775808  avgt   30   5.726 ± 0.006  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                     0  avgt   30   3.153 ± 0.021  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                 -9182  avgt   30   6.688 ± 0.010  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark              97385146  avgt   30  11.962 ± 0.191  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark     -6180362504315475  avgt   30  16.814 ± 0.217  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark   9223372036854775807  avgt   30  18.208 ± 0.042  ns/op

  JDK 17:
  Benchmark                                                 (value)  Mode  Cnt   Score   Error  Units
  UnsafeBufferPutLongAsciiBenchmark.benchmark  -9223372036854775808  avgt   30   5.882 ± 0.144  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                     0  avgt   30   2.874 ± 0.006  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark                 -9182  avgt   30   6.693 ± 0.005  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark              97385146  avgt   30  10.388 ± 0.019  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark     -6180362504315475  avgt   30  17.643 ± 0.062  ns/op
  UnsafeBufferPutLongAsciiBenchmark.benchmark   9223372036854775807  avgt   30  19.767 ± 0.091  ns/op
  ```

As can be seen from the above for the big number it gives about **10%** improvement.