### PR TITLE
[Java] Parse ASCII-encoded numbers in blocks of four/eight bytes at a time.

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -307,6 +307,56 @@ public final class AsciiEncoding
         return tally;
     }
 
+    /**
+     * Checks if the provided {@code value} represents an ASCII-encoded number which contains exactly four digits.
+     *
+     * @param value four ASCII-encoded bytes to check.
+     * @return {@code true} if the {@code value} is an ASCII-encoded number with four digits in it.
+     */
+    public static boolean isFourDigitsAsciiEncodedNumber(final int value)
+    {
+        return 0 == ((((value + 0x46464646) | (value - 0x30303030)) & 0x80808080));
+    }
+
+    /**
+     * Parses a four-digit number out of an ASCII-encoded value assuming little-endian byte order.
+     *
+     * @param bytes ASCII-encoded value in little-endian byte order.
+     * @return {@code int} value with four digits.
+     */
+    public static int parseFourDigitsLittleEndian(final int bytes)
+    {
+        int val = bytes & 0x0F0F0F0F;
+        val = (val * 10) + (val >> 8);
+        return ((val & 0x00FF00FF) * 6553601) >> 16;
+    }
+
+    /**
+     * Checks if the provided {@code value} represents an ASCII-encoded number which contains exactly eight digits.
+     *
+     * @param value eoght ASCII-encoded bytes to check.
+     * @return {@code true} if the {@code value} is an ASCII-encoded number with eight digits in it.
+     */
+    public static boolean isEightDigitAsciiEncodedNumber(final long value)
+    {
+        return 0L == ((((value + 0x4646464646464646L) | (value - 0x3030303030303030L)) & 0x8080808080808080L));
+    }
+
+    /**
+     * Parses an eight-digit number out of an ASCII-encoded value assuming little-endian byte order.
+     *
+     * @param bytes ASCII-encoded value in little-endian byte order.
+     * @return {@code int} value with eight digits.
+     */
+    public static int parseEightDigitsLittleEndian(final long bytes)
+    {
+        long val = bytes - 0x3030303030303030L;
+        val = (val * 10) + (val >> 8);
+        val = (((val & 0x000000FF000000FFL) * 0x000F424000000064L) +
+            (((val >> 16) & 0x000000FF000000FFL) * 0x0000271000000001L)) >> 32;
+        return (int)val;
+    }
+
     private static int parseSingleDigit(final CharSequence cs, final int index, final int length)
     {
         if (1 == length)

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -383,8 +383,7 @@ public final class AsciiEncoding
         final CharSequence cs, final int index, final int length, final int startIndex, final int end)
     {
         int i = startIndex;
-        int tally = 0;
-        int quartet;
+        int tally = 0, quartet;
         while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = readFourBytesLittleEndian(cs, i)))
         {
             tally = (tally * 10_000) + parseFourDigitsLittleEndian(quartet);

--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -84,11 +84,15 @@ public final class AsciiEncoding
         '9', '0', '9', '1', '9', '2', '9', '3', '9', '4', '9', '5', '9', '6', '9', '7', '9', '8', '9', '9'
     };
 
-    private static final byte[] MIN_INT_DIGITS = "2147483648".getBytes(US_ASCII);
-    private static final byte[] MAX_INT_DIGITS = "2147483647".getBytes(US_ASCII);
+    /**
+     * {@link Long#MAX_VALUE} split into components by 8 digits max.
+     */
+    public static final int[] LONG_MAX_VALUE_DIGITS = new int[]{ 92233720, 36854775, 807 };
 
-    private static final byte[] MIN_LONG_DIGITS = "9223372036854775808".getBytes(US_ASCII);
-    private static final byte[] MAX_LONG_DIGITS = "9223372036854775807".getBytes(US_ASCII);
+    /**
+     * {@link Long#MIN_VALUE} split into components by 8 digits max.
+     */
+    public static final int[] LONG_MIN_VALUE_DIGITS = new int[]{ 92233720, 36854775, 808 };
 
     private static final long[] INT_DIGITS =
     {
@@ -192,6 +196,17 @@ public final class AsciiEncoding
     }
 
     /**
+     * Check if the {@code value} is an ASCII-encoded digit.
+     *
+     * @param value ti be checked.
+     * @return {@code true} if the {@code value} is an ASCII-encoded digit.
+     */
+    public static boolean isDigit(final byte value)
+    {
+        return value >= 0x30 && value <= 0x39;
+    }
+
+    /**
      * Get the digit value of an ASCII encoded {@code byte}.
      *
      * @param index within the string the value is encoded.
@@ -234,37 +249,41 @@ public final class AsciiEncoding
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
      * @return the parsed value.
-     * @throws AsciiNumberFormatException if <code>cs</code> is not an int value
-     * @throws IndexOutOfBoundsException  if parsing results in access outside string boundaries, or length is negative
+     * @throws AsciiNumberFormatException if {@code length <= 0} or {@code cs} is not an int value
      */
     public static int parseIntAscii(final CharSequence cs, final int index, final int length)
     {
-        if (length <= 1)
+        if (length <= 0)
         {
-            return parseSingleDigit(cs, index, length);
+            throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
 
-        final boolean hasSign = cs.charAt(index) == MINUS_SIGN;
-        final int endExclusive = index + length;
-        int i = hasSign ? index + 1 : index;
-
-        if (length >= 10)
+        final boolean negative = MINUS_SIGN == cs.charAt(index);
+        int i = index;
+        if (negative)
         {
-            checkIntLimits(cs, index, length, i, hasSign);
+            i++;
+            if (1 == length)
+            {
+                throwParseIntError(cs, index, length);
+            }
         }
 
-        int tally = 0;
-        for (; i < endExclusive; i++)
+        final int end = index + length;
+        if (end - i < INT_MAX_DIGITS)
         {
-            tally = (tally * 10) + AsciiEncoding.getDigit(i, cs.charAt(i));
+            final int tally = parsePositiveIntAscii(cs, index, length, i, end);
+            return negative ? -tally : tally;
         }
-
-        if (hasSign)
+        else
         {
-            tally = -tally;
+            final long tally = parsePositiveIntAsciiOverflowCheck(cs, index, length, i, end);
+            if (tally > INTEGER_ABSOLUTE_MIN_VALUE || INTEGER_ABSOLUTE_MIN_VALUE == tally && !negative)
+            {
+                throwParseIntOverflowError(cs, index, length);
+            }
+            return (int)(negative ? -tally : tally);
         }
-
-        return tally;
     }
 
     /**
@@ -274,37 +293,40 @@ public final class AsciiEncoding
      * @param index  at which the number begins.
      * @param length of the encoded number in characters.
      * @return the parsed value.
-     * @throws AsciiNumberFormatException if <code>cs</code> is not a long value
-     * @throws IndexOutOfBoundsException  if parsing results in access outside string boundaries, or length is negative
+     * @throws AsciiNumberFormatException if {@code length <= 0} or {@code cs} is not a long value
      */
     public static long parseLongAscii(final CharSequence cs, final int index, final int length)
     {
-        if (length <= 1)
+        if (length <= 0)
         {
-            return parseSingleDigit(cs, index, length);
+            throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
 
-        final boolean hasSign = cs.charAt(index) == MINUS_SIGN;
-        final int endExclusive = index + length;
-        int i = hasSign ? index + 1 : index;
-
-        if (length >= 19)
+        final boolean negative = MINUS_SIGN == cs.charAt(index);
+        int i = index;
+        if (negative)
         {
-            checkLongLimits(cs, index, length, i, hasSign);
+            i++;
+            if (1 == length)
+            {
+                throwParseLongError(cs, index, length);
+            }
         }
 
-        long tally = 0;
-        for (; i < endExclusive; i++)
+        final int end = index + length;
+        if (end - i < LONG_MAX_DIGITS)
         {
-            tally = (tally * 10) + AsciiEncoding.getDigit(i, cs.charAt(i));
+            final long tally = parsePositiveLongAscii(cs, index, length, i, end);
+            return negative ? -tally : tally;
         }
-
-        if (hasSign)
+        else if (negative)
         {
-            tally = -tally;
+            return -parseLongAsciiOverflowCheck(cs, index, length, LONG_MIN_VALUE_DIGITS, i, end);
         }
-
-        return tally;
+        else
+        {
+            return parseLongAsciiOverflowCheck(cs, index, length, LONG_MAX_VALUE_DIGITS, i, end);
+        }
     }
 
     /**
@@ -357,86 +379,190 @@ public final class AsciiEncoding
         return (int)val;
     }
 
-    private static int parseSingleDigit(final CharSequence cs, final int index, final int length)
+    private static int parsePositiveIntAscii(
+        final CharSequence cs, final int index, final int length, final int startIndex, final int end)
     {
-        if (1 == length)
+        int i = startIndex;
+        int tally = 0;
+        int quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = readFourBytesLittleEndian(cs, i)))
         {
-            return AsciiEncoding.getDigit(index, cs.charAt(index));
+            tally = (tally * 10_000) + parseFourDigitsLittleEndian(quartet);
+            i += 4;
         }
-        else if (0 == length)
+
+        byte digit;
+        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
         {
-            throw new AsciiNumberFormatException("'' is not a valid digit @ " + index);
+            tally = (tally * 10) + (digit - 0x30);
+            i++;
         }
-        else
+
+        if (i != end)
         {
-            throw new IndexOutOfBoundsException("length=" + length);
+            throwParseIntError(cs, index, length);
         }
+
+        return tally;
     }
 
-    private static void checkIntLimits(
-        final CharSequence cs, final int index, final int length, final int i, final boolean hasSign)
+    private static long parsePositiveIntAsciiOverflowCheck(
+        final CharSequence cs, final int index, final int length, final int startIndex, final int end)
     {
-        if (10 == length)
+        if ((end - startIndex) > INT_MAX_DIGITS)
         {
-            if (!hasSign && isOverflow(MAX_INT_DIGITS, cs, i))
+            throwParseIntOverflowError(cs, index, length);
+        }
+
+        int i = startIndex;
+        long tally = 0;
+        final long octet = readEightBytesLittleEndian(cs, i);
+        if (isEightDigitAsciiEncodedNumber(octet))
+        {
+            tally = parseEightDigitsLittleEndian(octet);
+            i += 8;
+
+            byte digit;
+            while (i < end && isDigit(digit = (byte)cs.charAt(i)))
             {
-                throw new AsciiNumberFormatException("int overflow parsing: " + cs.subSequence(index, index + length));
+                tally = (tally * 10L) + (digit - 0x30);
+                i++;
             }
         }
-        else if (11 == length && hasSign)
+
+        if (i != end)
         {
-            if (isOverflow(MIN_INT_DIGITS, cs, i))
-            {
-                throw new AsciiNumberFormatException("int overflow parsing: " + cs.subSequence(index, index + length));
-            }
+            throwParseIntError(cs, index, length);
         }
-        else
-        {
-            throw new AsciiNumberFormatException("int overflow parsing: " + cs.subSequence(index, index + length));
-        }
+
+        return tally;
     }
 
-    private static void checkLongLimits(
-        final CharSequence cs, final int index, final int length, final int i, final boolean hasSign)
+    private static void throwParseIntError(final CharSequence cs, final int index, final int length)
     {
-        if (19 == length)
-        {
-            if (!hasSign && isOverflow(MAX_LONG_DIGITS, cs, i))
-            {
-                throw new AsciiNumberFormatException("long overflow parsing: " + cs.subSequence(index, index + length));
-            }
-        }
-        else if (20 == length && hasSign)
-        {
-            if (isOverflow(MIN_LONG_DIGITS, cs, i))
-            {
-                throw new AsciiNumberFormatException("long overflow parsing: " + cs.subSequence(index, index + length));
-            }
-        }
-        else
-        {
-            throw new AsciiNumberFormatException("long overflow parsing: " + cs.subSequence(index, index + length));
-        }
+        throw new AsciiNumberFormatException("error parsing int: " + cs.subSequence(index, index + length));
     }
 
-    private static boolean isOverflow(final byte[] limitDigits, final CharSequence cs, final int index)
+    private static void throwParseIntOverflowError(final CharSequence cs, final int index, final int length)
     {
-        for (int i = 0; i < limitDigits.length; i++)
+        throw new AsciiNumberFormatException("int overflow parsing: " + cs.subSequence(index, index + length));
+    }
+
+    private static long parsePositiveLongAscii(
+        final CharSequence cs, final int index, final int length, final int startIndex, final int end)
+    {
+        int i = startIndex;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = readEightBytesLittleEndian(cs, i)))
         {
-            final int digit = AsciiEncoding.getDigit(i, cs.charAt(index + i));
-            final int limitDigit = limitDigits[i] - 0x30;
-
-            if (digit < limitDigit)
-            {
-                break;
-            }
-
-            if (digit > limitDigit)
-            {
-                return true;
-            }
+            tally = (tally * 100_000_000L) + parseEightDigitsLittleEndian(octet);
+            i += 8;
         }
 
-        return false;
+        int quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = readFourBytesLittleEndian(cs, i)))
+        {
+            tally = (tally * 10_000L) + parseFourDigitsLittleEndian(quartet);
+            i += 4;
+        }
+
+        byte digit;
+        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+        {
+            tally = (tally * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(cs, index, length);
+        }
+
+        return tally;
+    }
+
+    private static long parseLongAsciiOverflowCheck(
+        final CharSequence cs,
+        final int index,
+        final int length,
+        final int[] maxValue,
+        final int startIndex,
+        final int end)
+    {
+        if ((end - startIndex) > LONG_MAX_DIGITS)
+        {
+            throwParseLongOverflowError(cs, index, length);
+        }
+
+        int i = startIndex, k = 0;
+        boolean checkOverflow = true;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = readEightBytesLittleEndian(cs, i)))
+        {
+            final int eightDigits = parseEightDigitsLittleEndian(octet);
+            if (checkOverflow)
+            {
+                if (eightDigits > maxValue[k])
+                {
+                    throwParseLongOverflowError(cs, index, length);
+                }
+                else if (eightDigits < maxValue[k])
+                {
+                    checkOverflow = false;
+                }
+                k++;
+            }
+            tally = (tally * 100_000_000L) + eightDigits;
+            i += 8;
+        }
+
+        byte digit;
+        int lastDigits = 0;
+        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+        {
+            lastDigits = (lastDigits * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(cs, index, length);
+        }
+        else if (checkOverflow && lastDigits > maxValue[k])
+        {
+            throwParseLongOverflowError(cs, index, length);
+        }
+
+        return (tally * 1000L) + lastDigits;
+    }
+
+    private static void throwParseLongError(final CharSequence cs, final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("error parsing long: " + cs.subSequence(index, index + length));
+    }
+
+    private static void throwParseLongOverflowError(final CharSequence cs, final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("long overflow parsing: " + cs.subSequence(index, index + length));
+    }
+
+    private static int readFourBytesLittleEndian(final CharSequence cs, final int index)
+    {
+        return cs.charAt(index + 3) << 24 |
+            cs.charAt(index + 2) << 16 |
+            cs.charAt(index + 1) << 8 |
+            cs.charAt(index);
+    }
+
+    private static long readEightBytesLittleEndian(final CharSequence cs, final int index)
+    {
+        return (long)cs.charAt(index + 7) << 56 |
+            (long)cs.charAt(index + 6) << 48 |
+            (long)cs.charAt(index + 5) << 40 |
+            (long)cs.charAt(index + 4) << 32 |
+            (long)cs.charAt(index + 3) << 24 |
+            (long)cs.charAt(index + 2) << 16 |
+            cs.charAt(index + 1) << 8 |
+            cs.charAt(index);
     }
 }

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -1542,17 +1542,15 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
     {
         final byte[] src = byteArray;
         int i = startIndex;
-        int tally = 0;
-        int bytes;
-
-        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(bytes = UNSAFE.getInt(src, ARRAY_BASE_OFFSET + i)))
+        int tally = 0, quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(src, ARRAY_BASE_OFFSET + i)))
         {
             if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
             {
-                bytes = Integer.reverseBytes(bytes);
+                quartet = Integer.reverseBytes(quartet);
             }
 
-            tally = (tally * 10_000) + parseFourDigitsLittleEndian(bytes);
+            tally = (tally * 10_000) + parseFourDigitsLittleEndian(quartet);
             i += 4;
         }
 
@@ -1581,15 +1579,15 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
 
         final byte[] src = byteArray;
         int i = startIndex;
-        long rawBytes = UNSAFE.getLong(src, ARRAY_BASE_OFFSET + i);
         long tally = 0;
-        if (isEightDigitAsciiEncodedNumber(rawBytes))
+        long octet = UNSAFE.getLong(src, ARRAY_BASE_OFFSET + i);
+        if (isEightDigitAsciiEncodedNumber(octet))
         {
             if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
             {
-                rawBytes = Long.reverseBytes(rawBytes);
+                octet = Long.reverseBytes(octet);
             }
-            tally = parseEightDigitsLittleEndian(rawBytes);
+            tally = parseEightDigitsLittleEndian(octet);
             i += 8;
 
             byte digit;

--- a/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableArrayBuffer.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.agrona.AsciiEncoding.*;
@@ -1115,35 +1116,17 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (length > INT_MAX_DIGITS)
-        {
-            throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
-        }
 
-        final byte[] src = byteArray;
-        final int firstDigit = AsciiEncoding.getDigit(index, src[index]);
-
-        if (length < INT_MAX_DIGITS || firstDigit < 2)
+        if (length < INT_MAX_DIGITS)
         {
-            int tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10) + AsciiEncoding.getDigit(i, src[i]);
-            }
-            return tally;
+            return parsePositiveIntAscii(index, length, index, index + length);
         }
         else
         {
-            long tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, src[i]);
-            }
-
+            final long tally = parsePositiveIntAsciiOverflowCheck(index, length, index, index + length);
             if (tally >= INTEGER_ABSOLUTE_MIN_VALUE)
             {
-                throw new AsciiNumberFormatException("int overflow parsing: " +
-                    getStringWithoutLengthAscii(index, length));
+                throwParseIntOverflowError(index, length);
             }
             return (int)tally;
         }
@@ -1160,27 +1143,14 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (length > LONG_MAX_DIGITS)
-        {
-            throw new AsciiNumberFormatException("long overflow parsing: " +
-                getStringWithoutLengthAscii(index, length));
-        }
 
-        final byte[] src = byteArray;
-        final int firstDigit = AsciiEncoding.getDigit(index, src[index]);
-
-        if (length < LONG_MAX_DIGITS || firstDigit < 9)
+        if (length < LONG_MAX_DIGITS)
         {
-            long tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, src[i]);
-            }
-            return tally;
+            return parsePositiveLongAscii(index, length, index, index + length);
         }
         else
         {
-            return parseLongAsciiOverflowCheck(index, length, src, MAX_LONG_VALUE, 1, firstDigit);
+            return parseLongAsciiOverflowCheck(index, length, LONG_MAX_VALUE_DIGITS, index, index + length);
         }
     }
 
@@ -1195,53 +1165,33 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (1 == length)
+
+        final boolean negative = MINUS_SIGN == byteArray[index];
+        int i = index;
+        if (negative)
         {
-            return AsciiEncoding.getDigit(index, byteArray[index]);
+            i++;
+            if (1 == length)
+            {
+                throwParseIntError(index, length);
+            }
         }
 
-        final byte[] src = byteArray;
-        final byte first = src[index];
-        final boolean negativeValue = MINUS_SIGN == first;
-        final int digitCount;
-        final int firstDigit;
-        int i = index + 1;
-        if (negativeValue)
+        final int end = index + length;
+        if (end - i < INT_MAX_DIGITS)
         {
-            digitCount = length - 1;
-            firstDigit = getDigit(i, src[i]);
-            i++;
+            final int tally = parsePositiveIntAscii(index, length, i, end);
+            return negative ? -tally : tally;
         }
         else
         {
-            digitCount = length;
-            firstDigit = getDigit(index, first);
-        }
-
-        if (digitCount < INT_MAX_DIGITS || INT_MAX_DIGITS == digitCount && firstDigit < 2)
-        {
-            int tally = firstDigit;
-            for (int end = index + length; i < end; i++)
+            final long tally = parsePositiveIntAsciiOverflowCheck(index, length, i, end);
+            if (tally > INTEGER_ABSOLUTE_MIN_VALUE || INTEGER_ABSOLUTE_MIN_VALUE == tally && !negative)
             {
-                tally = (tally * 10) + AsciiEncoding.getDigit(i, src[i]);
+                throwParseIntOverflowError(index, length);
             }
-            return negativeValue ? -tally : tally;
+            return (int)(negative ? -tally : tally);
         }
-        else if (INT_MAX_DIGITS == digitCount)
-        {
-            long tally = firstDigit;
-            for (int end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, src[i]);
-            }
-
-            if (tally < INTEGER_ABSOLUTE_MIN_VALUE || tally == INTEGER_ABSOLUTE_MIN_VALUE && negativeValue)
-            {
-                return (int)(negativeValue ? -tally : tally);
-            }
-        }
-
-        throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     /**
@@ -1255,51 +1205,32 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (1 == length)
+
+        final boolean negative = MINUS_SIGN == byteArray[index];
+        int i = index;
+        if (negative)
         {
-            return AsciiEncoding.getDigit(index, byteArray[index]);
+            i++;
+            if (1 == length)
+            {
+                throwParseLongError(index, length);
+            }
         }
 
-        final byte[] src = byteArray;
-        final byte first = src[index];
-        final boolean negativeValue = MINUS_SIGN == first;
-        final int digitCount;
-        final int firstDigit;
-        int i = index + 1;
-        if (negativeValue)
+        final int end = index + length;
+        if (end - i < LONG_MAX_DIGITS)
         {
-            digitCount = length - 1;
-            firstDigit = getDigit(i, src[i]);
-            i++;
+            final long tally = parsePositiveLongAscii(index, length, i, end);
+            return negative ? -tally : tally;
+        }
+        else if (negative)
+        {
+            return -parseLongAsciiOverflowCheck(index, length, LONG_MIN_VALUE_DIGITS, i, end);
         }
         else
         {
-            digitCount = length;
-            firstDigit = getDigit(index, first);
+            return parseLongAsciiOverflowCheck(index, length, LONG_MAX_VALUE_DIGITS, i, end);
         }
-
-        if (digitCount < LONG_MAX_DIGITS || LONG_MAX_DIGITS == digitCount && firstDigit < 9)
-        {
-            long tally = firstDigit;
-            for (int end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, src[i]);
-            }
-            return negativeValue ? -tally : tally;
-        }
-        else if (LONG_MAX_DIGITS == digitCount)
-        {
-            if (negativeValue)
-            {
-                return -parseLongAsciiOverflowCheck(index, length, src, MIN_LONG_VALUE, 2, firstDigit);
-            }
-            else
-            {
-                return parseLongAsciiOverflowCheck(index, length, src, MAX_LONG_VALUE, 1, firstDigit);
-            }
-        }
-
-        throw new AsciiNumberFormatException("long overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     /**
@@ -1607,34 +1538,197 @@ public class ExpandableArrayBuffer implements MutableDirectBuffer
         }
     }
 
+    private int parsePositiveIntAscii(final int index, final int length, final int startIndex, final int end)
+    {
+        final byte[] src = byteArray;
+        int i = startIndex;
+        int tally = 0;
+        int bytes;
+
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(bytes = UNSAFE.getInt(src, ARRAY_BASE_OFFSET + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                bytes = Integer.reverseBytes(bytes);
+            }
+
+            tally = (tally * 10_000) + parseFourDigitsLittleEndian(bytes);
+            i += 4;
+        }
+
+        byte digit;
+        while (i < end && isDigit(digit = UNSAFE.getByte(src, ARRAY_BASE_OFFSET + i)))
+        {
+            tally = (tally * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseIntError(index, length);
+        }
+
+        return tally;
+    }
+
+    private long parsePositiveIntAsciiOverflowCheck(
+        final int index, final int length, final int startIndex, final int end)
+    {
+        if ((end - startIndex) > INT_MAX_DIGITS)
+        {
+            throwParseIntOverflowError(index, length);
+        }
+
+        final byte[] src = byteArray;
+        int i = startIndex;
+        long rawBytes = UNSAFE.getLong(src, ARRAY_BASE_OFFSET + i);
+        long tally = 0;
+        if (isEightDigitAsciiEncodedNumber(rawBytes))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                rawBytes = Long.reverseBytes(rawBytes);
+            }
+            tally = parseEightDigitsLittleEndian(rawBytes);
+            i += 8;
+
+            byte digit;
+            while (i < end && isDigit(digit = UNSAFE.getByte(src, ARRAY_BASE_OFFSET + i)))
+            {
+                tally = (tally * 10) + (digit - 0x30);
+                i++;
+            }
+        }
+
+        if (i != end)
+        {
+            throwParseIntError(index, length);
+        }
+
+        return tally;
+    }
+
+    private void throwParseIntError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("error parsing int: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private void throwParseIntOverflowError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private long parsePositiveLongAscii(final int index, final int length, final int startIndex, final int end)
+    {
+        final byte[] src = byteArray;
+        int i = startIndex;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = UNSAFE.getLong(src, ARRAY_BASE_OFFSET + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                octet = Long.reverseBytes(octet);
+            }
+
+            tally = (tally * 100_000_000L) + parseEightDigitsLittleEndian(octet);
+            i += 8;
+        }
+
+        int quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(src, ARRAY_BASE_OFFSET + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                quartet = Integer.reverseBytes(quartet);
+            }
+
+            tally = (tally * 10_000L) + parseFourDigitsLittleEndian(quartet);
+            i += 4;
+        }
+
+        byte digit;
+        while (i < end && isDigit(digit = UNSAFE.getByte(src, ARRAY_BASE_OFFSET + i)))
+        {
+            tally = (tally * 10L) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(index, length);
+        }
+
+        return tally;
+    }
+
     private long parseLongAsciiOverflowCheck(
         final int index,
         final int length,
-        final byte[] src,
-        final byte[] maxValue,
-        final int position,
-        final int first)
+        final int[] maxValue,
+        final int startIndex,
+        final int end)
     {
-        long tally = first;
-        boolean checkOverflow = true;
-        for (int i = index + position, end = index + length; i < end; i++)
+        if ((end - startIndex) > LONG_MAX_DIGITS)
         {
-            final byte b = src[i];
+            throwParseLongOverflowError(index, length);
+        }
+
+        final byte[] src = byteArray;
+        int i = startIndex, k = 0;
+        boolean checkOverflow = true;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = UNSAFE.getLong(src, ARRAY_BASE_OFFSET + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                octet = Long.reverseBytes(octet);
+            }
+
+            final int eightDigits = parseEightDigitsLittleEndian(octet);
             if (checkOverflow)
             {
-                if (b > maxValue[i - index])
+                if (eightDigits > maxValue[k])
                 {
-                    throw new AsciiNumberFormatException("long overflow parsing: " +
-                        getStringWithoutLengthAscii(index, length));
+                    throwParseLongOverflowError(index, length);
                 }
-                else if (b < maxValue[i - index])
+                else if (eightDigits < maxValue[k])
                 {
                     checkOverflow = false;
                 }
+                k++;
             }
-            tally = (tally * 10L) + AsciiEncoding.getDigit(i, b);
+            tally = (tally * 100_000_000L) + eightDigits;
+            i += 8;
         }
-        return tally;
+
+        byte digit;
+        int lastDigits = 0;
+        while (i < end && isDigit(digit = UNSAFE.getByte(src, ARRAY_BASE_OFFSET + i)))
+        {
+            lastDigits = (lastDigits * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(index, length);
+        }
+        else if (checkOverflow && lastDigits > maxValue[k])
+        {
+            throwParseLongOverflowError(index, length);
+        }
+
+        return (tally * 1000L) + lastDigits;
+    }
+
+    private void throwParseLongError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("error parsing long: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private void throwParseLongOverflowError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("long overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     private static void putPositiveIntAscii(final byte[] dest, final int offset, final int value, final int digitCount)

--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -1600,8 +1600,7 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
     {
         final long offset = address;
         int i = startIndex;
-        int tally = 0;
-        int quartet;
+        int tally = 0, quartet;
         while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(null, offset + i)))
         {
             if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)

--- a/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
+++ b/agrona/src/main/java/org/agrona/ExpandableDirectByteBuffer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.agrona.AsciiEncoding.*;
@@ -1152,35 +1153,17 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (length > INT_MAX_DIGITS)
-        {
-            throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
-        }
 
-        final long offset = address;
-        final int firstDigit = AsciiEncoding.getDigit(index, UNSAFE.getByte(null, offset + index));
-
-        if (length < INT_MAX_DIGITS || firstDigit < 2)
+        if (length < INT_MAX_DIGITS)
         {
-            int tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
-            }
-            return tally;
+            return parsePositiveIntAscii(index, length, index, index + length);
         }
         else
         {
-            long tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
-            }
-
+            final long tally = parsePositiveIntAsciiOverflowCheck(index, length, index, index + length);
             if (tally >= INTEGER_ABSOLUTE_MIN_VALUE)
             {
-                throw new AsciiNumberFormatException("int overflow parsing: " +
-                    getStringWithoutLengthAscii(index, length));
+                throwParseIntOverflowError(index, length);
             }
             return (int)tally;
         }
@@ -1197,27 +1180,14 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (length > LONG_MAX_DIGITS)
-        {
-            throw new AsciiNumberFormatException("long overflow parsing: " +
-                getStringWithoutLengthAscii(index, length));
-        }
 
-        final long offset = address;
-        final int firstDigit = AsciiEncoding.getDigit(index, UNSAFE.getByte(null, offset + index));
-
-        if (length < LONG_MAX_DIGITS || firstDigit < 9)
+        if (length < LONG_MAX_DIGITS)
         {
-            long tally = firstDigit;
-            for (int i = index + 1, end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
-            }
-            return tally;
+            return parsePositiveLongAscii(index, length, index, index + length);
         }
         else
         {
-            return parseLongAsciiOverflowCheck(index, length, offset, MAX_LONG_VALUE, 1, firstDigit);
+            return parseLongAsciiOverflowCheck(index, length, LONG_MAX_VALUE_DIGITS, index, index + length);
         }
     }
 
@@ -1232,53 +1202,33 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (1 == length)
+
+        final boolean negative = MINUS_SIGN == UNSAFE.getByte(null, address + index);
+        int i = index;
+        if (negative)
         {
-            return AsciiEncoding.getDigit(index, UNSAFE.getByte(null, address + index));
+            i++;
+            if (1 == length)
+            {
+                throwParseIntError(index, length);
+            }
         }
 
-        final long offset = address;
-        final byte first = UNSAFE.getByte(null, offset + index);
-        final boolean negativeValue = MINUS_SIGN == first;
-        final int digitCount;
-        final int firstDigit;
-        int i = index + 1;
-        if (negativeValue)
+        final int end = index + length;
+        if (end - i < INT_MAX_DIGITS)
         {
-            digitCount = length - 1;
-            firstDigit = getDigit(i, UNSAFE.getByte(null, offset + i));
-            i++;
+            final int tally = parsePositiveIntAscii(index, length, i, end);
+            return negative ? -tally : tally;
         }
         else
         {
-            digitCount = length;
-            firstDigit = getDigit(index, first);
-        }
-
-        if (digitCount < INT_MAX_DIGITS || INT_MAX_DIGITS == digitCount && firstDigit < 2)
-        {
-            int tally = firstDigit;
-            for (int end = index + length; i < end; i++)
+            final long tally = parsePositiveIntAsciiOverflowCheck(index, length, i, end);
+            if (tally > INTEGER_ABSOLUTE_MIN_VALUE || INTEGER_ABSOLUTE_MIN_VALUE == tally && !negative)
             {
-                tally = (tally * 10) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
+                throwParseIntOverflowError(index, length);
             }
-            return negativeValue ? -tally : tally;
+            return (int)(negative ? -tally : tally);
         }
-        else if (INT_MAX_DIGITS == digitCount)
-        {
-            long tally = firstDigit;
-            for (int end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
-            }
-
-            if (tally < INTEGER_ABSOLUTE_MIN_VALUE || tally == INTEGER_ABSOLUTE_MIN_VALUE && negativeValue)
-            {
-                return (int)(negativeValue ? -tally : tally);
-            }
-        }
-
-        throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     /**
@@ -1292,51 +1242,32 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         {
             throw new AsciiNumberFormatException("empty string: index=" + index + " length=" + length);
         }
-        else if (1 == length)
+
+        final boolean negative = MINUS_SIGN == UNSAFE.getByte(null, address + index);
+        int i = index;
+        if (negative)
         {
-            return AsciiEncoding.getDigit(index, UNSAFE.getByte(null, address + index));
+            i++;
+            if (1 == length)
+            {
+                throwParseLongError(index, length);
+            }
         }
 
-        final long offset = address;
-        final byte first = UNSAFE.getByte(null, offset + index);
-        final boolean negativeValue = MINUS_SIGN == first;
-        final int digitCount;
-        final int firstDigit;
-        int i = index + 1;
-        if (negativeValue)
+        final int end = index + length;
+        if (end - i < LONG_MAX_DIGITS)
         {
-            digitCount = length - 1;
-            firstDigit = getDigit(i, UNSAFE.getByte(null, offset + i));
-            i++;
+            final long tally = parsePositiveLongAscii(index, length, i, end);
+            return negative ? -tally : tally;
+        }
+        else if (negative)
+        {
+            return -parseLongAsciiOverflowCheck(index, length, LONG_MIN_VALUE_DIGITS, i, end);
         }
         else
         {
-            digitCount = length;
-            firstDigit = getDigit(index, first);
+            return parseLongAsciiOverflowCheck(index, length, LONG_MAX_VALUE_DIGITS, i, end);
         }
-
-        if (digitCount < LONG_MAX_DIGITS || LONG_MAX_DIGITS == digitCount && firstDigit < 9)
-        {
-            long tally = firstDigit;
-            for (int end = index + length; i < end; i++)
-            {
-                tally = (tally * 10L) + AsciiEncoding.getDigit(i, UNSAFE.getByte(null, offset + i));
-            }
-            return negativeValue ? -tally : tally;
-        }
-        else if (LONG_MAX_DIGITS == digitCount)
-        {
-            if (negativeValue)
-            {
-                return -parseLongAsciiOverflowCheck(index, length, offset, MIN_LONG_VALUE, 2, firstDigit);
-            }
-            else
-            {
-                return parseLongAsciiOverflowCheck(index, length, offset, MAX_LONG_VALUE, 1, firstDigit);
-            }
-        }
-
-        throw new AsciiNumberFormatException("long overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     /**
@@ -1664,34 +1595,197 @@ public class ExpandableDirectByteBuffer implements MutableDirectBuffer
         }
     }
 
+    private int parsePositiveIntAscii(
+        final int index, final int length, final int startIndex, final int end)
+    {
+        final long offset = address;
+        int i = startIndex;
+        int tally = 0;
+        int quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(null, offset + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                quartet = Integer.reverseBytes(quartet);
+            }
+
+            tally = (tally * 10_000) + parseFourDigitsLittleEndian(quartet);
+            i += 4;
+        }
+
+        byte digit;
+        while (i < end && isDigit(digit = UNSAFE.getByte(null, offset + i)))
+        {
+            tally = (tally * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseIntError(index, length);
+        }
+
+        return tally;
+    }
+
+    private long parsePositiveIntAsciiOverflowCheck(
+        final int index, final int length, final int startIndex, final int end)
+    {
+        if ((end - startIndex) > INT_MAX_DIGITS)
+        {
+            throwParseIntOverflowError(index, length);
+        }
+
+        final long offset = address;
+        int i = startIndex;
+        long tally = 0;
+        long octet = UNSAFE.getLong(null, offset + i);
+        if (isEightDigitAsciiEncodedNumber(octet))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                octet = Long.reverseBytes(octet);
+            }
+            tally = parseEightDigitsLittleEndian(octet);
+            i += 8;
+
+            byte digit;
+            while (i < end && isDigit(digit = UNSAFE.getByte(null, offset + i)))
+            {
+                tally = (tally * 10L) + (digit - 0x30);
+                i++;
+            }
+        }
+
+        if (i != end)
+        {
+            throwParseIntError(index, length);
+        }
+
+        return tally;
+    }
+
+    private void throwParseIntError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("error parsing int: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private void throwParseIntOverflowError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("int overflow parsing: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private long parsePositiveLongAscii(final int index, final int length, final int startIndex, final int end)
+    {
+        final long offset = address;
+        int i = startIndex;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = UNSAFE.getLong(null, offset + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                octet = Long.reverseBytes(octet);
+            }
+
+            tally = (tally * 100_000_000L) + parseEightDigitsLittleEndian(octet);
+            i += 8;
+        }
+
+        int quartet;
+        while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(null, offset + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                quartet = Integer.reverseBytes(quartet);
+            }
+
+            tally = (tally * 10_000L) + parseFourDigitsLittleEndian(quartet);
+            i += 4;
+        }
+
+        byte digit;
+        while (i < end && isDigit(digit = UNSAFE.getByte(null, offset + i)))
+        {
+            tally = (tally * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(index, length);
+        }
+
+        return tally;
+    }
+
     private long parseLongAsciiOverflowCheck(
         final int index,
         final int length,
-        final long offset,
-        final byte[] maxValue,
-        final int position,
-        final int first)
+        final int[] maxValue,
+        final int startIndex,
+        final int end)
     {
-        long tally = first;
-        boolean checkOverflow = true;
-        for (int i = index + position, end = index + length; i < end; i++)
+        if ((end - startIndex) > LONG_MAX_DIGITS)
         {
-            final byte b = UNSAFE.getByte(null, offset + i);
+            throwParseLongOverflowError(index, length);
+        }
+
+        final long offset = address;
+        int i = startIndex, k = 0;
+        boolean checkOverflow = true;
+        long tally = 0, octet;
+        while ((end - i) >= 8 && isEightDigitAsciiEncodedNumber(octet = UNSAFE.getLong(null, offset + i)))
+        {
+            if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)
+            {
+                octet = Long.reverseBytes(octet);
+            }
+
+            final int eightDigits = parseEightDigitsLittleEndian(octet);
             if (checkOverflow)
             {
-                if (b > maxValue[i - index])
+                if (eightDigits > maxValue[k])
                 {
-                    throw new AsciiNumberFormatException("long overflow parsing: " +
-                        getStringWithoutLengthAscii(index, length));
+                    throwParseLongOverflowError(index, length);
                 }
-                else if (b < maxValue[i - index])
+                else if (eightDigits < maxValue[k])
                 {
                     checkOverflow = false;
                 }
+                k++;
             }
-            tally = (tally * 10L) + AsciiEncoding.getDigit(i, b);
+            tally = (tally * 100_000_000L) + eightDigits;
+            i += 8;
         }
-        return tally;
+
+        byte digit;
+        int lastDigits = 0;
+        while (i < end && isDigit(digit = UNSAFE.getByte(null, offset + i)))
+        {
+            lastDigits = (lastDigits * 10) + (digit - 0x30);
+            i++;
+        }
+
+        if (i != end)
+        {
+            throwParseLongError(index, length);
+        }
+        else if (checkOverflow && lastDigits > maxValue[k])
+        {
+            throwParseLongOverflowError(index, length);
+        }
+
+        return (tally * 1000L) + lastDigits;
+    }
+
+    private void throwParseLongError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("error parsing long: " + getStringWithoutLengthAscii(index, length));
+    }
+
+    private void throwParseLongOverflowError(final int index, final int length)
+    {
+        throw new AsciiNumberFormatException("long overflow parsing: " + getStringWithoutLengthAscii(index, length));
     }
 
     private static void putPositiveIntAscii(

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -2228,8 +2228,7 @@ public class UnsafeBuffer implements AtomicBuffer
         final long offset = addressOffset;
         final byte[] src = byteArray;
         int i = startIndex;
-        int tally = 0;
-        int quartet;
+        int tally = 0, quartet;
         while ((end - i) >= 4 && isFourDigitsAsciiEncodedNumber(quartet = UNSAFE.getInt(src, offset + i)))
         {
             if (NATIVE_BYTE_ORDER != LITTLE_ENDIAN)

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -15,15 +15,17 @@
  */
 package org.agrona;
 
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.util.stream.IntStream;
 
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.AsciiEncoding.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AsciiEncodingTest
 {
@@ -235,5 +237,81 @@ class AsciiEncodingTest
             System.out.print("L");
         }
         System.out.println();
+    }
+
+    @Test
+    void shouldDetectFourDigitsAsciiEncodedNumbers()
+    {
+        final int index = 2;
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[8]);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            buffer.putIntAscii(index, i);
+            assertFalse(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, LITTLE_ENDIAN)));
+            assertFalse(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, BIG_ENDIAN)));
+        }
+
+        for (int i = 1000; i < 10000; i++)
+        {
+            buffer.putIntAscii(index, i);
+            assertTrue(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, LITTLE_ENDIAN)));
+            assertTrue(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, BIG_ENDIAN)));
+        }
+
+        buffer.putIntAscii(index, 1234);
+        buffer.putByte(index, (byte)'a');
+        assertFalse(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, LITTLE_ENDIAN)));
+        assertFalse(isFourDigitsAsciiEncodedNumber(buffer.getInt(index, BIG_ENDIAN)));
+    }
+
+    @Test
+    void shouldParseFourDigitsFromAnAsciiEncodedNumberInLittleEndianByteOrder()
+    {
+        final int index = 2;
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[8]);
+
+        for (int i = 1000; i < 10000; i++)
+        {
+            buffer.putIntAscii(index, i);
+            final int bytes = buffer.getInt(index, LITTLE_ENDIAN);
+            assertEquals(i, parseFourDigitsLittleEndian(bytes));
+        }
+    }
+
+    @Test
+    void shouldDetectEightDigitsAsciiEncodedNumbers()
+    {
+        final int index = 4;
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[16]);
+
+        buffer.putIntAscii(index, 1234);
+        assertFalse(isEightDigitAsciiEncodedNumber(buffer.getLong(index, LITTLE_ENDIAN)));
+        assertFalse(isEightDigitAsciiEncodedNumber(buffer.getLong(index, BIG_ENDIAN)));
+
+        for (int i = 10_000_000; i < 100_000_000; i += 111)
+        {
+            buffer.putLongAscii(index, i);
+            assertTrue(isEightDigitAsciiEncodedNumber(buffer.getLong(index, LITTLE_ENDIAN)));
+            assertTrue(isEightDigitAsciiEncodedNumber(buffer.getLong(index, BIG_ENDIAN)));
+        }
+
+        buffer.putByte(index, (byte)'a');
+        assertFalse(isEightDigitAsciiEncodedNumber(buffer.getLong(index, LITTLE_ENDIAN)));
+        assertFalse(isEightDigitAsciiEncodedNumber(buffer.getLong(index, BIG_ENDIAN)));
+    }
+
+    @Test
+    void shouldParseEightDigitsFromAnAsciiEncodedNumberInLittleEndianByteOrder()
+    {
+        final int index = 3;
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[16]);
+
+        for (int i = 10_000_000; i < 100_000_000; i += 111)
+        {
+            buffer.putIntAscii(index, i);
+            final long bytes = buffer.getLong(index, LITTLE_ENDIAN);
+            assertEquals(i, parseEightDigitsLittleEndian(bytes));
+        }
     }
 }

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -18,8 +18,11 @@ package org.agrona;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
@@ -29,6 +32,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class AsciiEncodingTest
 {
+    private static final int ITERATIONS = 1_000_000;
+
     @Test
     void shouldParseInt()
     {
@@ -153,16 +158,18 @@ class AsciiEncodingTest
         assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("+", 0, 1));
     }
 
-    @Test
-    void shouldThrowExceptionWhenParsingEmptyInteger()
+    @ParameterizedTest
+    @ValueSource(ints = { -3, 0 })
+    void shouldThrowExceptionWhenParsingEmptyInteger(final int length)
     {
-        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("", 0, 0));
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("123", 0, length));
     }
 
-    @Test
-    void shouldThrowExceptionWhenParsingEmptyLong()
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 0 })
+    void shouldThrowExceptionWhenParsingEmptyLong(final int length)
     {
-        assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("", 0, 0));
+        assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("900000", 0, length));
     }
 
     @Test
@@ -312,6 +319,65 @@ class AsciiEncodingTest
             buffer.putIntAscii(index, i);
             final long bytes = buffer.getLong(index, LITTLE_ENDIAN);
             assertEquals(i, parseEightDigitsLittleEndian(bytes));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(bytes = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' })
+    void isDigitReturnsTrueForAsciiEncodedDigits(final byte value)
+    {
+        assertTrue(isDigit(value));
+    }
+
+    @Test
+    void isDigitReturnsFalseForAnyOtherByte()
+    {
+        for (int i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++)
+        {
+            final byte value = (byte)i;
+            if (value >= 0x30 && value <= 0x39)
+            {
+                continue;
+            }
+            assertFalse(isDigit(value), () -> Integer.toHexString(value));
+        }
+    }
+
+    @Test
+    void parseIntAsciiRoundTrip()
+    {
+        final String prefix = "testInt";
+        final StringBuilder buffer = new StringBuilder(24);
+        buffer.append(prefix);
+
+        for (int i = 0; i < ITERATIONS; i++)
+        {
+            final int value = ThreadLocalRandom.current().nextInt();
+            buffer.append(value);
+
+            final int parsedValue = parseIntAscii(buffer, prefix.length(), buffer.length() - prefix.length());
+
+            assertEquals(parsedValue, value);
+            buffer.delete(prefix.length(), 24);
+        }
+    }
+
+    @Test
+    void parseLongAsciiRoundTrip()
+    {
+        final String prefix = "long to test";
+        final StringBuilder buffer = new StringBuilder(64);
+        buffer.append(prefix);
+
+        for (int i = 0; i < ITERATIONS; i++)
+        {
+            final long value = ThreadLocalRandom.current().nextLong();
+            buffer.append(value);
+
+            final long parsedValue = parseLongAscii(buffer, prefix.length(), buffer.length() - prefix.length());
+
+            assertEquals(parsedValue, value);
+            buffer.delete(prefix.length(), 64);
         }
     }
 }

--- a/agrona/src/test/java/org/agrona/MutableDirectBufferTests.java
+++ b/agrona/src/test/java/org/agrona/MutableDirectBufferTests.java
@@ -180,8 +180,7 @@ public abstract class MutableDirectBufferTests
 
     @ParameterizedTest
     @MethodSource("nonParsableIntValues")
-    void parseIntAsciiThrowsAsciiNumberFormatExceptionIfValueContainsInvalidCharacters(
-        final String value, final int baseIndex)
+    void parseIntAsciiThrowsAsciiNumberFormatExceptionIfValueContainsInvalidCharacters(final String value)
     {
         final int index = 2;
         final MutableDirectBuffer buffer = newBuffer(16);
@@ -189,7 +188,7 @@ public abstract class MutableDirectBufferTests
 
         final AsciiNumberFormatException exception =
             assertThrowsExactly(AsciiNumberFormatException.class, () -> buffer.parseIntAscii(index, length));
-        assertTrue(exception.getMessage().endsWith("is not a valid digit @ " + (index + baseIndex)));
+        assertEquals("error parsing int: " + value, exception.getMessage());
     }
 
     @ParameterizedTest
@@ -203,13 +202,12 @@ public abstract class MutableDirectBufferTests
 
         final AsciiNumberFormatException exception =
             assertThrowsExactly(AsciiNumberFormatException.class, () -> buffer.parseLongAscii(index, length));
-        assertTrue(exception.getMessage().endsWith("is not a valid digit @ " + (index + baseIndex)));
+        assertEquals("error parsing long: " + value, exception.getMessage());
     }
 
     @ParameterizedTest
     @MethodSource("nonParsableIntValues")
-    void parseNaturalIntAsciiThrowsAsciiNumberFormatExceptionIfValueContainsInvalidCharacters(
-        final String value, final int baseIndex)
+    void parseNaturalIntAsciiThrowsAsciiNumberFormatExceptionIfValueContainsInvalidCharacters(final String value)
     {
         final int index = 1;
         final MutableDirectBuffer buffer = newBuffer(16);
@@ -217,7 +215,7 @@ public abstract class MutableDirectBufferTests
 
         final AsciiNumberFormatException exception =
             assertThrowsExactly(AsciiNumberFormatException.class, () -> buffer.parseNaturalIntAscii(index, length));
-        assertTrue(exception.getMessage().endsWith("is not a valid digit @ " + (index + baseIndex)));
+        assertEquals("error parsing int: " + value, exception.getMessage());
     }
 
     @ParameterizedTest
@@ -231,7 +229,7 @@ public abstract class MutableDirectBufferTests
 
         final AsciiNumberFormatException exception =
             assertThrowsExactly(AsciiNumberFormatException.class, () -> buffer.parseNaturalLongAscii(index, length));
-        assertTrue(exception.getMessage().endsWith("is not a valid digit @ " + (index + baseIndex)));
+        assertEquals("error parsing long: " + value, exception.getMessage());
     }
 
     @ParameterizedTest
@@ -326,18 +324,17 @@ public abstract class MutableDirectBufferTests
             Arguments.arguments(9999, 4));
     }
 
-    private static List<Arguments> nonParsableIntValues()
+    private static List<String> nonParsableIntValues()
     {
         return Arrays.asList(
-            Arguments.arguments("23.5", 2),
-            Arguments.arguments("+1", 0),
-            Arguments.arguments("a14349", 0),
-            Arguments.arguments("0xFF", 1),
-            Arguments.arguments("999v", 3),
-            Arguments.arguments("-", 0),
-            Arguments.arguments("+", 0),
-            Arguments.arguments("1234%67890", 4)
-        );
+            "23.5",
+            "+1",
+            "a14349",
+            "0xFF",
+            "999v",
+            "-",
+            "+",
+            "1234%67890");
     }
 
     private static List<Arguments> nonParsableLongValues()


### PR DESCRIPTION
This PR makes parsing in chunks of four or eight bytes at a time which improves parsing speed a lot. Here are the latest benchmark results:
```
Benchmark                                                      (value)  Mode  Cnt   Score   Error  Units
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt  -2147483648  avgt   30  16.934 ± 0.020  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt  -1234567890  avgt   30  16.932 ± 0.012  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt            0  avgt   30   3.828 ± 0.009  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt        -9182  avgt   30   8.587 ± 0.013  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt     27085146  avgt   30  13.291 ± 0.008  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt   1999999999  avgt   30  15.987 ± 0.015  ns/op
MutableDirectBufferParseIntAsciiBenchmark.integerParseInt   2147483647  avgt   30  15.960 ± 0.013  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer     -2147483648  avgt   30   6.158 ± 0.011  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer     -1234567890  avgt   30   6.206 ± 0.004  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer               0  avgt   30   2.860 ± 0.001  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer           -9182  avgt   30   3.972 ± 0.020  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer        27085146  avgt   30   5.092 ± 0.006  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer      1999999999  avgt   30   5.859 ± 0.067  ns/op
MutableDirectBufferParseIntAsciiBenchmark.unsafeBuffer      2147483647  avgt   30   5.869 ± 0.065  ns/op

Benchmark                                                              (value)  Mode  Cnt   Score   Error  Units
MutableDirectBufferParseLongAsciiBenchmark.longParseLong  -9223372036854775808  avgt   30  30.510 ± 0.074  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong  -1913372036854775855  avgt   30  30.507 ± 0.072  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong                     0  avgt   30   3.918 ± 0.008  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong                 -9182  avgt   30   8.880 ± 0.034  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong              27085146  avgt   30  14.390 ± 0.035  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong      1010101010101010  avgt   30  26.098 ± 0.070  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong   8999999999999999999  avgt   30  31.103 ± 0.704  ns/op
MutableDirectBufferParseLongAsciiBenchmark.longParseLong   9223372036854775807  avgt   30  30.621 ± 0.439  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer   -9223372036854775808  avgt   30  11.434 ± 0.027  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer   -1913372036854775855  avgt   30  10.932 ± 0.018  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer                      0  avgt   30   2.638 ± 0.005  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer                  -9182  avgt   30   4.233 ± 0.011  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer               27085146  avgt   30   4.295 ± 0.006  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer       1010101010101010  avgt   30   8.987 ± 0.212  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer    8999999999999999999  avgt   30  10.979 ± 0.010  ns/op
MutableDirectBufferParseLongAsciiBenchmark.unsafeBuffer    9223372036854775807  avgt   30  11.032 ± 0.024  ns/op
```

The parsing code is inspired by [fast_float/ascii_number.h methods](https://github.com/fastfloat/fast_float/blob/d35368cae610b4edeec61cd41e4d2367a4d33f58/include/fast_float/ascii_number.h#L47-L69).