### PR TITLE
single lookup implementation of compute methods in maps

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/IntObjToObjFunction.java
+++ b/agrona/src/main/java/org/agrona/collections/IntObjToObjFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * This is an (int, Object) -&gt; Object primitive specialisation of a BiFunction.
+ */
+@FunctionalInterface
+public interface
+    IntObjToObjFunction<T, R>
+{
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param i the second function argument
+     * @param t the first function argument
+     * @return the function result
+     */
+    R apply(int i, T t);
+}

--- a/agrona/src/main/java/org/agrona/collections/ObjIntToIntFunction.java
+++ b/agrona/src/main/java/org/agrona/collections/ObjIntToIntFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * This is an (Object, int) -&gt; int primitive specialisation of a BiFunction.
+ */
+@FunctionalInterface
+public interface
+    ObjIntToIntFunction<T>
+{
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param i the second function argument
+     * @return the function result
+     */
+    int apply(T t, int i);
+}

--- a/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
+++ b/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
@@ -48,6 +48,8 @@ public final class SpecialisationGenerator
     {
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntConsumer", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjConsumer", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjToObjFunction", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjIntToIntFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntArrayList", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntArrayQueue", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "Int2IntHashMap", SRC_DIR, DST_DIR);

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -408,10 +409,14 @@ public class Int2IntHashMapTest
     {
         final int testKey = 7;
         final int testValue = 7;
+        final int testValue2 = 8;
 
         assertEquals(map.missingValue(), map.get(testKey));
 
         assertThat(map.computeIfAbsent(testKey, (i) -> testValue), is(testValue));
+        assertThat(map.get(testKey), is(testValue));
+
+        assertThat(map.computeIfAbsent(testKey, (i) -> testValue2), is(testValue));
         assertThat(map.get(testKey), is(testValue));
     }
 
@@ -422,9 +427,76 @@ public class Int2IntHashMapTest
 
         final int testKey = 7;
         final int testValue = 7;
+        final int testValue2 = 8;
 
         assertThat(map.computeIfAbsent(testKey, (i) -> testValue), is(testValue));
         assertThat(map.get(testKey), is(testValue));
+
+        assertThat(map.computeIfAbsent(testKey, (i) -> testValue2), is(testValue));
+        assertThat(map.get(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldComputeIfPresent()
+    {
+        final int testKey = 7;
+        final int testValue = 7;
+        final int testValue2 = 8;
+
+        assertThat(map.computeIfPresent(testKey, (k, v) -> testValue), is(map.missingValue()));
+        assertThat(map.get(testKey), is(map.missingValue()));
+
+        map.put(testKey, testValue);
+        assertThat(map.computeIfPresent(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(map.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeIfPresentBoxed()
+    {
+        final Map<Integer, Integer> map = this.map;
+
+        final int testKey = 7;
+        final int testValue = 7;
+        final int testValue2 = 8;
+
+        assertThat(map.computeIfPresent(testKey, (k, v) -> testValue), nullValue());
+        assertThat(map.get(testKey), nullValue());
+
+        map.put(testKey, testValue);
+        assertThat(map.computeIfPresent(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(map.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldCompute()
+    {
+        final int testKey = 7;
+        final int testValue = 7;
+        final int testValue2 = 8;
+
+        assertEquals(map.missingValue(), map.get(testKey));
+        assertThat(map.compute(testKey, (k, v) -> testValue), is(testValue));
+        assertThat(map.get(testKey), is(testValue));
+
+        assertThat(map.compute(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(map.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeBoxed()
+    {
+        final Map<Integer, Integer> map = this.map;
+
+        final int testKey = 7;
+        final int testValue = 7;
+        final int testValue2 = 8;
+
+        assertThat(map.compute(testKey, (k, v) -> testValue), is(testValue));
+        assertThat(map.get(testKey), is(testValue));
+
+        assertThat(map.compute(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(map.get(testKey), is(testValue2));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -151,6 +151,101 @@ class Int2ObjectHashMapTest
     }
 
     @Test
+    public void shouldCompute()
+    {
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.get(testKey), nullValue());
+        assertThat(intToObjectMap.compute(testKey, (k, v) -> testValue), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+
+        assertThat(intToObjectMap.compute(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(intToObjectMap.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeBoxed()
+    {
+        final Map<Integer, String> intToObjectMap = this.intToObjectMap;
+
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.compute(testKey, (k, v) -> testValue), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+
+        assertThat(intToObjectMap.compute(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(intToObjectMap.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeIfAbsent()
+    {
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.get(testKey), nullValue());
+
+        assertThat(intToObjectMap.computeIfAbsent(testKey, (i) -> testValue), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+
+        assertThat(intToObjectMap.computeIfAbsent(testKey, (i) -> testValue2), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldComputeIfAbsentBoxed()
+    {
+        final Map<Integer, String> intToObjectMap = this.intToObjectMap;
+
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.computeIfAbsent(testKey, (i) -> testValue), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+
+        assertThat(intToObjectMap.computeIfAbsent(testKey, (i) -> testValue2), is(testValue));
+        assertThat(intToObjectMap.get(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldComputeIfPresent()
+    {
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.computeIfPresent(testKey, (k, v) -> testValue), nullValue());
+        assertThat(intToObjectMap.get(testKey), nullValue());
+
+        intToObjectMap.put(testKey, testValue);
+        assertThat(intToObjectMap.computeIfPresent(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(intToObjectMap.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeIfPresentBoxed()
+    {
+        final Map<Integer, String> intToObjectMap = this.intToObjectMap;
+
+        final int testKey = 7;
+        final String testValue = "Seven";
+        final String testValue2 = "7";
+
+        assertThat(intToObjectMap.computeIfPresent(testKey, (k, v) -> testValue), nullValue());
+        assertThat(intToObjectMap.get(testKey), nullValue());
+
+        intToObjectMap.put(testKey, testValue);
+        assertThat(intToObjectMap.computeIfPresent(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(intToObjectMap.get(testKey), is(testValue2));
+    }
+
+    @Test
     void shouldContainValue()
     {
         final int key = 7;

--- a/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2IntHashMapTest.java
@@ -24,11 +24,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.ToIntFunction;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -151,6 +153,106 @@ class Object2IntHashMapTest
         objectToIntMap.compact();
 
         assertThat(objectToIntMap.capacity(), lessThan(capacityBeforeCompaction));
+    }
+
+    @Test
+    public void shouldCompute()
+    {
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+
+        assertThat(objectToIntMap.getValue(testKey), is(objectToIntMap.missingValue()));
+        assertThat(objectToIntMap.compute(testKey, (final String k, final int v) -> testValue), is(testValue));
+        assertThat(objectToIntMap.getValue(testKey), is(testValue));
+
+        assertThat(objectToIntMap.compute(testKey, (final String k, final int v) -> testValue2), is(testValue2));
+        assertThat(objectToIntMap.getValue(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeBoxed()
+    {
+        final Map<String, Integer> objectToIntMap = this.objectToIntMap;
+
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+
+        assertThat(objectToIntMap.compute(testKey, (k, v) -> testValue), is(testValue));
+        assertThat(objectToIntMap.get(testKey), is(testValue));
+
+        assertThat(objectToIntMap.compute(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(objectToIntMap.get(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeIfAbsent()
+    {
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+
+        assertThat(objectToIntMap.getValue(testKey), is(objectToIntMap.missingValue()));
+
+        final ToIntFunction<String> function = (i) -> testValue;
+        assertThat(objectToIntMap.computeIfAbsent(testKey, function), is(testValue));
+        assertThat(objectToIntMap.getValue(testKey), is(testValue));
+
+        final ToIntFunction<String> function2 = (i) -> testValue2;
+        assertThat(objectToIntMap.computeIfAbsent(testKey, function2), is(testValue));
+        assertThat(objectToIntMap.getValue(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldComputeIfAbsentBoxed()
+    {
+        final Map<String, Integer> objectToIntMap = this.objectToIntMap;
+
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+
+        assertThat(objectToIntMap.computeIfAbsent(testKey, (i) -> testValue), is(testValue));
+        assertThat(objectToIntMap.get(testKey), is(testValue));
+
+        assertThat(objectToIntMap.computeIfAbsent(testKey, (i) -> testValue2), is(testValue));
+        assertThat(objectToIntMap.get(testKey), is(testValue));
+    }
+
+    @Test
+    public void shouldComputeIfPresent()
+    {
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+        final int missingValue = objectToIntMap.missingValue();
+
+        assertThat(objectToIntMap.computeIfPresent(testKey, (final String k, final int v) -> testValue),
+            is(missingValue));
+        assertThat(objectToIntMap.getValue(testKey), is(missingValue));
+
+        objectToIntMap.put(testKey, testValue);
+        assertThat(objectToIntMap.computeIfPresent(testKey, (final String k, final int v) -> testValue2),
+            is(testValue2));
+        assertThat(objectToIntMap.getValue(testKey), is(testValue2));
+    }
+
+    @Test
+    public void shouldComputeIfPresentBoxed()
+    {
+        final Map<String, Integer> objectToIntMap = this.objectToIntMap;
+
+        final String testKey = "Seven";
+        final int testValue = 7;
+        final int testValue2 = -7;
+
+        assertThat(objectToIntMap.computeIfPresent(testKey, (k, v) -> testValue), nullValue());
+        assertThat(objectToIntMap.get(testKey), nullValue());
+
+        objectToIntMap.put(testKey, testValue);
+        assertThat(objectToIntMap.computeIfPresent(testKey, (k, v) -> testValue2), is(testValue2));
+        assertThat(objectToIntMap.get(testKey), is(testValue2));
     }
 
     @Test


### PR DESCRIPTION
As discussed in issue #258, the goal of this PR is to have enhanced compute / computeIfPresent / computeIfAbsent implementations by avoiding doing several lookups in the map as done by the default implementation of j.u.Map

A few remarks : 
- for maps with primitive key/values, the optimized implementations are the one using the primitive API, boxed methods inherited from the j.u.Map API are still using the default implementation
- Behavior of computeIfAbsent for Int2NullableObjectHashMap has been changed to match JDK behavior : if a key is already mapped to null, invoking computeIfAbsent will now compute a new mapping, whereas it just returned null in previous implementation
- Code of put/get methods has not been changed. If we feel there are no performance concern about this, we may factorize some code (and maybe easily have efficient implementation of all Map default methods that have been in java 8). For example, we can imagine having put and putIfAbsent calling a single method with a boolean parameter as it is done in j.u.HashMap, which means that an additionnal inlining will be required when invoking put. However I did not want to start such a refactoring without prior approval
- Using compute methods for Object2IntHashMap is pretty clunky because of ambiguous inference for lambda expression. I keep the current pattern (computeIfAbsent was already there with an @SuppressWarnings("overloads") annotation), but as you can see in the test class, client code cannot directly use lambda expression. It might make sense to rename them to computeValue / computeValueIfAbsent / computeValueIfPresent (to keep the same logic than the get method)