### PR TITLE
[Java] Eliminate boxing operations

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -270,6 +270,18 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
+     * Use {@link #forEachInt(IntIntConsumer)} instead.
+     *
+     * @param consumer a callback called for each key/value pair in the map.
+     * @deprecated Use {@link #forEachInt(IntIntConsumer)} instead.
+     */
+    @Deprecated
+    public void intForEach(final IntIntConsumer consumer)
+    {
+        forEachInt(consumer);
+    }
+
+    /**
      * Primitive specialised forEach implementation.
      * <p>
      * NB: Renamed from forEach to avoid overloading on parameter types of lambda
@@ -277,7 +289,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      *
      * @param consumer a callback called for each key/value pair in the map.
      */
-    public void intForEach(final IntIntConsumer consumer)
+    public void forEachInt(final IntIntConsumer consumer)
     {
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
@@ -505,7 +517,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public void forEach(final BiConsumer<? super Integer, ? super Integer> action)
     {
-        intForEach(action::accept);
+        forEachInt(action::accept);
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -574,6 +574,21 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
+     * Put all values from the given map into this map without allocation.
+     *
+     * @param map whose value are to be added.
+     */
+    public void putAll(final Int2IntHashMap map)
+    {
+        final EntryIterator it = map.entrySet().iterator();
+        while (it.hasNext())
+        {
+            it.findNext();
+            put(it.getIntKey(), it.getIntValue());
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public Integer putIfAbsent(final Integer key, final Integer value)

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntBinaryOperator;
+import java.util.function.IntPredicate;
 import java.util.function.IntUnaryOperator;
 
 import static java.util.Objects.*;
@@ -1419,6 +1420,30 @@ public class Int2IntHashMap implements Map<Integer, Integer>
         {
             return containsKey(key);
         }
+
+        /**
+         * Removes all the elements of this collection that satisfy the given predicate.
+         * <p>
+         * NB: Renamed from removeIf to avoid overloading on parameter types of lambda
+         * expression, which doesn't play well with type inference in lambda expressions.
+         *
+         * @param filter a predicate to apply.
+         * @return {@code true} if at least one key was removed.
+         */
+        public boolean removeIfInt(final IntPredicate filter)
+        {
+            boolean removed = false;
+            final KeyIterator iterator = iterator();
+            while (iterator.hasNext())
+            {
+                if (filter.test(iterator.nextValue()))
+                {
+                    iterator.remove();
+                    removed = true;
+                }
+            }
+            return removed;
+        }
     }
 
     /**
@@ -1469,6 +1494,30 @@ public class Int2IntHashMap implements Map<Integer, Integer>
         public boolean contains(final int value)
         {
             return containsValue(value);
+        }
+
+        /**
+         * Removes all the elements of this collection that satisfy the given predicate.
+         * <p>
+         * NB: Renamed from removeIf to avoid overloading on parameter types of lambda
+         * expression, which doesn't play well with type inference in lambda expressions.
+         *
+         * @param filter a predicate to apply.
+         * @return {@code true} if at least one value was removed.
+         */
+        public boolean removeIfInt(final IntPredicate filter)
+        {
+            boolean removed = false;
+            final ValueIterator iterator = iterator();
+            while (iterator.hasNext())
+            {
+                if (filter.test(iterator.nextValue()))
+                {
+                    iterator.remove();
+                    removed = true;
+                }
+            }
+            return removed;
         }
     }
 
@@ -1532,6 +1581,31 @@ public class Int2IntHashMap implements Map<Integer, Integer>
             final Integer value = get(entry.getKey());
 
             return value != null && value.equals(entry.getValue());
+        }
+
+        /**
+         * Removes all the elements of this collection that satisfy the given predicate.
+         * <p>
+         * NB: Renamed from removeIf to avoid overloading on parameter types of lambda
+         * expression, which doesn't play well with type inference in lambda expressions.
+         *
+         * @param filter a predicate to apply.
+         * @return {@code true} if at least one entry was removed.
+         */
+        public boolean removeIfInt(final IntIntPredicate filter)
+        {
+            boolean removed = false;
+            final EntryIterator iterator = iterator();
+            while (iterator.hasNext())
+            {
+                iterator.findNext();
+                if (filter.test(iterator.getIntKey(), iterator.getIntValue()))
+                {
+                    iterator.remove();
+                    removed = true;
+                }
+            }
+            return removed;
         }
 
         /**

--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.function.IntBinaryOperator;
 import java.util.function.IntUnaryOperator;
 
+import static java.util.Objects.*;
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
 import static org.agrona.collections.CollectionUtil.validateLoadFactor;
 
@@ -231,7 +232,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #putIfAbsent(Integer, Integer)} method.
+     * Primitive specialised version of {@link Map#putIfAbsent(Object, Object)} method.
      *
      * @param key   key with which the specified value is to be associated
      * @param value value to be associated with the specified key
@@ -294,6 +295,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      *
      * @param consumer a callback called for each key/value pair in the map.
      * @deprecated Use {@link #forEachInt(IntIntConsumer)} instead.
+     * @see #forEachInt(IntIntConsumer)
      */
     @Deprecated
     public void intForEach(final IntIntConsumer consumer)
@@ -311,6 +313,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public void forEachInt(final IntIntConsumer consumer)
     {
+        requireNonNull(consumer);
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
         @DoNotSub final int length = entries.length;
@@ -394,7 +397,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #computeIfAbsent(Object, Function)}.
+     * Primitive specialised version of {@link Map#computeIfAbsent(Object, Function)}.
      *
      * @param key             to search on.
      * @param mappingFunction to provide a value if the get returns null.
@@ -402,6 +405,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public int computeIfAbsent(final int key, final IntUnaryOperator mappingFunction)
     {
+        requireNonNull(mappingFunction);
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
         @DoNotSub final int mask = entries.length - 1;
@@ -418,7 +422,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
             index = next(index, mask);
         }
 
-        if (value == missingValue && (value = mappingFunction.applyAsInt(key)) != missingValue)
+        if (missingValue == value && missingValue != (value = mappingFunction.applyAsInt(key)))
         {
             entries[index] = key;
             entries[index + 1] = value;
@@ -430,7 +434,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link java.util.Map#computeIfPresent}.
+     * Primitive specialised version of {@link Map#computeIfPresent}.
      *
      * @param key               to search on.
      * @param remappingFunction to compute a value if a mapping is found.
@@ -438,6 +442,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public int computeIfPresent(final int key, final IntBinaryOperator remappingFunction)
     {
+        requireNonNull(remappingFunction);
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
         @DoNotSub final int mask = entries.length - 1;
@@ -454,7 +459,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
             index = next(index, mask);
         }
 
-        if (value != missingValue)
+        if (missingValue != value)
         {
             value = remappingFunction.applyAsInt(key, value);
             entries[index + 1] = value;
@@ -469,7 +474,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link java.util.Map#compute}.
+     * Primitive specialised version of {@link Map#compute}.
      *
      * @param key               to search on.
      * @param remappingFunction to compute a value.
@@ -477,6 +482,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public int compute(final int key, final IntBinaryOperator remappingFunction)
     {
+        requireNonNull(remappingFunction);
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
         @DoNotSub final int mask = entries.length - 1;
@@ -494,7 +500,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
         }
 
         final int newValue = remappingFunction.applyAsInt(key, oldValue);
-        if (newValue != missingValue)
+        if (missingValue != newValue)
         {
             entries[index + 1] = newValue;
             if (oldValue == missingValue)
@@ -504,7 +510,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
                 increaseCapacity();
             }
         }
-        else if (oldValue != missingValue)
+        else if (missingValue != oldValue)
         {
             entries[index + 1] = missingValue;
             size--;
@@ -687,7 +693,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #remove(Object, Object)}.
+     * Primitive specialised version of {@link Map#remove(Object, Object)}.
      *
      * @param key   with which the specified value is associated.
      * @param value expected to be associated with the specified key.
@@ -704,7 +710,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #merge(Object, Object, BiFunction)}.
+     * Primitive specialised version of {@link Map#merge(Object, Object, BiFunction)}.
      *
      * @param key               with which the resulting value is to be associated.
      * @param value             to be merged with the existing value associated with the key or, if no existing value or a null
@@ -715,6 +721,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public int merge(final int key, final int value, final IntIntFunction remappingFunction)
     {
+        requireNonNull(remappingFunction);
         final int oldValue = get(key);
         final int newValue = missingValue == oldValue ? value : remappingFunction.apply(oldValue, value);
         if (missingValue == newValue)
@@ -835,7 +842,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #replace(Integer, Integer)}.
+     * Primitive specialised version of {@link Map#replace(Object, Object)}.
      *
      * @param key   key with which the specified value is associated.
      * @param value value to be associated with the specified key.
@@ -854,7 +861,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #replace(Integer, Integer, Integer)}.
+     * Primitive specialised version of {@link Map#replace(Object, Object, Object)}.
      *
      * @param key      key with which the specified value is associated.
      * @param oldValue value expected to be associated with the specified key.
@@ -875,7 +882,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
-     * Primitive specialised version of {@link #replaceAll(BiFunction)}.
+     * Primitive specialised version of {@link Map#replaceAll(BiFunction)}.
      * <p>
      * NB: Renamed from replaceAll to avoid overloading on parameter types of lambda
      * expression, which doesn't play well with type inference in lambda expressions.
@@ -884,6 +891,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      */
     public void replaceAllInt(final IntIntFunction function)
     {
+        requireNonNull(function);
         final int missingValue = this.missingValue;
         final int[] entries = this.entries;
         @DoNotSub final int length = entries.length;
@@ -953,7 +961,7 @@ public class Int2IntHashMap implements Map<Integer, Integer>
 
     private Integer valOrNull(final int value)
     {
-        return value == missingValue ? null : value;
+        return missingValue == value ? null : value;
     }
 
     // ---------------- Utility Classes ----------------

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
@@ -17,7 +17,12 @@ package org.agrona.collections;
 
 import org.agrona.generation.DoNotSub;
 
-import java.util.*;
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -480,10 +485,10 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
      * <p>
      * Primitive specialized version of {@link Map#putIfAbsent(Object, Object)}.
      *
-     * @param key with which the specified value is to be associated.
+     * @param key   with which the specified value is to be associated.
      * @param value to be associated with the specified key.
      * @return the previous value associated with the specified key, or
-     *         {@code null} if there was no mapping for the key.
+     * {@code null} if there was no mapping for the key.
      */
     public V putIfAbsent(final int key, final V value)
     {
@@ -577,7 +582,7 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
      * <p>
      * Primitive specialized version of {@link Map#remove(Object, Object)}.
      *
-     * @param key key with which the specified value is associated.
+     * @param key   key with which the specified value is associated.
      * @param value expected to be associated with the specified key.
      * @return {@code true} if the value was removed.
      */
@@ -649,7 +654,7 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
      * <p>
      * Primitive specialized version of {@link Map#replace(Object, Object, Object)}.
      *
-     * @param key with which the specified value is associated.
+     * @param key      with which the specified value is associated.
      * @param oldValue expected to be associated with the specified key.
      * @param newValue to be associated with the specified key.
      * @return {@code true} if the value was replaced.
@@ -678,7 +683,7 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
      * <p>
      * Primitive specialized version of {@link Map#replace(Object, Object)}.
      *
-     * @param key with which the specified value is associated.
+     * @param key   with which the specified value is associated.
      * @param value to be associated with the specified key.
      * @return the previous value associated with the specified key.
      */

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
@@ -794,6 +794,21 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
     }
 
     /**
+     * Put all values from the given map into this one without allocation.
+     *
+     * @param map whose value are to be added.
+     */
+    public void putAll(final Int2ObjectCache<? extends V> map)
+    {
+        final Int2ObjectCache<? extends V>.EntryIterator iterator = map.entrySet().iterator();
+        while (iterator.hasNext())
+        {
+            iterator.findNext();
+            put(iterator.getIntKey(), iterator.getValue());
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public KeySet keySet()

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
@@ -18,6 +18,7 @@ package org.agrona.collections;
 import org.agrona.generation.DoNotSub;
 
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
@@ -272,6 +273,35 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
     {
         final V value = get(key);
         return null != value ? value : defaultValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void forEach(final BiConsumer<? super Integer, ? super V> action)
+    {
+        forEachInt(action::accept);
+    }
+
+    /**
+     * Implementation of the {@link #forEach(BiConsumer)} that avoids boxing of keys.
+     *
+     * @param consumer to be called for each key/value pair.
+     */
+    @SuppressWarnings("unchecked")
+    public void forEachInt(final IntObjConsumer<? super V> consumer)
+    {
+        final int[] keys = this.keys;
+        final Object[] values = this.values;
+
+        for (@DoNotSub int i = 0, size = values.length; i < size; i++)
+        {
+            final Object value = values[i];
+            if (null != value)
+            {
+                consumer.accept(keys[i], (V)value);
+            }
+        }
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 import static org.agrona.collections.CollectionUtil.validatePositivePowerOfTwo;
@@ -990,7 +991,15 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
          */
         public boolean remove(final Object o)
         {
-            throw new UnsupportedOperationException("Cannot remove on iterator");
+            throw new UnsupportedOperationException("Cannot remove from KeySet");
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean removeIf(final Predicate<? super Integer> filter)
+        {
+            throw new UnsupportedOperationException("Cannot remove from KeySet");
         }
 
         /**
@@ -1042,6 +1051,22 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
         {
             Int2ObjectCache.this.clear();
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean remove(final Object o)
+        {
+            throw new UnsupportedOperationException("Cannot remove from ValueCollection");
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean removeIf(final Predicate<? super V> filter)
+        {
+            throw new UnsupportedOperationException("Cannot remove from ValueCollection");
+        }
     }
 
     /**
@@ -1075,6 +1100,22 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
         public void clear()
         {
             Int2ObjectCache.this.clear();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean remove(final Object o)
+        {
+            throw new UnsupportedOperationException("Cannot remove from EntrySet");
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean removeIf(final Predicate<? super Entry<Integer, V>> filter)
+        {
+            throw new UnsupportedOperationException("Cannot remove from EntrySet");
         }
     }
 

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
 
 import static java.util.Objects.requireNonNull;
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
@@ -1115,6 +1116,30 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V>
         {
             Int2ObjectHashMap.this.clear();
         }
+
+        /**
+         * Removes all the elements of this collection that satisfy the given predicate.
+         * <p>
+         * NB: Renamed from removeIf to avoid overloading on parameter types of lambda
+         * expression, which doesn't play well with type inference in lambda expressions.
+         *
+         * @param filter a predicate to apply.
+         * @return {@code true} if at least one key was removed.
+         */
+        public boolean removeIfInt(final IntPredicate filter)
+        {
+            boolean removed = false;
+            final KeyIterator iterator = iterator();
+            while (iterator.hasNext())
+            {
+                if (filter.test(iterator.nextInt()))
+                {
+                    iterator.remove();
+                    removed = true;
+                }
+            }
+            return removed;
+        }
     }
 
     /**
@@ -1236,6 +1261,31 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V>
             final int key = (Integer)entry.getKey();
             final V value = getMapped(key);
             return null != value && value.equals(mapNullValue(entry.getValue()));
+        }
+
+        /**
+         * Removes all the elements of this collection that satisfy the given predicate.
+         * <p>
+         * NB: Renamed from removeIf to avoid overloading on parameter types of lambda
+         * expression, which doesn't play well with type inference in lambda expressions.
+         *
+         * @param filter a predicate to apply.
+         * @return {@code true} if at least one key was removed.
+         */
+        public boolean removeIfInt(final IntObjPredicate<V> filter)
+        {
+            boolean removed = false;
+            final EntryIterator iterator = iterator();
+            while (iterator.hasNext())
+            {
+                iterator.findNext();
+                if (filter.test(iterator.getIntKey(), iterator.getValue()))
+                {
+                    iterator.remove();
+                    removed = true;
+                }
+            }
+            return removed;
         }
 
         /**

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -18,6 +18,7 @@ package org.agrona.collections;
 import org.agrona.generation.DoNotSub;
 
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
@@ -156,6 +157,26 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V>
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public void forEach(final BiConsumer<? super Integer, ? super V> action)
+    {
+        forEachInt(action::accept);
+    }
+
+    /**
+     * Use {@link #forEachInt(IntObjConsumer)} instead.
+     *
+     * @param consumer a callback called for each key/value pair in the map.
+     * @deprecated Use {@link #forEachInt(IntObjConsumer)} instead.
+     */
+    @Deprecated
+    public void intForEach(final IntObjConsumer<V> consumer)
+    {
+        forEachInt(consumer);
+    }
+
+    /**
      * Primitive specialised forEach implementation.
      * <p>
      * NB: Renamed from forEach to avoid overloading on parameter types of lambda
@@ -163,7 +184,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V>
      *
      * @param consumer a callback called for each key/value pair in the map.
      */
-    public void intForEach(final IntObjConsumer<V> consumer)
+    public void forEachInt(final IntObjConsumer<V> consumer)
     {
         @DoNotSub final int length = values.length;
         @DoNotSub int remaining = size;

--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectHashMap.java
@@ -707,6 +707,21 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V>
     }
 
     /**
+     * Put all values from the given map into this one without allocation.
+     *
+     * @param map whose value are to be added.
+     */
+    public void putAll(final Int2ObjectHashMap<? extends V> map)
+    {
+        final Int2ObjectHashMap<? extends V>.EntryIterator iterator = map.entrySet().iterator();
+        while (iterator.hasNext())
+        {
+            iterator.findNext();
+            put(iterator.getIntKey(), iterator.getValue());
+        }
+    }
+
+    /**
      * Primitive specialised version of {@link #putIfAbsent(Object, Object)}.
      *
      * @param key   with which the specified value is to be associated.

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -20,7 +20,10 @@ import org.agrona.generation.DoNotSub;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
+
+import static java.util.Objects.*;
 
 /**
  * A {@link List} implementation that stores int values with the ability to not have them boxed.
@@ -486,6 +489,48 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     }
 
     /**
+     * Removes all the elements of this collection that satisfy the given predicate.
+     *
+     * @param filter a predicate which returns true for elements to be removed.
+     * @return {@code true} if any elements were removed.
+     */
+    public boolean removeIfInt(final IntPredicate filter)
+    {
+        requireNonNull(filter);
+        final int[] elements = this.elements;
+        @DoNotSub final int size = this.size;
+        if (size > 0)
+        {
+            int[] filteredElements = null;
+            @DoNotSub int j = -1;
+            for (@DoNotSub int i = 0; i < size; i++)
+            {
+                final int value = elements[i];
+                if (filter.test(value))
+                {
+                    if (null == filteredElements)
+                    {
+                        filteredElements = Arrays.copyOf(elements, size);
+                        j = i - 1;
+                    }
+                }
+                else if (null != filteredElements)
+                {
+                    filteredElements[++j] = value;
+                }
+            }
+
+            if (null != filteredElements)
+            {
+                this.elements = filteredElements;
+                this.size = j + 1;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public boolean remove(final Object o)
@@ -792,6 +837,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public void forEach(final Consumer<? super Integer> action)
     {
+        requireNonNull(action);
         final int nullValue = this.nullValue;
         final int[] elements = this.elements;
         for (@DoNotSub int i = 0, size = this.size; i < size; i++)
@@ -808,6 +854,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public void forEachInt(final IntConsumer action)
     {
+        requireNonNull(action);
         final int[] elements = this.elements;
         for (@DoNotSub int i = 0, size = this.size; i < size; i++)
         {

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -547,7 +547,8 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     public Integer remove(
         @DoNotSub final int index)
     {
-        return removeAt(index);
+        final int value = removeAt(index);
+        return nullValue == value ? null : value;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -117,7 +117,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     /**
      * {@inheritDoc}
      */
-    public @DoNotSub int size()
+    @DoNotSub public int size()
     {
         return size;
     }
@@ -159,7 +159,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     {
         final int value = getInt(index);
 
-        return value == nullValue ? null : value;
+        return nullValue == value ? null : value;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -386,10 +386,13 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean containsAll(final IntArrayList list)
     {
-        final int[] elements = list.elements;
+        final int[] listElements = list.elements;
+        final int listNullValue = list.nullValue;
+        final boolean hasNulls = contains(null);
         for (@DoNotSub int i = 0, size = list.size; i < size; i++)
         {
-            if (!containsInt(elements[i]))
+            final int value = listElements[i];
+            if (!(containsInt(value) || hasNulls && listNullValue == value))
             {
                 return false;
             }
@@ -417,12 +420,14 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
                 return true;
             }
 
+            final int nullValue = this.nullValue;
+            final boolean listHasNulls = list.contains(null);
             int[] filteredElements = null;
             @DoNotSub int j = -1;
             for (@DoNotSub int i = 0; i < size; i++)
             {
                 final int value = elements[i];
-                if (!list.containsInt(value))
+                if (!(list.containsInt(value) || (listHasNulls && nullValue == value)))
                 {
                     if (null == filteredElements)
                     {
@@ -459,12 +464,14 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
         @DoNotSub final int size = this.size;
         if (size > 0 && !list.isEmpty())
         {
+            final int nullValue = this.nullValue;
+            final boolean listHasNulls = list.contains(null);
             int[] filteredElements = null;
             @DoNotSub int j = -1;
             for (@DoNotSub int i = 0; i < size; i++)
             {
                 final int value = elements[i];
-                if (list.containsInt(value))
+                if (list.containsInt(value) || (listHasNulls && nullValue == value))
                 {
                     if (null == filteredElements)
                     {

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -383,7 +383,16 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean containsAll(final IntArrayList list)
     {
-        return super.containsAll(list);
+        final int[] elements = list.elements;
+        for (@DoNotSub int i = 0, size = list.size; i < size; i++)
+        {
+            if (!containsInt(elements[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -395,7 +404,43 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean retainAll(final IntArrayList list)
     {
-        return super.retainAll(list);
+        final int[] elements = this.elements;
+        @DoNotSub final int size = this.size;
+        if (size > 0)
+        {
+            if (list.isEmpty())
+            {
+                this.size = 0;
+                return true;
+            }
+
+            int[] filteredElements = null;
+            @DoNotSub int j = -1;
+            for (@DoNotSub int i = 0; i < size; i++)
+            {
+                final int value = elements[i];
+                if (!list.containsInt(value))
+                {
+                    if (null == filteredElements)
+                    {
+                        filteredElements = Arrays.copyOf(elements, size);
+                        j = i - 1;
+                    }
+                }
+                else if (null != filteredElements)
+                {
+                    filteredElements[++j] = value;
+                }
+            }
+
+            if (null != filteredElements)
+            {
+                this.elements = filteredElements;
+                this.size = j + 1;
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -407,7 +452,37 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean removeAll(final IntArrayList list)
     {
-        return super.removeAll(list);
+        final int[] elements = this.elements;
+        @DoNotSub final int size = this.size;
+        if (size > 0 && !list.isEmpty())
+        {
+            int[] filteredElements = null;
+            @DoNotSub int j = -1;
+            for (@DoNotSub int i = 0; i < size; i++)
+            {
+                final int value = elements[i];
+                if (list.containsInt(value))
+                {
+                    if (null == filteredElements)
+                    {
+                        filteredElements = Arrays.copyOf(elements, size);
+                        j = i - 1;
+                    }
+                }
+                else if (null != filteredElements)
+                {
+                    filteredElements[++j] = value;
+                }
+            }
+
+            if (null != filteredElements)
+            {
+                this.elements = filteredElements;
+                this.size = j + 1;
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -85,7 +85,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      * @param initialElements to be wrapped.
      * @param initialSize     of the array to wrap.
      * @throws IllegalArgumentException if the initialSize is less than 0 or greater than the length of the
-     * initial array.
+     *                                  initial array.
      */
     public void wrap(
         final int[] initialElements,
@@ -263,6 +263,14 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object o)
+    {
+        return containsInt((int)o);
+    }
+
+    /**
      * Does the list contain this element value.
      *
      * @param value of the element.
@@ -313,6 +321,101 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
         }
 
         return -1;
+    }
+
+    /**
+     * Appends all the elements in the specified list to the end of this list, in the order that they are stored in the
+     * specified list.
+     *
+     * @param list containing elements to be added to this list.
+     * @return {@code true} if this list changed as a result of the call.
+     */
+    public boolean addAll(final IntArrayList list)
+    {
+        @DoNotSub final int numElements = list.size;
+        if (numElements > 0)
+        {
+            ensureCapacityPrivate(size + numElements);
+            System.arraycopy(list.elements, 0, elements, size, numElements);
+            size += numElements;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Inserts all the elements from the specified list to this list at the specified position. Shifts the element
+     * currently at that position (if any) and any subsequent elements to the right (increases their indices). The new
+     * elements will appear in this list in the order that they are stored in the specified list.
+     *
+     * @param index at which to insert the first element from the specified collection.
+     * @param list  containing elements to be added to this list.
+     * @return {@code true} if this list changed as a result of the call.
+     */
+    public boolean addAll(
+        @DoNotSub final int index,
+        final IntArrayList list)
+    {
+        checkIndexForAdd(index);
+
+        @DoNotSub final int numElements = list.size;
+        if (numElements > 0)
+        {
+            @DoNotSub final int size = this.size;
+            ensureCapacityPrivate(size + numElements);
+            final int[] elements = this.elements;
+            for (@DoNotSub int i = size - 1; i >= index; i--)
+            {
+                elements[i + numElements] = elements[i];
+            }
+            System.arraycopy(list.elements, 0, elements, index, numElements);
+            this.size += numElements;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if this list contains all the elements of the specified list.
+     *
+     * @param list to be checked for containment in this list.
+     * @return {@code true} if this list contains all the elements of the specified list.
+     */
+    public boolean containsAll(final IntArrayList list)
+    {
+        return super.containsAll(list);
+    }
+
+    /**
+     * Retains only the elements in this list that are contained in the specified list. In other words, removes from
+     * this list all of its elements that are not contained in the specified list.
+     *
+     * @param list containing elements to be removed from this list.
+     * @return {@code true} if this list changed as a result of the call.
+     */
+    public boolean retainAll(final IntArrayList list)
+    {
+        return super.retainAll(list);
+    }
+
+    /**
+     * Removes all of this collection's elements that are also contained in the specified list. After this call
+     * returns, this list will contain no elements in common with the specified list.
+     *
+     * @param list whose elements are to be removed from this list.
+     * @return {@code true} if this list changed as a result of the call.
+     */
+    public boolean removeAll(final IntArrayList list)
+    {
+        return super.removeAll(list);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean remove(final Object o)
+    {
+        return removeInt((int)o);
     }
 
     /**
@@ -373,6 +476,8 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
 
     /**
      * Remove the first instance of a value if found in the list.
+     * <p>
+     * Primitive specialization of the {@link List#remove(Object)} method.
      *
      * @param value to be removed.
      * @return true if successful otherwise false.

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -324,6 +324,18 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
     public Integer remove(
         @DoNotSub final int index)
     {
+        return removeAt(index);
+    }
+
+    /**
+     * Remove at a given index.
+     *
+     * @param index of the element to be removed.
+     * @return the existing value at this index.
+     */
+    public int removeAt(
+        @DoNotSub final int index)
+    {
         checkIndex(index);
 
         final int value = elements[index];
@@ -370,7 +382,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
         @DoNotSub final int index = indexOf(value);
         if (-1 != index)
         {
-            remove(index);
+            removeAt(index);
 
             return true;
         }

--- a/agrona/src/main/java/org/agrona/collections/IntArrayList.java
+++ b/agrona/src/main/java/org/agrona/collections/IntArrayList.java
@@ -270,7 +270,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean contains(final Object o)
     {
-        return containsInt((int)o);
+        return containsInt(null == o ? nullValue : (int)o);
     }
 
     /**
@@ -535,7 +535,7 @@ public class IntArrayList extends AbstractList<Integer> implements List<Integer>
      */
     public boolean remove(final Object o)
     {
-        return removeInt((int)o);
+        return removeInt(null == o ? nullValue : (int)o);
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -170,6 +170,16 @@ public class IntHashSet extends AbstractSet<Integer>
     }
 
     /**
+     * The missing value used by this set.
+     *
+     * @return missing value used by this set.
+     */
+    public int missingValue()
+    {
+        return missingValue;
+    }
+
+    /**
      * Get the load factor beyond which the set will increase size.
      *
      * @return load factor for when the set should increase size.
@@ -529,13 +539,13 @@ public class IntHashSet extends AbstractSet<Integer>
     {
         IntHashSet difference = null;
 
-        final int[] values = this.values;
         final int missingValue = this.missingValue;
+        final int[] values = this.values;
         for (final int value : values)
         {
             if (missingValue != value && !other.contains(value))
             {
-                if (difference == null)
+                if (null == difference)
                 {
                     difference = new IntHashSet(DEFAULT_INITIAL_CAPACITY, missingValue);
                 }
@@ -544,12 +554,11 @@ public class IntHashSet extends AbstractSet<Integer>
             }
         }
 
-        // FIXME
-        if (other.containsMissingValue && !this.containsMissingValue)
+        if (containsMissingValue && !other.contains(missingValue))
         {
-            if (difference == null)
+            if (null == difference)
             {
-                difference = new IntHashSet();
+                difference = new IntHashSet(DEFAULT_INITIAL_CAPACITY, missingValue);
             }
 
             difference.add(missingValue);
@@ -579,6 +588,7 @@ public class IntHashSet extends AbstractSet<Integer>
     {
         boolean removed = false;
         final int missingValue = this.missingValue;
+        final int[] values = this.values;
         for (final int value : values)
         {
             if (missingValue != value && filter.test(value))
@@ -736,18 +746,23 @@ public class IntHashSet extends AbstractSet<Integer>
     }
 
     /**
-     * Copye values from another {@link IntHashSet} into this one.
+     * Copy values from another {@link IntHashSet} into this one.
      *
      * @param that set to copy values from.
      */
     public void copy(final IntHashSet that)
     {
-        if (this.values.length != that.values.length)
+        if (values.length != that.values.length)
         {
             throw new IllegalArgumentException("cannot copy object: masks not equal");
         }
 
-        System.arraycopy(that.values, 0, this.values, 0, this.values.length);
+        if (missingValue != that.missingValue)
+        {
+            throw new IllegalArgumentException("cannot copy object: missing value not equal");
+        }
+
+        System.arraycopy(that.values, 0, values, 0, values.length);
         this.sizeOfArrayValues = that.sizeOfArrayValues;
         this.containsMissingValue = that.containsMissingValue;
     }

--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -19,6 +19,7 @@ import org.agrona.generation.DoNotSub;
 
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.function.IntConsumer;
 
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
 import static org.agrona.collections.CollectionUtil.validateLoadFactor;
@@ -547,6 +548,30 @@ public class IntHashSet extends AbstractSet<Integer>
         }
 
         return iterator.reset();
+    }
+
+    /**
+     * Iterate over the collection without boxing.
+     *
+     * @param action to be taken for each element.
+     */
+    public void forEachInt(final IntConsumer action)
+    {
+        if (sizeOfArrayValues > 0)
+        {
+            final int[] values = this.values;
+            for (final int v : values)
+            {
+                if (MISSING_VALUE != v)
+                {
+                    action.accept(v);
+                }
+            }
+        }
+        if (containsMissingValue)
+        {
+            action.accept(MISSING_VALUE);
+        }
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -293,7 +293,7 @@ public class IntHashSet extends AbstractSet<Integer>
      */
     public boolean remove(final Object value)
     {
-        return value instanceof Integer && remove(((Integer)value).intValue());
+        return value instanceof Integer && remove((int)value);
     }
 
     /**
@@ -383,7 +383,7 @@ public class IntHashSet extends AbstractSet<Integer>
      */
     public boolean contains(final Object value)
     {
-        return value instanceof Integer && contains(((Integer)value).intValue());
+        return value instanceof Integer && contains((int)value);
     }
 
     /**
@@ -574,23 +574,23 @@ public class IntHashSet extends AbstractSet<Integer>
      */
     public boolean removeAll(final IntHashSet coll)
     {
-        boolean acc = false;
+        boolean removed = false;
 
-        final int missingValue = this.missingValue;
+        final int missingValue = coll.missingValue;
         for (final int value : coll.values)
         {
             if (missingValue != value)
             {
-                acc |= remove(value);
+                removed |= remove(value);
             }
         }
 
         if (coll.containsMissingValue)
         {
-            acc |= remove(missingValue);
+            removed |= remove(missingValue);
         }
 
-        return acc;
+        return removed;
     }
 
     /**
@@ -598,23 +598,23 @@ public class IntHashSet extends AbstractSet<Integer>
      */
     public boolean retainAll(final Collection<?> coll)
     {
-        boolean acc = false;
+        boolean removed = false;
         final int missingValue = this.missingValue;
         for (final int value : values)
         {
             if (missingValue != value && !coll.contains(value))
             {
                 remove(value);
-                acc = true;
+                removed = true;
             }
         }
 
         if (containsMissingValue && !coll.contains(missingValue))
         {
             remove(missingValue);
-            acc = true;
+            removed = true;
         }
-        return acc;
+        return removed;
     }
 
     /**
@@ -626,23 +626,23 @@ public class IntHashSet extends AbstractSet<Integer>
      */
     public boolean retainAll(final IntHashSet coll)
     {
-        boolean acc = false;
+        boolean removed = false;
         final int missingValue = this.missingValue;
         for (final int value : values)
         {
             if (missingValue != value && !coll.contains(value))
             {
                 remove(value);
-                acc = true;
+                removed = true;
             }
         }
 
         if (containsMissingValue && !coll.contains(missingValue))
         {
             remove(missingValue);
-            acc = true;
+            removed = true;
         }
-        return acc;
+        return removed;
     }
 
     /**

--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -475,8 +475,7 @@ public class IntHashSet extends AbstractSet<Integer>
     {
         boolean acc = false;
 
-        // FIXME: Missing value check is wrong....
-        final int missingValue = this.missingValue;
+        final int missingValue = coll.missingValue;
         for (final int value : coll.values)
         {
             if (missingValue != value)
@@ -496,13 +495,13 @@ public class IntHashSet extends AbstractSet<Integer>
     /**
      * IntHashSet specialised variant of {this#containsAll(Collection)}.
      *
-     * @param other int hash set to compare against.
+     * @param coll int hash set to compare against.
      * @return true if every element in other is in this.
      */
-    public boolean containsAll(final IntHashSet other)
+    public boolean containsAll(final IntHashSet coll)
     {
-        final int missingValue = this.missingValue;
-        for (final int value : other.values)
+        final int missingValue = coll.missingValue;
+        for (final int value : coll.values)
         {
             if (missingValue != value && !contains(value))
             {
@@ -510,7 +509,12 @@ public class IntHashSet extends AbstractSet<Integer>
             }
         }
 
-        return !other.containsMissingValue || this.containsMissingValue;
+        if (coll.containsMissingValue)
+        {
+            return contains(missingValue);
+        }
+
+        return true;
     }
 
     /**
@@ -533,13 +537,14 @@ public class IntHashSet extends AbstractSet<Integer>
             {
                 if (difference == null)
                 {
-                    difference = new IntHashSet();
+                    difference = new IntHashSet(DEFAULT_INITIAL_CAPACITY, missingValue);
                 }
 
                 difference.add(value);
             }
         }
 
+        // FIXME
         if (other.containsMissingValue && !this.containsMissingValue)
         {
             if (difference == null)

--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -507,7 +507,7 @@ public class IntHashSet extends AbstractSet<Integer>
 
     /**
      * Alias for {@link #removeAll(Collection)} for the specialized case when removing another IntHashSet,
-     * avoids boxing and allocations
+     * avoids boxing and allocations.
      *
      * @param coll containing the values to be removed.
      * @return {@code true} if this set changed as a result of the call.
@@ -529,6 +529,56 @@ public class IntHashSet extends AbstractSet<Integer>
             acc |= remove(MISSING_VALUE);
         }
 
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean retainAll(final Collection<?> coll)
+    {
+        boolean acc = false;
+        for (final int value : values)
+        {
+            if (MISSING_VALUE != value && !coll.contains(value))
+            {
+                remove(value);
+                acc = true;
+            }
+        }
+
+        if (containsMissingValue && !coll.contains(MISSING_VALUE))
+        {
+            remove(MISSING_VALUE);
+            acc = true;
+        }
+        return acc;
+    }
+
+    /**
+     * Alias for {@link #retainAll(Collection)} for the specialized case when retaining on another IntHashSet,
+     * avoids boxing and allocations.
+     *
+     * @param coll containing elements to be retained in this set.
+     * @return {@code true} if this set changed as a result of the call.
+     */
+    public boolean retainAll(final IntHashSet coll)
+    {
+        boolean acc = false;
+        for (final int value : values)
+        {
+            if (MISSING_VALUE != value && !coll.contains(value))
+            {
+                remove(value);
+                acc = true;
+            }
+        }
+
+        if (containsMissingValue && !coll.contains(MISSING_VALUE))
+        {
+            remove(MISSING_VALUE);
+            acc = true;
+        }
         return acc;
     }
 

--- a/agrona/src/main/java/org/agrona/collections/IntIntFunction.java
+++ b/agrona/src/main/java/org/agrona/collections/IntIntFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * Primitive specialisation of a BiFunction for a pair of ints.
+ */
+@FunctionalInterface
+public interface
+    IntIntFunction
+{
+    /**
+     * Accept two values that comes as a tuple of ints.
+     *
+     * @param valueOne for the tuple.
+     * @param valueTwo for the tuple.
+     * @return the function result.
+     */
+    int apply(int valueOne, int valueTwo);
+}

--- a/agrona/src/main/java/org/agrona/collections/IntIntPredicate.java
+++ b/agrona/src/main/java/org/agrona/collections/IntIntPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * Primitive specialisation of a BiPredicate for a pair of ints.
+ */
+@FunctionalInterface
+public interface
+    IntIntPredicate
+{
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param valueOne for the tuple.
+     * @param valueTwo for the tuple.
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}.
+     */
+    boolean test(int valueOne, int valueTwo);
+}

--- a/agrona/src/main/java/org/agrona/collections/IntObjPredicate.java
+++ b/agrona/src/main/java/org/agrona/collections/IntObjPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * This is an (int, Object) primitive specialisation of a BiPredicate.
+ */
+@FunctionalInterface
+public interface
+    IntObjPredicate<T>
+{
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param valueOne for the tuple.
+     * @param valueTwo for the tuple.
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}.
+     */
+    boolean test(int valueOne, T valueTwo);
+}

--- a/agrona/src/main/java/org/agrona/collections/ObjIntConsumer.java
+++ b/agrona/src/main/java/org/agrona/collections/ObjIntConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * This is an (Object, i) primitive specialisation of a BiConsumer.
+ */
+@FunctionalInterface
+public interface
+    ObjIntConsumer<T>
+{
+    /**
+     * @param i for the tuple.
+     * @param v for the tuple.
+     */
+    void accept(T i, int v);
+}

--- a/agrona/src/main/java/org/agrona/collections/ObjIntPredicate.java
+++ b/agrona/src/main/java/org/agrona/collections/ObjIntPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+/**
+ * This is an (Object, int) primitive specialisation of a BiPredicate.
+ */
+@FunctionalInterface
+public interface
+    ObjIntPredicate<T>
+{
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param valueOne for the tuple.
+     * @param valueTwo for the tuple.
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}.
+     */
+    boolean test(T valueOne, int valueTwo);
+}

--- a/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
+++ b/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
@@ -47,6 +47,7 @@ public final class SpecialisationGenerator
     public static void main(final String[] args) throws IOException
     {
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntConsumer", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjConsumer", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjectToObjectFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjectIntToIntFunction", SRC_DIR, DST_DIR);

--- a/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
+++ b/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
@@ -48,7 +48,9 @@ public final class SpecialisationGenerator
     {
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntConsumer", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntFunction", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntIntPredicate", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjConsumer", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjPredicate", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjectToObjectFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjectIntToIntFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntArrayList", SRC_DIR, DST_DIR);

--- a/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
+++ b/agrona/src/main/java/org/agrona/generation/SpecialisationGenerator.java
@@ -53,6 +53,8 @@ public final class SpecialisationGenerator
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjPredicate", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntObjectToObjectFunction", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjectIntToIntFunction", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjIntConsumer", SRC_DIR, DST_DIR);
+        specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "ObjIntPredicate", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntArrayList", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "IntArrayQueue", SRC_DIR, DST_DIR);
         specialise(SUBSTITUTIONS, COLLECTIONS_PACKAGE, "Int2IntHashMap", SRC_DIR, DST_DIR);

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,8 +37,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class Int2IntHashMapTest
 {
@@ -839,6 +839,238 @@ public class Int2IntHashMapTest
         map.put(key, value);
 
         assertEquals(value, map.getOrDefault(key, defaultValue));
+    }
+
+    @Test
+    void mergeShouldPutANewKeyIntoTheMap()
+    {
+        final int key = -9;
+        final int value = 113;
+        final IntIntFunction remappingFunction = mock(IntIntFunction.class);
+
+        assertEquals(value, map.merge(key, value, remappingFunction));
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    void mergeShouldReplaceAnExistingValueInTheMap()
+    {
+        final int key = 42;
+        final int oldValue = 0;
+        final int value = 5;
+        final int expectedNewValue = 8;
+        final IntIntFunction remappingFunction = (val1, val2) -> val1 + val2 + 3;
+        map.put(key, oldValue);
+
+        assertEquals(expectedNewValue, map.merge(key, value, remappingFunction));
+
+        assertEquals(1, map.size());
+        assertEquals(expectedNewValue, map.get(key));
+    }
+
+    @Test
+    void mergeShouldRemoveTheExistingMappingIfRemappingToAMissingValue()
+    {
+        final int key = 8;
+        final int oldValue = -17;
+        final int value = 5;
+        final IntIntFunction remappingFunction = (val1, val2) -> MISSING_VALUE;
+        map.put(key, oldValue);
+
+        assertEquals(MISSING_VALUE, map.merge(key, value, remappingFunction));
+
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    void putIfAbsentReturnsAnExistingValue()
+    {
+        final int key = 52;
+        final int value = -19;
+        final int newValue = Integer.MIN_VALUE;
+        map.put(key, value);
+
+        assertEquals(value, map.putIfAbsent(key, newValue));
+
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
+    void putIfAbsentPutANewMappingForANewKey()
+    {
+        final int key = 52;
+        final int newValue = Integer.MIN_VALUE;
+
+        assertEquals(MISSING_VALUE, map.putIfAbsent(key, newValue));
+
+        assertEquals(newValue, map.get(key));
+    }
+
+    @Test
+    void replaceShouldReturnMissingValueForAnUnknownKey()
+    {
+        final int key = 42;
+        final int value = 8;
+        map.put(1, 2);
+
+        assertEquals(MISSING_VALUE, map.replace(key, value));
+
+        assertEquals(1, map.size());
+        assertEquals(2, map.get(1));
+    }
+
+    @Test
+    void replaceShouldOverwriteAnExistingValue()
+    {
+        final int key = 42;
+        final int value = 8;
+        final int newValue = Integer.MAX_VALUE;
+        map.put(key, value);
+
+        assertEquals(value, map.replace(key, newValue));
+
+        assertEquals(1, map.size());
+        assertEquals(newValue, map.get(key));
+    }
+
+    @Test
+    void replaceReturnsFalseForAnUnknownKey()
+    {
+        final int key = 42;
+        final int value = 8;
+        final int newValue = 0;
+        map.put(1, 2);
+        map.put(2, 3);
+
+        assertFalse(map.replace(key, value, newValue));
+
+        assertEquals(2, map.size());
+        assertEquals(2, map.get(1));
+        assertEquals(3, map.get(2));
+    }
+
+    @Test
+    void replaceReturnsFalseForIfOldValueIsNotCorrect()
+    {
+        final int key = 42;
+        final int value = 8;
+        final int oldValue = -value;
+        final int newValue = 0;
+        map.put(key, value);
+
+        assertFalse(map.replace(key, oldValue, newValue));
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
+    void replaceReturnsTrueAfterUpdatingTheValueOfAnExistingKeyIfTheOldValueMatches()
+    {
+        final int key = 42;
+        final int value = 8;
+        final int newValue = 100;
+        map.put(key, value);
+
+        assertTrue(map.replace(key, value, newValue));
+
+        assertEquals(newValue, map.get(key));
+    }
+
+    @Test
+    void replaceAllIntShouldThrowIllegalArgumentExceptionIfANewValueIsAMissingValue()
+    {
+        final IntIntFunction function = (key, value) -> MISSING_VALUE;
+        map.put(1, 2);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.replaceAllInt(function));
+        assertEquals("cannot replace with a missingValue", exception.getMessage());
+    }
+
+    @Test
+    void replaceAllIntShouldUpdateAllExistingValues()
+    {
+        final IntIntFunction function = (key, value) -> value / 10;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(-4, 40);
+
+        map.replaceAllInt(function);
+
+        assertEquals(3, map.size());
+        assertEquals(1, map.get(1));
+        assertEquals(2, map.get(2));
+        assertEquals(4, map.get(-4));
+    }
+
+    @Test
+    void replaceAllShouldThrowIllegalArgumentExceptionIfANewValueIsAMissingValue()
+    {
+        final BiFunction<Integer, Integer, Integer> function = (key, value) -> MISSING_VALUE;
+        map.put(1, 2);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.replaceAll(function));
+        assertEquals("cannot replace with a missingValue", exception.getMessage());
+    }
+
+    @Test
+    void replaceAllShouldUpdateAllExistingValues()
+    {
+        final BiFunction<Integer, Integer, Integer> function = (key, value) -> value / 10;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(-4, 40);
+
+        map.replaceAll(function);
+
+        assertEquals(3, map.size());
+        assertEquals(1, map.get(1));
+        assertEquals(2, map.get(2));
+        assertEquals(4, map.get(-4));
+    }
+
+    @Test
+    void removeIsANoOpIfTheValueIsAMissingValue()
+    {
+        final int key = 5;
+        final int value = 18;
+        map.put(key, value);
+
+        assertFalse(map.remove(key, MISSING_VALUE));
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
+    void removeIsANoOpIfTheValueIsWrong()
+    {
+        final int key = 5;
+        final int value = 18;
+        map.put(key, value);
+
+        assertFalse(map.remove(key, 34));
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
+    void removeDeleteAMappingWhenAKeyAndValueMatch()
+    {
+        final int key = 5;
+        final int value = 18;
+        map.put(key, value);
+
+        assertTrue(map.remove(key, value));
+
+        assertEquals(0, map.size());
+        assertEquals(MISSING_VALUE, map.get(key));
     }
 
     private void assertEntryIs(final Entry<Integer, Integer> entry, final int expectedKey, final int expectedValue)

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -1073,6 +1073,40 @@ public class Int2IntHashMapTest
         assertEquals(MISSING_VALUE, map.get(key));
     }
 
+    @Test
+    void putAllCopiesAllValuesFromTheSourceMap()
+    {
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+        final Int2IntHashMap otherMap = new Int2IntHashMap(Integer.MIN_VALUE);
+        otherMap.put(-100, -100);
+        otherMap.put(1, 10);
+        otherMap.put(3, 30);
+        otherMap.put(5, 50);
+
+        map.putAll(otherMap);
+
+        assertEquals(5, map.size());
+        assertEquals(10, map.get(1));
+        assertEquals(2, map.get(2));
+        assertEquals(30, map.get(3));
+        assertEquals(50, map.get(5));
+        assertEquals(-100, map.get(-100));
+    }
+
+    @Test
+    void putAllThrowsIllegalArgumentExceptionIfOtherMapContainsMissingValue()
+    {
+        map.put(1, 1);
+        final Int2IntHashMap otherMap = new Int2IntHashMap(Integer.MIN_VALUE);
+        otherMap.put(MISSING_VALUE, MISSING_VALUE);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.putAll(otherMap));
+        assertEquals("cannot accept missingValue", exception.getMessage());
+    }
+
     private void assertEntryIs(final Entry<Integer, Integer> entry, final int expectedKey, final int expectedValue)
     {
         assertEquals(expectedKey, entry.getKey().intValue());

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -125,7 +125,7 @@ public class Int2IntHashMapTest
         map.put(100, 100);
 
         final IntIntConsumer mockConsumer = mock(IntIntConsumer.class);
-        map.intForEach(mockConsumer);
+        map.forEachInt(mockConsumer);
 
         final InOrder inOrder = inOrder(mockConsumer);
         inOrder.verify(mockConsumer).accept(100, 100);
@@ -515,7 +515,7 @@ public class Int2IntHashMapTest
         assertEquals(1, map.size());
 
         final int[] tuple = new int[2];
-        map.intForEach((k, v) ->
+        map.forEachInt((k, v) ->
         {
             tuple[0] = k;
             tuple[1] = v;

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -843,6 +843,19 @@ public class Int2IntHashMapTest
     }
 
     @Test
+    void mergeThrowsIllegalArgumentExceptionIfValueIsMissingValue()
+    {
+        final int missingValue = 42;
+        final Int2IntHashMap map = new Int2IntHashMap(missingValue);
+        final int key = -9;
+        final IntIntFunction remappingFunction = mock(IntIntFunction.class);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.merge(key, missingValue, remappingFunction));
+        assertEquals("cannot accept missingValue", exception.getMessage());
+    }
+
+    @Test
     void mergeShouldPutANewKeyIntoTheMap()
     {
         final int key = -9;

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1105,6 +1106,62 @@ public class Int2IntHashMapTest
         final IllegalArgumentException exception =
             assertThrowsExactly(IllegalArgumentException.class, () -> map.putAll(otherMap));
         assertEquals("cannot accept missingValue", exception.getMessage());
+    }
+
+    @Test
+    void removeIfIntOnKeySet()
+    {
+        final IntPredicate filter = (v) -> v < 3;
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+        map.put(4, 4);
+
+        assertTrue(map.keySet().removeIfInt(filter));
+
+        assertEquals(2, map.size());
+        assertEquals(3, map.get(3));
+        assertEquals(4, map.get(4));
+
+        assertFalse(map.keySet().removeIfInt(filter));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void removeIfIntOnValuesCollection()
+    {
+        final IntPredicate filter = (v) -> v >= 20;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(3, 30);
+        map.put(4, 40);
+
+        assertTrue(map.values().removeIfInt(filter));
+
+        assertEquals(1, map.size());
+        assertEquals(10, map.get(1));
+
+        assertFalse(map.values().removeIfInt(filter));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void removeIfIntOnEntrySet()
+    {
+        final IntIntPredicate filter = (k, v) -> k >= 2 && v <= 30;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(3, 30);
+        map.put(4, 40);
+
+        assertTrue(map.entrySet().removeIfInt(filter));
+
+        assertEquals(2, map.size());
+        assertEquals(10, map.get(1));
+        assertEquals(40, map.get(4));
+
+        assertFalse(map.entrySet().removeIfInt(filter));
+        assertEquals(2, map.size());
     }
 
     private void assertEntryIs(final Entry<Integer, Integer> entry, final int expectedKey, final int expectedValue)

--- a/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapConformanceTest.java
@@ -92,8 +92,12 @@ public class Int2NullableObjectHashMapConformanceTest
         }.withFeatures(
             MapFeature.GENERAL_PURPOSE,
             MapFeature.ALLOWS_NULL_VALUES,
+            MapFeature.ALLOWS_NULL_VALUE_QUERIES,
+            MapFeature.ALLOWS_NULL_ENTRY_QUERIES,
+            MapFeature.RESTRICTS_KEYS,
+            MapFeature.RESTRICTS_VALUES,
             CollectionSize.ANY,
-            CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
+            CollectionFeature.REMOVE_OPERATIONS)
             .named(name)
             .createTestSuite();
     }

--- a/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapTest.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
+
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class Int2NullableObjectHashMapTest
+{
+
+    @Test
+    void getOrDefaultShouldReturnDefaultValueIfNoMappingExistsForAGivenKey()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = -2;
+        final String defaultValue = "fallback";
+
+        assertEquals(defaultValue, map.getOrDefault(key, defaultValue));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = "abc")
+    void getOrDefaultShouldReturnExistingValueForTheGivenKey(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 121;
+        final String defaultValue = "default value";
+        map.put(key, value);
+
+        assertEquals(value, map.getOrDefault(key, defaultValue));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = "abc")
+    void replaceShouldReturnAnOldValueAfterReplacingAnExisitngValue(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = Integer.MIN_VALUE;
+        final String newValue = "new value";
+        map.put(key, value);
+
+        assertEquals(value, map.replace(key, newValue));
+
+        assertEquals(newValue, map.get(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = "xyz")
+    void replaceShouldReturnTrueAfterReplacingAnExistingValue(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = Integer.MAX_VALUE;
+        final String newValue = "new value";
+        map.put(key, value);
+
+        assertTrue(map.replace(key, value, newValue));
+        assertEquals(newValue, map.get(key));
+
+        assertTrue(map.replace(key, newValue, null));
+        assertEquals(1, map.size());
+        assertNull(map.get(key));
+    }
+
+    @Test
+    void replaceShouldReplaceWithNullValue()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 0;
+        final String value = "change me";
+        map.put(key, value);
+
+        assertTrue(map.replace(key, value, null));
+        assertEquals(1, map.size());
+        assertNull(map.get(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void putIfAbsentShouldReturnAnExistingValueForAnExistingKey(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        final String newValue = " this is something new";
+        map.put(key, value);
+
+        assertEquals(value, map.putIfAbsent(key, newValue));
+    }
+
+    @Test
+    void putIfAbsentShouldReturnNullAfterReplacingExistingNullMapping()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        final String newValue = " this is something new";
+        map.put(key, null);
+
+        assertNull(map.putIfAbsent(key, newValue));
+
+        assertEquals(newValue, map.get(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void putIfAbsentShouldReturnNullAfterPuttingANewValue(final String newValue)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(3, "three");
+
+        assertNull(map.putIfAbsent(key, newValue));
+
+        assertEquals(newValue, map.get(key));
+        assertEquals("three", map.get(3));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void removeReturnsTrueAfterRemovingTheKey(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(3, "three");
+        map.put(key, value);
+
+        assertTrue(map.remove(key, value));
+
+        assertEquals(1, map.size());
+        assertEquals("three", map.get(3));
+    }
+
+    @Test
+    void computeIfAbsentThrowsNullPointerExceptionIfMappingFunctionIsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 2;
+
+        assertThrows(NullPointerException.class, () -> map.computeIfAbsent(key, null));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    @SuppressWarnings("unchecked")
+    void computeIfAbsentReturnsAnExistingValueWithoutInvokingTheMappingFunction(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 2;
+        final IntFunction<String> mappingFunction = mock(IntFunction.class);
+        map.put(key, value);
+
+        assertEquals(value, map.computeIfAbsent(key, mappingFunction));
+
+        assertEquals(value, map.get(key));
+        verifyNoInteractions(mappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfAbsentReturnsNullIfMappingFunctionReturnsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final IntFunction<String> mappingFunction = mock(IntFunction.class);
+        final int key = 2;
+
+        assertNull(map.computeIfAbsent(key, mappingFunction));
+
+        assertFalse(map.containsKey(key));
+        verify(mappingFunction).apply(key);
+        verifyNoMoreInteractions(mappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfAbsentReturnsNewValueAfterCreatingAMapping()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 2;
+        final String value = "new value";
+        final IntFunction<String> mappingFunction = mock(IntFunction.class);
+        when(mappingFunction.apply(key)).thenReturn(value);
+
+        assertEquals(value, map.computeIfAbsent(key, mappingFunction));
+
+        assertTrue(map.containsKey(key));
+        assertEquals(value, map.get(key));
+        verify(mappingFunction).apply(key);
+        verifyNoMoreInteractions(mappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfAbsentReturnsNewValueAfterReplacingNullMapping()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = -190;
+        map.put(key, null);
+        final String value = "new value";
+        final IntFunction<String> mappingFunction = mock(IntFunction.class);
+        when(mappingFunction.apply(key)).thenReturn(value);
+
+        assertEquals(value, map.computeIfAbsent(key, mappingFunction));
+
+        assertTrue(map.containsKey(key));
+        assertEquals(value, map.get(key));
+        verify(mappingFunction).apply(key);
+        verifyNoMoreInteractions(mappingFunction);
+    }
+
+    @Test
+    void computeIfPresentThrowsNullPointerExceptionIfRemappingFunctionIsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 3;
+
+        assertThrowsExactly(NullPointerException.class, () -> map.computeIfPresent(key, null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfPresentReturnsNullForNonExistingKey()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final IntObjectToObjectFunction<String, String> remappingFunction = mock(IntObjectToObjectFunction.class);
+        final int key = 3;
+
+        assertNull(map.computeIfPresent(key, remappingFunction));
+
+        assertFalse(map.containsKey(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfPresentReturnsNullForIfKeyIsMappedToNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final IntObjectToObjectFunction<String, String> remappingFunction = mock(IntObjectToObjectFunction.class);
+        final int key = 3;
+        map.put(key, null);
+
+        assertNull(map.computeIfPresent(key, remappingFunction));
+
+        assertTrue(map.containsKey(key));
+        assertNull(map.get(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void computeIfPresentReturnsNewValueAfterAnUpdate(final String oldValue)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(key, oldValue);
+        map.put(5, "five");
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> k + v;
+        final String expectedNewValue = key + oldValue;
+
+        assertEquals(expectedNewValue, map.computeIfPresent(key, remappingFunction));
+
+        assertEquals(expectedNewValue, map.get(key));
+        assertEquals("five", map.get(5));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void computeIfPresentReturnsNullAfterRemovingAnExistingValue(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(key, value);
+        map.put(5, "five");
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> null;
+
+        assertNull(map.computeIfPresent(key, remappingFunction));
+
+        assertFalse(map.containsKey(key));
+        assertEquals("five", map.get(5));
+    }
+
+
+    @Test
+    void computeThrowsNullPointerExceptionIfRemappingFunctionIsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 3;
+
+        assertThrowsExactly(NullPointerException.class, () -> map.compute(key, null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeReturnsNullForUnExistingKey()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final IntObjectToObjectFunction<String, String> remappingFunction = mock(IntObjectToObjectFunction.class);
+        final int key = 3;
+        map.put(5, "five");
+
+        assertNull(map.compute(key, remappingFunction));
+
+        assertEquals("five", map.get(5));
+        assertFalse(map.containsKey(key));
+        verify(remappingFunction).apply(key, null);
+        verifyNoMoreInteractions(remappingFunction);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void computeReturnsNullAfterRemovingAnExistingValue(final String value)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(key, value);
+        map.put(5, "five");
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> null;
+
+        assertNull(map.compute(key, remappingFunction));
+
+        assertFalse(map.containsKey(key));
+        assertEquals("five", map.get(5));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "val 1", "你好" })
+    void computeReturnsANewValueAfterReplacingAnExistingOne(final String oldValue)
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(key, oldValue);
+        map.put(5, "five");
+        final String newValue = key + oldValue;
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> k + v;
+
+        assertEquals(newValue, map.compute(key, remappingFunction));
+
+        assertEquals(newValue, map.get(key));
+        assertEquals("five", map.get(5));
+    }
+
+    @Test
+    void computeReturnsANewValueAfterCreatingANewMapping()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        map.put(5, "five");
+        final String newValue = String.valueOf(System.currentTimeMillis());
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> newValue;
+
+        assertEquals(newValue, map.compute(key, remappingFunction));
+
+        assertEquals(newValue, map.get(key));
+        assertEquals("five", map.get(5));
+    }
+
+    @Test
+    void mergeThrowsNullPointerExceptionIfValueIsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 42;
+        final BiFunction<String, String, String> remappingFunction = (oldValue, newValue) -> null;
+
+        assertThrowsExactly(NullPointerException.class, () -> map.merge(key, null, remappingFunction));
+    }
+
+    @Test
+    void mergeThrowsNullPointerExceptionIfRemappingFunctionIsNull()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 8888;
+        final String value = "value";
+
+        assertThrowsExactly(NullPointerException.class, () -> map.merge(key, value, null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mergeShouldPutANewMappingForAnUnknownKeyWithoutCallingARemappingFunction()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 8888;
+        final String value = "value";
+        final BiFunction<String, String, String> remappingFunction = mock(BiFunction.class);
+
+        assertEquals(value, map.merge(key, value, remappingFunction));
+
+        assertEquals(value, map.get(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mergeShouldReplaceNullMappingWithAGivenValue()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 8888;
+        final String value = "value";
+        final BiFunction<String, String, String> remappingFunction = mock(BiFunction.class);
+        map.put(key, null);
+
+        assertEquals(value, map.merge(key, value, remappingFunction));
+
+        assertEquals(value, map.get(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mergeShouldReplaceExistingValueWithComputedValue()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final int key = 8888;
+        final String value = "value";
+        final String newValue = "NEW";
+        final String computedValue = "value => NEW";
+        final BiFunction<String, String, String> remappingFunction = mock(BiFunction.class);
+        when(remappingFunction.apply(any(), any())).thenAnswer((Answer<String>)invocation ->
+        {
+            final String oldVal = invocation.getArgument(0);
+            final String val = invocation.getArgument(1);
+            return oldVal + " => " + val;
+        });
+        map.put(key, value);
+
+        assertEquals(computedValue, map.merge(key, newValue, remappingFunction));
+
+        assertEquals(computedValue, map.get(key));
+        verify(remappingFunction).apply(value, newValue);
+        verifyNoMoreInteractions(remappingFunction);
+    }
+}

--- a/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2NullableObjectHashMapTest.java
@@ -461,4 +461,25 @@ class Int2NullableObjectHashMapTest
         verify(remappingFunction).apply(value, newValue);
         verifyNoMoreInteractions(remappingFunction);
     }
+
+    @Test
+    void removeIfIntOnEntrySet()
+    {
+        final Int2NullableObjectHashMap<String> map = new Int2NullableObjectHashMap<>();
+        final IntObjPredicate<String> filter = (key, value) -> (key & 1) == 0 || null == value;
+        map.put(1, "one");
+        map.put(2, "two");
+        map.put(3, "three");
+        map.put(4, "four");
+        map.put(5, null);
+
+        assertTrue(map.entrySet().removeIfInt(filter));
+
+        assertEquals(2, map.size());
+        assertEquals("one", map.get(1));
+        assertEquals("three", map.get(3));
+
+        assertFalse(map.entrySet().removeIfInt(filter));
+        assertEquals(2, map.size());
+    }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
@@ -28,6 +29,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class Int2ObjectCacheTest
 {
@@ -103,6 +105,9 @@ class Int2ObjectCacheTest
         cache.clear();
 
         assertThat(cache.size(), is(0));
+        assertNull(cache.get(0));
+        assertFalse(cache.containsKey(CAPACITY - 1));
+        assertFalse(cache.containsValue("1"));
     }
 
     @Test
@@ -276,5 +281,51 @@ class Int2ObjectCacheTest
         assertEquals(value, cache.getOrDefault(key, defaultValue));
         assertEquals(1, cache.cacheHits());
         assertEquals(0, cache.cacheMisses());
+    }
+
+    @Test
+    void forEachIntShouldIterateOverAllStoredValues()
+    {
+        @SuppressWarnings("unchecked")
+        final IntObjConsumer<String> consumer = mock(IntObjConsumer.class);
+        cache.put(1, "one");
+        cache.put(-3, "three");
+        cache.put(10, "ten");
+        cache.put(13, "thirteen");
+        cache.put(-11, "eleven");
+        cache.put(12, "twelve");
+        cache.put(42, "forty two");
+
+        cache.forEachInt(consumer);
+
+        verify(consumer).accept(1, "one");
+        verify(consumer).accept(-3, "three");
+        verify(consumer).accept(10, "ten");
+        verify(consumer).accept(13, "thirteen");
+        verify(consumer).accept(-11, "eleven");
+        verify(consumer).accept(12, "twelve");
+        verify(consumer).accept(42, "forty two");
+        verifyNoMoreInteractions(consumer);
+    }
+
+    @Test
+    void forEachShouldIterateOverAllStoredValues()
+    {
+        @SuppressWarnings("unchecked")
+        final BiConsumer<Integer, String> consumer = mock(BiConsumer.class);
+        cache.put(1, "one");
+        cache.put(-3, "three");
+        cache.put(10, "ten");
+        cache.put(12, "twelve");
+        cache.put(42, "forty two");
+
+        cache.forEach(consumer);
+
+        verify(consumer).accept(1, "one");
+        verify(consumer).accept(-3, "three");
+        verify(consumer).accept(10, "ten");
+        verify(consumer).accept(12, "twelve");
+        verify(consumer).accept(42, "forty two");
+        verifyNoMoreInteractions(consumer);
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -689,5 +690,35 @@ class Int2ObjectCacheTest
         assertEquals("2", cache.get(2));
         assertEquals("3", cache.get(3));
         assertEquals("42", cache.get(42));
+    }
+
+    @Test
+    void removeIfOnKeySet()
+    {
+        final Predicate<Integer> filter = (key) -> true;
+
+        final UnsupportedOperationException exception =
+            assertThrowsExactly(UnsupportedOperationException.class, () -> cache.keySet().removeIf(filter));
+        assertEquals("Cannot remove from KeySet", exception.getMessage());
+    }
+
+    @Test
+    void removeIfOnValuesCollection()
+    {
+        final Predicate<String> filter = (value) -> value.contains("e");
+
+        final UnsupportedOperationException exception =
+            assertThrowsExactly(UnsupportedOperationException.class, () -> cache.values().removeIf(filter));
+        assertEquals("Cannot remove from ValueCollection", exception.getMessage());
+    }
+
+    @Test
+    void removeIfOnEntrySetThrowsUnsupportedOperationException()
+    {
+        final Predicate<Map.Entry<Integer, String>> filter = (entry) -> true;
+
+        final UnsupportedOperationException exception =
+            assertThrowsExactly(UnsupportedOperationException.class, () -> cache.entrySet().removeIf(filter));
+        assertEquals("Cannot remove from EntrySet", exception.getMessage());
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
@@ -16,10 +16,14 @@
 package org.agrona.collections;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
@@ -211,6 +215,17 @@ class Int2ObjectCacheTest
     }
 
     @Test
+    void computeIfAbsentIsANoOpIfNewValueIsNull()
+    {
+        final int key = 9;
+        final IntFunction<String> function = (i) -> null;
+
+        assertNull(cache.computeIfAbsent(key, function));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
     void shouldTestStats()
     {
         assertThat(cache.cachePuts(), is(0L));
@@ -286,8 +301,7 @@ class Int2ObjectCacheTest
     @Test
     void forEachIntShouldIterateOverAllStoredValues()
     {
-        @SuppressWarnings("unchecked")
-        final IntObjConsumer<String> consumer = mock(IntObjConsumer.class);
+        @SuppressWarnings("unchecked") final IntObjConsumer<String> consumer = mock(IntObjConsumer.class);
         cache.put(1, "one");
         cache.put(-3, "three");
         cache.put(10, "ten");
@@ -311,8 +325,7 @@ class Int2ObjectCacheTest
     @Test
     void forEachShouldIterateOverAllStoredValues()
     {
-        @SuppressWarnings("unchecked")
-        final BiConsumer<Integer, String> consumer = mock(BiConsumer.class);
+        @SuppressWarnings("unchecked") final BiConsumer<Integer, String> consumer = mock(BiConsumer.class);
         cache.put(1, "one");
         cache.put(-3, "three");
         cache.put(10, "ten");
@@ -327,5 +340,333 @@ class Int2ObjectCacheTest
         verify(consumer).accept(12, "twelve");
         verify(consumer).accept(42, "forty two");
         verifyNoMoreInteractions(consumer);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void computeIfPresentReturnsNullForAnUnknownKey()
+    {
+        cache.put(1, "one");
+        final IntObjectToObjectFunction<String, String> remappingFunction = mock(IntObjectToObjectFunction.class);
+
+        assertNull(cache.computeIfPresent(555, remappingFunction));
+
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    void computeIfPresentReturnsNewValueAfterUpdatingTheMapping()
+    {
+        final int key = 1;
+        final String oldValue = "one";
+        final String newValue = "1oneNEW";
+        cache.put(key, oldValue);
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> k + v + "NEW";
+
+        assertEquals(newValue, cache.computeIfPresent(key, remappingFunction));
+
+        assertEquals(newValue, cache.get(key));
+    }
+
+    @Test
+    void computeIfPresentReturnsNullAfterRemovingTheExistingMapping()
+    {
+        final int key = -1111;
+        final String value = "one";
+        cache.put(key, value);
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> null;
+
+        assertNull(cache.computeIfPresent(key, remappingFunction));
+
+        assertNull(cache.get(key));
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void computeReturnsNewValueAfterInsertingANewMapping()
+    {
+        final int key = 42;
+        final String newValue = "new";
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) ->
+        {
+            assertEquals(key, k);
+            assertNull(v);
+            return newValue;
+        };
+
+        assertEquals(newValue, cache.compute(key, remappingFunction));
+
+        assertEquals(newValue, cache.get(key));
+    }
+
+    @Test
+    void computeReturnsNewValueAfterUpdatingAnExistingValue()
+    {
+        final int key = 42;
+        final String oldValue = "old";
+        cache.put(key, oldValue);
+        final String newValue = "new";
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) ->
+        {
+            assertEquals(key, k);
+            assertEquals(oldValue, v);
+            return newValue;
+        };
+
+        assertEquals(newValue, cache.compute(key, remappingFunction));
+
+        assertEquals(newValue, cache.get(key));
+    }
+
+    @Test
+    void computeReturnsNullAfterRemovingAnExistingMapping()
+    {
+        final int key = 42;
+        final String oldValue = "old";
+        cache.put(key, oldValue);
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) -> null;
+
+        assertNull(cache.compute(key, remappingFunction));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void computeReturnsNullForAnUnknownKeyIfTheFunctionReturnsNull()
+    {
+        final int key = 42;
+        final IntObjectToObjectFunction<String, String> remappingFunction = (k, v) ->
+        {
+            assertEquals(key, k);
+            assertNull(v);
+            return null;
+        };
+
+        assertNull(cache.compute(key, remappingFunction));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void mergeThrowsNullPointerExceptionIfValueIsNull()
+    {
+        final int key = -9;
+        final BiFunction<String, String, String> remappingFunction = (v1, v2) -> "NEW";
+
+        assertThrowsExactly(NullPointerException.class, () -> cache.merge(key, null, remappingFunction));
+    }
+
+    @Test
+    void mergeThrowsNullPointerExceptionIfRemappingFunctionIsNull()
+    {
+        final int key = -9;
+        final String value = "abc";
+
+        assertThrowsExactly(NullPointerException.class, () -> cache.merge(key, value, null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mergeInsertsNewValueForAnUnknownKey()
+    {
+        final int key = -9;
+        final String value = "abc";
+        final BiFunction<String, String, String> remappingFunction = mock(BiFunction.class);
+
+        assertEquals(value, cache.merge(key, value, remappingFunction));
+
+        assertEquals(value, cache.get(key));
+        verifyNoInteractions(remappingFunction);
+    }
+
+    @Test
+    void mergeReplacesAnExistingValue()
+    {
+        final int key = -9;
+        final String oldValue = "abc";
+        final String newValue = "abcXYZ";
+        cache.put(key, oldValue);
+        final BiFunction<String, String, String> remappingFunction = (oldVal, newVal) -> oldVal + newVal;
+
+        assertEquals(newValue, cache.merge(key, "XYZ", remappingFunction));
+
+        assertEquals(newValue, cache.get(key));
+    }
+
+    @Test
+    void mergeReturnsNullAfterRemovingExistingMapping()
+    {
+        final int key = -9;
+        final String oldValue = "abc";
+        cache.put(key, oldValue);
+        final BiFunction<String, String, String> remappingFunction = (oldVal, newVal) -> null;
+
+        assertNull(cache.merge(key, "XYZ", remappingFunction));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void putIfAbsentReturnsAnExistingValue()
+    {
+        final int key = 8;
+        final String value = "abc";
+        final String replaceValue = "something else";
+        cache.put(key, value);
+
+        assertEquals(value, cache.putIfAbsent(key, replaceValue));
+
+        assertEquals(value, cache.get(key));
+    }
+
+    @Test
+    void putIfAbsentInsertsANewValueIfNoMappingExists()
+    {
+        final int key = 8;
+        final String replaceValue = "something else";
+
+        assertNull(cache.putIfAbsent(key, replaceValue));
+
+        assertEquals(replaceValue, cache.get(key));
+    }
+
+    @Test
+    void removeIsANoOpIfTheKeyDoesNotExist()
+    {
+        final int key = 5;
+        final String value = "abc";
+        assertFalse(cache.remove(key, value));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "xyz", "ਯੋਧਾ" })
+    void removeIsANoOpIfTheValueDoesNotMatch(final String otherValue)
+    {
+        final int key = 5;
+        final String value = "abc";
+        cache.put(key, value);
+
+        assertFalse(cache.remove(key, otherValue));
+
+        assertEquals(value, cache.get(key));
+    }
+
+    @Test
+    void removeDeletesAKeyUponValueMatch()
+    {
+        final Int2ObjectCache<CharSequence> cache = new Int2ObjectCache<>(2, 4, (v) -> {});
+        final int key = 42;
+        cache.put(key, new CharSequenceKey("1,2,3"));
+
+        assertTrue(cache.remove(key, "1,2,3"));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "xyz", "ਯੋਧਾ" })
+    void replaceReturnsFalseIfOldValueDoesNotMatch(final String oldValue)
+    {
+        final int key = -5;
+        final String value = "abc";
+        final String newValue = "NEW";
+        cache.put(key, value);
+
+        assertFalse(cache.replace(key, oldValue, newValue));
+
+        assertEquals(value, cache.get(key));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "xyz", "ਯੋਧਾ" })
+    void replaceIsANoOpIfTheKeyDoesNotExist(final String oldValue)
+    {
+        final int key = 0;
+
+        assertFalse(cache.replace(key, oldValue, "NEW"));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void replaceReturnsTrueAfterChangingTheMapping()
+    {
+        final Int2ObjectCache<CharSequence> cache = new Int2ObjectCache<>(2, 4, (v) -> {});
+        final int key = -990;
+        cache.put(key, new CharSequenceKey("old"));
+
+        assertTrue(cache.replace(key, "old", "new"));
+
+        assertEquals("new", cache.get(key));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "hello", "добрий вечір" })
+    void replaceReturnsOldValueAfterReplacingItWithANewOne(final String value)
+    {
+        final int key = 2;
+        final String newValue = "new";
+        cache.put(key, value);
+
+        assertEquals(value, cache.replace(key, newValue));
+
+        assertEquals(newValue, cache.get(key));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "hello", "добрий вечір" })
+    void replaceReturnsNullWithoutAddingMappingForAnUnknownKey(final String newValue)
+    {
+        final int key = 2;
+
+        assertNull(cache.replace(key, newValue));
+
+        assertFalse(cache.containsKey(key));
+    }
+
+    @Test
+    void replaceThrowsNullPointerExceptionIfNewValueIsNull()
+    {
+        final int key = 2;
+        final String value = "abc";
+        cache.put(key, value);
+
+        assertThrowsExactly(NullPointerException.class, () -> cache.replace(key, null));
+    }
+
+    @Test
+    void replaceAllIntThrowsNullPointerExceptionIfFunctionIsNull()
+    {
+        assertThrowsExactly(NullPointerException.class, () -> cache.replaceAllInt(null));
+    }
+
+    @Test
+    void replaceAllIntThrowsNullPointerExceptionIfFunctionReturnsNullForAnyValue()
+    {
+        cache.put(4, "four");
+        final IntObjectToObjectFunction<String, String> function = (k, v) -> null;
+
+        final NullPointerException exception =
+            assertThrowsExactly(NullPointerException.class, () -> cache.replaceAllInt(function));
+        assertEquals("null values are not supported", exception.getMessage());
+    }
+
+    @Test
+    void replaceAllIntUpdatesEveryValueMapping()
+    {
+        cache.put(4, "four");
+        cache.put(-1, "minus one");
+        final IntObjectToObjectFunction<String, String> function = (k, v) -> v + k;
+
+        cache.replaceAllInt(function);
+
+        assertEquals(2, cache.size());
+        assertEquals("minus one-1", cache.get(-1));
+        assertEquals("four4", cache.get(4));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectCacheTest.java
@@ -669,4 +669,25 @@ class Int2ObjectCacheTest
         assertEquals("minus one-1", cache.get(-1));
         assertEquals("four4", cache.get(4));
     }
+
+    @Test
+    void putAllCopiesAllOfTheValuesFromTheSourceMap()
+    {
+        cache.put(42, "forty two");
+        cache.put(0, "zero");
+        final Int2ObjectCache<String> otherMap = new Int2ObjectCache<>(8, 32, EVICTION_CONSUMER);
+        otherMap.put(1, "1");
+        otherMap.put(2, "2");
+        otherMap.put(3, "3");
+        otherMap.put(42, "42");
+
+        cache.putAll(otherMap);
+
+        assertEquals(5, cache.size());
+        assertEquals("zero", cache.get(0));
+        assertEquals("1", cache.get(1));
+        assertEquals("2", cache.get(2));
+        assertEquals("3", cache.get(3));
+        assertEquals("42", cache.get(42));
+    }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -155,7 +155,7 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldCompute()
+    void shouldCompute()
     {
         final int testKey = 7;
         final String testValue = "Seven";
@@ -170,7 +170,7 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldComputeBoxed()
+    void shouldComputeBoxed()
     {
         final Map<Integer, String> intToObjectMap = this.intToObjectMap;
 
@@ -186,7 +186,7 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldComputeIfAbsent()
+    void shouldComputeIfAbsent()
     {
         final int testKey = 7;
         final String testValue = "Seven";
@@ -202,7 +202,7 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldComputeIfAbsentBoxed()
+    void shouldComputeIfAbsentBoxed()
     {
         final Map<Integer, String> intToObjectMap = this.intToObjectMap;
 
@@ -218,7 +218,7 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldComputeIfPresent()
+    void shouldComputeIfPresent()
     {
         final int testKey = 7;
         final String testValue = "Seven";
@@ -233,7 +233,29 @@ class Int2ObjectHashMapTest
     }
 
     @Test
-    public void shouldComputeIfPresentBoxed()
+    void computeIfPresentShouldDeleteExistingEntryIfFunctionReturnsNull()
+    {
+        intToObjectMap.put(1, "one");
+        final int key = 3;
+        final String value = "three";
+        intToObjectMap.put(key, value);
+        final IntObjectToObjectFunction<String, String> function = (k, v) ->
+        {
+            assertEquals(key, k);
+            assertEquals(value, v);
+            return null;
+        };
+
+        assertNull(intToObjectMap.computeIfPresent(key, function));
+
+        assertEquals(1, intToObjectMap.size());
+        assertEquals("one", intToObjectMap.get(1));
+        assertFalse(intToObjectMap.containsKey(key));
+        assertFalse(intToObjectMap.containsValue(value));
+    }
+
+    @Test
+    void shouldComputeIfPresentBoxed()
     {
         final Map<Integer, String> intToObjectMap = this.intToObjectMap;
 
@@ -711,6 +733,14 @@ class Int2ObjectHashMapTest
     }
 
     @Test
+    void replaceThrowsNullPointerExceptionIfValueIsNull()
+    {
+        final NullPointerException exception =
+            assertThrowsExactly(NullPointerException.class, () -> intToObjectMap.replace(42, null));
+        assertEquals("value cannot be null", exception.getMessage());
+    }
+
+    @Test
     void replaceReturnsNullForAnUnknownKey()
     {
         intToObjectMap.put(1, "one");
@@ -731,6 +761,14 @@ class Int2ObjectHashMapTest
         assertEquals(oldValue, intToObjectMap.replace(key, newValue));
 
         assertEquals(newValue, intToObjectMap.get(key));
+    }
+
+    @Test
+    void replaceThrowsNullPointerExceptionIfNewValueIsNull()
+    {
+        final NullPointerException exception =
+            assertThrowsExactly(NullPointerException.class, () -> intToObjectMap.replace(42, "abc", null));
+        assertEquals("value cannot be null", exception.getMessage());
     }
 
     @Test
@@ -817,6 +855,14 @@ class Int2ObjectHashMapTest
 
         assertEquals(newValue, intToObjectMap.get(key));
         assertEquals("three", intToObjectMap.get(3));
+    }
+
+    @Test
+    void putIfAbsentThrowsNullPointerExceptionIfValueIsNull()
+    {
+        final NullPointerException exception =
+            assertThrowsExactly(NullPointerException.class, () -> intToObjectMap.putIfAbsent(42, null));
+        assertEquals("value cannot be null", exception.getMessage());
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -486,7 +486,7 @@ class Int2ObjectHashMapTest
         }
 
         final Collection<Integer> copyToSet = new HashSet<>();
-        intToObjectMap.intForEach(
+        intToObjectMap.forEachInt(
             (key, value) ->
             {
                 assertEquals(value, String.valueOf(key));

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -794,7 +794,7 @@ class Int2ObjectHashMapTest
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "val 1", "你好"})
+    @ValueSource(strings = { "", "val 1", "你好" })
     void putIfAbsentShouldReturnAnExistingValueForAnExistingKey(final String value)
     {
         final int key = 42;
@@ -805,7 +805,7 @@ class Int2ObjectHashMapTest
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "val 1", "你好"})
+    @ValueSource(strings = { "", "val 1", "你好" })
     void putIfAbsentShouldReturnNullAfterPuttingANewValue(final String newValue)
     {
         final int key = 42;
@@ -817,4 +817,36 @@ class Int2ObjectHashMapTest
         assertEquals("three", intToObjectMap.get(3));
     }
 
+    @Test
+    void putAllCopiesAllOfTheValuesFromTheSourceMap()
+    {
+        intToObjectMap.put(42, "forty two");
+        intToObjectMap.put(0, "zero");
+        final Int2ObjectHashMap<String> otherMap = new Int2ObjectHashMap<>();
+        otherMap.put(1, "1");
+        otherMap.put(2, "2");
+        otherMap.put(3, "3");
+        otherMap.put(42, "42");
+
+        intToObjectMap.putAll(otherMap);
+
+        assertEquals(5, intToObjectMap.size());
+        assertEquals("zero", intToObjectMap.get(0));
+        assertEquals("1", intToObjectMap.get(1));
+        assertEquals("2", intToObjectMap.get(2));
+        assertEquals("3", intToObjectMap.get(3));
+        assertEquals("42", intToObjectMap.get(42));
+    }
+
+    @Test
+    void putAllThrowsNullPointerExceptionIfOtherMapContainsNull()
+    {
+        intToObjectMap.put(0, "zero");
+        final Int2NullableObjectHashMap<String> otherMap = new Int2NullableObjectHashMap<>();
+        otherMap.put(1, null);
+
+        final NullPointerException exception =
+            assertThrowsExactly(NullPointerException.class, () -> intToObjectMap.putAll(otherMap));
+        assertEquals("value cannot be null", exception.getMessage());
+    }
 }

--- a/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2ObjectHashMapTest.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -848,5 +850,60 @@ class Int2ObjectHashMapTest
         final NullPointerException exception =
             assertThrowsExactly(NullPointerException.class, () -> intToObjectMap.putAll(otherMap));
         assertEquals("value cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void removeIfIntOnKeySet()
+    {
+        final IntPredicate filter = (key) -> (key & 1) == 0;
+        intToObjectMap.put(1, "one");
+        intToObjectMap.put(2, "two");
+        intToObjectMap.put(3, "three");
+
+        assertTrue(intToObjectMap.keySet().removeIfInt(filter));
+
+        assertEquals(2, intToObjectMap.size());
+        assertEquals("one", intToObjectMap.get(1));
+        assertEquals("three", intToObjectMap.get(3));
+
+        assertFalse(intToObjectMap.keySet().removeIfInt(filter));
+        assertEquals(2, intToObjectMap.size());
+    }
+
+    @Test
+    void removeIfOnValuesCollection()
+    {
+        final Predicate<String> filter = (value) -> value.contains("e");
+        intToObjectMap.put(1, "one");
+        intToObjectMap.put(2, "two");
+        intToObjectMap.put(3, "three");
+
+        assertTrue(intToObjectMap.values().removeIf(filter));
+
+        assertEquals(1, intToObjectMap.size());
+        assertEquals("two", intToObjectMap.get(2));
+
+        assertFalse(intToObjectMap.values().removeIf(filter));
+        assertEquals(1, intToObjectMap.size());
+    }
+
+    @Test
+    void removeIfIntOnEntrySet()
+    {
+        final IntObjPredicate<String> filter = (key, value) -> (key & 1) == 0 && value.startsWith("t");
+        intToObjectMap.put(1, "one");
+        intToObjectMap.put(2, "two");
+        intToObjectMap.put(3, "three");
+        intToObjectMap.put(4, "four");
+
+        assertTrue(intToObjectMap.entrySet().removeIfInt(filter));
+
+        assertEquals(3, intToObjectMap.size());
+        assertEquals("one", intToObjectMap.get(1));
+        assertEquals("three", intToObjectMap.get(3));
+        assertEquals("four", intToObjectMap.get(4));
+
+        assertFalse(intToObjectMap.entrySet().removeIfInt(filter));
+        assertEquals(3, intToObjectMap.size());
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -695,11 +695,12 @@ class IntArrayListTest
     @Test
     void removeAllShouldDeleteAllElementsThatAreContainedInTheTargetList()
     {
-        final IntArrayList other = new IntArrayList();
+        final IntArrayList other = new IntArrayList(2, -1);
         other.addInt(1);
         other.addInt(3);
         other.addInt(5);
         other.addInt(7);
+        other.addInt(DEFAULT_NULL_VALUE);
         list.addInt(7);
         list.addInt(1);
         list.addInt(2);
@@ -711,6 +712,7 @@ class IntArrayListTest
         list.addInt(5);
         list.addInt(8);
         list.addInt(7);
+        list.addInt(DEFAULT_NULL_VALUE);
 
         assertTrue(list.removeAll(other));
 
@@ -719,5 +721,48 @@ class IntArrayListTest
         assertEquals(4, list.getInt(1));
         assertEquals(6, list.getInt(2));
         assertEquals(8, list.getInt(3));
+    }
+
+    @Test
+    void removeIfIntThrowsNullPointerExceptionIsFilterIsNull()
+    {
+        assertThrowsExactly(NullPointerException.class, () -> list.removeIfInt(null));
+    }
+
+    @Test
+    void removeIfIntDeletesAllElementsThatMatchFilter()
+    {
+        final IntPredicate filter = (v) -> v < 0 || v > 10;
+        list.add(null);
+        list.addInt(2);
+        list.addInt(DEFAULT_NULL_VALUE);
+        list.addInt(3);
+        list.addInt(0);
+        list.addInt(42);
+
+        assertTrue(list.removeIfInt(filter));
+
+        assertEquals(3, list.size());
+        assertEquals(2, list.getInt(0));
+        assertEquals(3, list.getInt(1));
+        assertEquals(0, list.getInt(2));
+    }
+
+    @Test
+    void removeIfIsANoOpIfNoElementsMatchTheFilter()
+    {
+        final IntPredicate filter = (v) -> v < 0;
+        list.addInt(2);
+        list.addInt(3);
+        list.addInt(0);
+        list.addInt(42);
+
+        assertFalse(list.removeIfInt(filter));
+
+        assertEquals(4, list.size());
+        assertEquals(2, list.getInt(0));
+        assertEquals(3, list.getInt(1));
+        assertEquals(0, list.getInt(2));
+        assertEquals(42, list.getInt(3));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 
+import static org.agrona.collections.IntArrayList.DEFAULT_NULL_VALUE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -139,6 +141,20 @@ class IntArrayListTest
 
         assertThat(list.size(), is(count - 1));
         assertThat(list.getInt(10), is(11));
+    }
+
+    @Test
+    void shouldRemoveNullValueAtIndexBoxing()
+    {
+        list.addInt(34);
+        list.add(null);
+        list.addInt(15);
+
+        assertNull(list.remove(1));
+
+        assertEquals(2, list.size());
+        assertEquals(34, list.getInt(0));
+        assertEquals(15, list.getInt(1));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -16,6 +16,8 @@
 package org.agrona.collections;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,19 +29,19 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IntArrayListTest
+class IntArrayListTest
 {
     private final IntArrayList list = new IntArrayList();
 
     @Test
-    public void shouldReportEmpty()
+    void shouldReportEmpty()
     {
         assertThat(list.size(), is(0));
         assertThat(list.isEmpty(), is(true));
     }
 
     @Test
-    public void shouldAddValue()
+    void shouldAddValue()
     {
         list.add(7);
 
@@ -48,7 +50,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldAddNull()
+    void shouldAddNull()
     {
         list.add(null);
 
@@ -57,7 +59,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldAddIntValue()
+    void shouldAddIntValue()
     {
         list.addInt(7);
 
@@ -66,7 +68,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldAddValueAtIndex()
+    void shouldAddValueAtIndex()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
@@ -79,7 +81,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldAddValueAtIndexWithNearlyFullCapacity()
+    void shouldAddValueAtIndexWithNearlyFullCapacity()
     {
         final int count = IntArrayList.INITIAL_CAPACITY - 1;
         final int value = count + 1;
@@ -93,7 +95,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldSetIntValue()
+    void shouldSetIntValue()
     {
         list.addInt(7);
         list.setInt(0, 8);
@@ -103,7 +105,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldSetValue()
+    void shouldSetValue()
     {
         list.add(7);
         list.set(0, 8);
@@ -113,7 +115,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldContainCorrectValues()
+    void shouldContainCorrectValues()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
@@ -128,7 +130,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldRemoveAtIndexBoxing()
+    void shouldRemoveAtIndexBoxing()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
@@ -140,7 +142,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldRemoveAtIndex()
+    void shouldRemoveAtIndex()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
@@ -152,7 +154,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldRemoveAtIndexForListLengthOne()
+    void shouldRemoveAtIndexForListLengthOne()
     {
         list.addInt(1);
 
@@ -162,7 +164,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldFastRemoveUnorderedAtIndex()
+    void shouldFastRemoveUnorderedAtIndex()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
@@ -174,7 +176,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldFastRemoveUnorderedByValue()
+    void shouldFastRemoveUnorderedByValue()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered((value) -> list.addInt(value * 10));
@@ -221,7 +223,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldForEachOrderedInt()
+    void shouldForEachOrderedInt()
     {
         final List<Integer> expected = new ArrayList<>();
         IntStream.range(0, 20).forEachOrdered(expected::add);
@@ -234,7 +236,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldCreateObjectRefArray()
+    void shouldCreateObjectRefArray()
     {
         final int count = 20;
         final List<Integer> expected = new ArrayList<>();
@@ -245,7 +247,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldCreateIntArray()
+    void shouldCreateIntArray()
     {
         final int count = 20;
         final int[] expected = new int[count];
@@ -265,7 +267,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldCreateIntegerArray()
+    void shouldCreateIntegerArray()
     {
         final int count = 20;
         final Integer[] expected = new Integer[count];
@@ -281,7 +283,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldPushAndThenPopInOrder()
+    void shouldPushAndThenPopInOrder()
     {
         final int count = 7;
         for (int i = 0; i < count; i++)
@@ -296,13 +298,13 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldThrowExceptionWhenPoppingEmptyList()
+    void shouldThrowExceptionWhenPoppingEmptyList()
     {
         assertThrows(NoSuchElementException.class, list::popInt);
     }
 
     @Test
-    public void shouldEqualGenericList()
+    void shouldEqualGenericList()
     {
         final int count = 7;
         final List<Integer> genericList = new ArrayList<>();
@@ -320,7 +322,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldEqualsAndHashcode()
+    void shouldEqualsAndHashcode()
     {
         final ArrayList<Integer> genericList = new ArrayList<>();
         final int count = 20;
@@ -337,7 +339,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldGenerateStringRepresentation()
+    void shouldGenerateStringRepresentation()
     {
         final int[] testEntries = { 3, 1, -1, 19, 7, 11, 12, 7 };
 
@@ -351,7 +353,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldWrapLessThanInitialCapacityThenGrow()
+    void shouldWrapLessThanInitialCapacityThenGrow()
     {
         final int[] array = new int[]{ 1, 2, 3 };
         final IntArrayList list = new IntArrayList();
@@ -363,7 +365,7 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldWrapLessZeroLengthArrayThenGrow()
+    void shouldWrapLessZeroLengthArrayThenGrow()
     {
         final IntArrayList list = new IntArrayList();
 
@@ -371,5 +373,186 @@ public class IntArrayListTest
 
         list.addInt(7);
         assertThat(list.capacity(), is(IntArrayList.INITIAL_CAPACITY));
+    }
+
+    @Test
+    void removeThrowsNullPointerExceptionIfValueIsNull()
+    {
+        assertThrowsExactly(NullPointerException.class, () -> list.remove(null));
+    }
+
+    @Test
+    void removeThrowsNClassCastExceptionIfValueIsNotInteger()
+    {
+        assertThrowsExactly(ClassCastException.class, () -> list.remove(Double.valueOf(24.5)));
+    }
+
+    @Test
+    void removeReturnsFalseForAnUnknownValue()
+    {
+        list.addInt(42);
+
+        assertFalse(list.remove(Integer.valueOf(5)));
+
+        assertEquals(42, list.get(0));
+    }
+
+    @Test
+    void removeReturnsTrueAfterRemovingTheFirstOccurrenceOfTheValue()
+    {
+        list.addInt(42);
+        list.addInt(5);
+        list.addInt(42);
+
+        assertTrue(list.remove(Integer.valueOf(42)));
+
+        assertEquals(2, list.size());
+        assertEquals(5, list.get(0));
+        assertEquals(42, list.get(1));
+    }
+
+    @Test
+    void addAllAppendsAllItemsToTheEndOfTheList()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(3);
+        other.addInt(4);
+        other.addInt(5);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+
+        assertTrue(list.addAll(other));
+
+        assertEquals(6, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+        assertEquals(3, list.getInt(2));
+        assertEquals(3, list.getInt(3));
+        assertEquals(4, list.getInt(4));
+        assertEquals(5, list.getInt(5));
+    }
+
+    @Test
+    void addAllAppendsToItself()
+    {
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+
+        assertTrue(list.addAll(list));
+
+        assertEquals(6, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+        assertEquals(3, list.getInt(2));
+        assertEquals(1, list.getInt(3));
+        assertEquals(2, list.getInt(4));
+        assertEquals(3, list.getInt(5));
+    }
+
+    @Test
+    void addAllIsANoOpIfTheSourceListIsEmpty()
+    {
+        list.addInt(3);
+
+        assertFalse(list.addAll(new IntArrayList()));
+
+        assertEquals(1, list.size());
+        assertEquals(3, list.getInt(0));
+    }
+
+    @Test
+    void addAllWithIndexAddsElementsStartingAtAGivenIndex()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(17);
+        other.addInt(9);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+        list.addInt(4);
+        list.addInt(5);
+
+        assertTrue(list.addAll(1, other));
+
+        assertEquals(7, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(17, list.getInt(1));
+        assertEquals(9, list.getInt(2));
+        assertEquals(2, list.getInt(3));
+        assertEquals(3, list.getInt(4));
+        assertEquals(4, list.getInt(5));
+        assertEquals(5, list.getInt(6));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 4 })
+    void addAllWithIndexThrowsIndexOutOfBoundsExceptionIfIndexIsInvalid(final int index)
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(19);
+
+        final IndexOutOfBoundsException exception =
+            assertThrowsExactly(IndexOutOfBoundsException.class, () -> list.addAll(index, other));
+        assertEquals("index=" + index + " size=0", exception.getMessage());
+    }
+
+    @Test
+    void addAllWithIndexCanAddFromTheBeginning()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(4);
+        other.addInt(5);
+        other.addInt(6);
+        list.addInt(1);
+        list.addInt(2);
+
+        assertTrue(list.addAll(0, other));
+
+        assertEquals(5, list.size());
+        assertEquals(4, list.getInt(0));
+        assertEquals(5, list.getInt(1));
+        assertEquals(6, list.getInt(2));
+        assertEquals(1, list.getInt(3));
+        assertEquals(2, list.getInt(4));
+    }
+
+    @Test
+    void addAllWithIndexCanAddAtTheEnd()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(4);
+        other.addInt(5);
+        other.addInt(6);
+        list.addInt(1);
+        list.addInt(2);
+
+        assertTrue(list.addAll(2, other));
+
+        assertEquals(5, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+        assertEquals(4, list.getInt(2));
+        assertEquals(5, list.getInt(3));
+        assertEquals(6, list.getInt(4));
+    }
+
+    @Test
+    void addAllWithIndexCanAddToItself()
+    {
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+
+        assertTrue(list.addAll(2, list));
+
+        assertEquals(6, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+        assertEquals(1, list.getInt(2));
+        assertEquals(2, list.getInt(3));
+        assertEquals(3, list.getInt(4));
+        assertEquals(3, list.getInt(5));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.IntPredicate;
@@ -392,12 +393,6 @@ class IntArrayListTest
     }
 
     @Test
-    void removeThrowsNullPointerExceptionIfValueIsNull()
-    {
-        assertThrowsExactly(NullPointerException.class, () -> list.remove(null));
-    }
-
-    @Test
     void removeThrowsNClassCastExceptionIfValueIsNotInteger()
     {
         assertThrowsExactly(ClassCastException.class, () -> list.remove(Double.valueOf(24.5)));
@@ -575,7 +570,7 @@ class IntArrayListTest
     @Test
     void containsAllReturnsTrueIfTheListContainsAllOfTheElementsOfSourceList()
     {
-        final IntArrayList other = new IntArrayList();
+        final IntArrayList other = new IntArrayList(2, 42);
         other.addInt(1);
         other.addInt(1);
         other.addInt(1);
@@ -585,6 +580,7 @@ class IntArrayListTest
         other.addInt(0);
         other.addInt(2);
         other.addInt(1);
+        other.add(null);
         list.addInt(-8);
         list.addInt(0);
         list.addInt(1);
@@ -602,6 +598,38 @@ class IntArrayListTest
         list.addInt(42);
 
         assertTrue(list.containsAll(other));
+    }
+
+    @Test
+    void containsAllHandlesNullValueInTheSourceList()
+    {
+        final List<Integer> other = Arrays.asList(1, 2, null, 100);
+        list.addInt(1);
+        list.addInt(100);
+        list.addInt(2);
+        list.addInt(DEFAULT_NULL_VALUE);
+        list.addInt(3);
+        list.addInt(-1);
+
+        assertTrue(list.containsAll(other));
+    }
+
+    @Test
+    void containsReturnsTrueIfListContainsValue()
+    {
+        final int element = 13;
+        list.addInt(element);
+
+        assertTrue(list.contains(element));
+    }
+
+    @Test
+    void containsReturnsTrueIfListContainsNull()
+    {
+        list.addInt(42);
+        list.add(null);
+
+        assertTrue(list.contains(null));
     }
 
     @Test
@@ -780,5 +808,39 @@ class IntArrayListTest
         assertEquals(3, list.getInt(1));
         assertEquals(0, list.getInt(2));
         assertEquals(42, list.getInt(3));
+    }
+
+    @Test
+    void removeByObjectReturnsTrueAfterRemovingTheFirstOccurrenceOfTheValue()
+    {
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(1);
+        list.addInt(5);
+
+        assertTrue(list.remove(Integer.valueOf(1)));
+
+        assertEquals(3, list.size());
+        assertEquals(2, list.getInt(0));
+        assertEquals(1, list.getInt(1));
+        assertEquals(5, list.getInt(2));
+    }
+
+    @Test
+    void removeByObjectReturnsTrueAfterRemovingFirstNull()
+    {
+        list.addInt(1);
+        list.addInt(1);
+        list.addInt(DEFAULT_NULL_VALUE);
+        list.addInt(5);
+        list.add(null);
+
+        assertTrue(list.remove(null));
+
+        assertEquals(4, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(1, list.getInt(1));
+        assertEquals(5, list.getInt(2));
+        assertEquals(DEFAULT_NULL_VALUE, list.getInt(3));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -601,6 +601,19 @@ class IntArrayListTest
     }
 
     @Test
+    void containsAllReturnsTrueIfTheNullValueContainedInBothLists()
+    {
+        final IntArrayList other = new IntArrayList(1, 888);
+        other.add(null);
+        other.add(5);
+        list.addInt(5);
+        list.addInt(42);
+        list.add(null);
+
+        assertTrue(list.containsAll(other));
+    }
+
+    @Test
     void containsAllHandlesNullValueInTheSourceList()
     {
         final List<Integer> other = Arrays.asList(1, 2, null, 100);
@@ -672,7 +685,43 @@ class IntArrayListTest
     @Test
     void retainAllShouldDeleteAllItemsNotFoundInOtherList()
     {
-        final IntArrayList other = new IntArrayList();
+        final IntArrayList other = new IntArrayList(2, -100);
+        other.addInt(1);
+        other.addInt(10);
+        other.addInt(100);
+        other.addInt(1000);
+        other.add(null);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(-999);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(10);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(1);
+        list.addInt(10);
+        list.addInt(5);
+        list.addInt(-1);
+        list.add(null);
+        list.addInt(100);
+
+        assertTrue(list.retainAll(other));
+
+        assertEquals(6, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(10, list.getInt(1));
+        assertEquals(1, list.getInt(2));
+        assertEquals(10, list.getInt(3));
+        assertEquals(DEFAULT_NULL_VALUE, list.getInt(4));
+        assertEquals(100, list.getInt(5));
+    }
+
+    @Test
+    void retainAllShouldDeleteNullsIfTheTargetListDoesNotContainAny()
+    {
+        final IntArrayList other = new IntArrayList(2, -100);
         other.addInt(1);
         other.addInt(10);
         other.addInt(100);
@@ -690,6 +739,7 @@ class IntArrayListTest
         list.addInt(10);
         list.addInt(5);
         list.addInt(-1);
+        list.add(null);
         list.addInt(100);
 
         assertTrue(list.retainAll(other));
@@ -739,12 +789,14 @@ class IntArrayListTest
     @Test
     void removeAllShouldDeleteAllElementsThatAreContainedInTheTargetList()
     {
-        final IntArrayList other = new IntArrayList(2, -1);
+        final int nullValue = -1;
+        assertNotEquals(DEFAULT_NULL_VALUE, nullValue);
+        final IntArrayList other = new IntArrayList(2, nullValue);
         other.addInt(1);
         other.addInt(3);
         other.addInt(5);
         other.addInt(7);
-        other.addInt(DEFAULT_NULL_VALUE);
+        other.add(null);
         list.addInt(7);
         list.addInt(1);
         list.addInt(2);
@@ -752,6 +804,7 @@ class IntArrayListTest
         list.addInt(6);
         list.addInt(1);
         list.addInt(1);
+        list.add(null);
         list.addInt(1);
         list.addInt(5);
         list.addInt(8);
@@ -765,6 +818,29 @@ class IntArrayListTest
         assertEquals(4, list.getInt(1));
         assertEquals(6, list.getInt(2));
         assertEquals(8, list.getInt(3));
+    }
+
+    @Test
+    void removeAllShouldNotDeleteNullValuesIfTheSourceListDoesNotContainAny()
+    {
+        final IntArrayList other = new IntArrayList(5, 333);
+        other.addInt(1);
+        other.addInt(3);
+        list.addInt(1);
+        list.add(null);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+        list.addInt(6);
+        list.addInt(DEFAULT_NULL_VALUE);
+
+        assertTrue(list.removeAll(other));
+
+        assertEquals(4, list.size());
+        assertEquals(DEFAULT_NULL_VALUE, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+        assertEquals(6, list.getInt(2));
+        assertEquals(DEFAULT_NULL_VALUE, list.getInt(3));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -555,4 +555,169 @@ class IntArrayListTest
         assertEquals(3, list.getInt(4));
         assertEquals(3, list.getInt(5));
     }
+
+    @Test
+    void containsAllReturnsTrueIfTheListContainsAllOfTheElementsOfSourceList()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(1);
+        other.addInt(1);
+        other.addInt(1);
+        other.addInt(2);
+        other.addInt(0);
+        other.addInt(0);
+        other.addInt(0);
+        other.addInt(2);
+        other.addInt(1);
+        list.addInt(-8);
+        list.addInt(0);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(42);
+
+        assertTrue(list.containsAll(other));
+    }
+
+    @Test
+    void containsAllReturnsTrueIfTheSourceListIsEmpty()
+    {
+        final IntArrayList other = new IntArrayList();
+        list.addInt(-8);
+        list.addInt(42);
+
+        assertTrue(list.containsAll(other));
+    }
+
+    @Test
+    void containsAllReturnsFalseIfAtLeastOneElementOfTheSourceListIsNotFound()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(1);
+        other.addInt(1);
+        other.addInt(2);
+        other.addInt(10);
+        other.addInt(20);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(3);
+        list.addInt(20);
+
+        assertFalse(list.containsAll(other));
+    }
+
+    @Test
+    void retainAllIsANoOpIfTheTargetListContainsAllOfTheItemsInTheSourceList()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(1);
+        other.addInt(10);
+        other.addInt(100);
+        other.addInt(1000);
+        list.addInt(100);
+        list.addInt(100);
+        list.addInt(1);
+
+        assertFalse(list.retainAll(other));
+
+        assertEquals(3, list.size());
+        assertEquals(100, list.getInt(0));
+        assertEquals(100, list.getInt(1));
+        assertEquals(1, list.getInt(2));
+    }
+
+    @Test
+    void retainAllShouldDeleteAllItemsNotFoundInOtherList()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(1);
+        other.addInt(10);
+        other.addInt(100);
+        other.addInt(1000);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(-999);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(10);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(1);
+        list.addInt(10);
+        list.addInt(5);
+        list.addInt(-1);
+        list.addInt(100);
+
+        assertTrue(list.retainAll(other));
+
+        assertEquals(5, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(10, list.getInt(1));
+        assertEquals(1, list.getInt(2));
+        assertEquals(10, list.getInt(3));
+        assertEquals(100, list.getInt(4));
+    }
+
+    @Test
+    void retainAllShouldEraseTheEntireListIfTheTargetListIsEmpty()
+    {
+        final IntArrayList other = new IntArrayList();
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(10);
+        list.addInt(2);
+        list.addInt(2);
+        list.addInt(1);
+        list.addInt(10);
+        list.addInt(5);
+        list.addInt(-1);
+        list.addInt(100);
+
+        assertTrue(list.retainAll(other));
+
+        assertEquals(0, list.size());
+    }
+
+    @Test
+    void removeAllIsANoOpIfTheTargetListIsEmpty()
+    {
+        final IntArrayList other = new IntArrayList();
+        list.addInt(5);
+        list.addInt(8);
+
+        assertFalse(list.removeAll(other));
+
+        assertEquals(2, list.size());
+        assertEquals(5, list.getInt(0));
+        assertEquals(8, list.getInt(1));
+    }
+
+    @Test
+    void removeAllShouldDeleteAllElementsThatAreContainedInTheTargetList()
+    {
+        final IntArrayList other = new IntArrayList();
+        other.addInt(1);
+        other.addInt(3);
+        other.addInt(5);
+        other.addInt(7);
+        list.addInt(7);
+        list.addInt(1);
+        list.addInt(2);
+        list.addInt(4);
+        list.addInt(6);
+        list.addInt(1);
+        list.addInt(1);
+        list.addInt(1);
+        list.addInt(5);
+        list.addInt(8);
+        list.addInt(7);
+
+        assertTrue(list.removeAll(other));
+
+        assertEquals(4, list.size());
+        assertEquals(2, list.getInt(0));
+        assertEquals(4, list.getInt(1));
+        assertEquals(6, list.getInt(2));
+        assertEquals(8, list.getInt(3));
+    }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -128,12 +128,24 @@ public class IntArrayListTest
     }
 
     @Test
-    public void shouldRemoveAtIndex()
+    public void shouldRemoveAtIndexBoxing()
     {
         final int count = 20;
         IntStream.range(0, count).forEachOrdered(list::addInt);
 
         assertThat(list.remove(10), is(10));
+
+        assertThat(list.size(), is(count - 1));
+        assertThat(list.getInt(10), is(11));
+    }
+
+    @Test
+    public void shouldRemoveAtIndex()
+    {
+        final int count = 20;
+        IntStream.range(0, count).forEachOrdered(list::addInt);
+
+        assertThat(list.removeAt(10), is(10));
 
         assertThat(list.size(), is(count - 1));
         assertThat(list.getInt(10), is(11));
@@ -171,6 +183,41 @@ public class IntArrayListTest
 
         assertThat(list.size(), is(count - 1));
         assertThat(list.getInt(1), is(190));
+    }
+
+    @Test
+    void removeIntReturnsFalseIfValueDoesNotExist()
+    {
+        list.addInt(5);
+        list.addInt(0);
+        list.addInt(42);
+
+        assertFalse(list.removeInt(8));
+
+        assertEquals(3, list.size());
+        assertEquals(5, list.getInt(0));
+        assertEquals(0, list.getInt(1));
+        assertEquals(42, list.getInt(2));
+    }
+
+    @Test
+    void removeIntReturnsTrueAfterRemovingFirstMatchingValueFromTheList()
+    {
+        list.addInt(5);
+        list.addInt(-1);
+        list.addInt(42);
+        list.addInt(8);
+        list.addInt(-1);
+        list.addInt(0);
+
+        assertTrue(list.removeInt(-1));
+
+        assertEquals(5, list.size());
+        assertEquals(5, list.getInt(0));
+        assertEquals(42, list.getInt(1));
+        assertEquals(8, list.getInt(2));
+        assertEquals(-1, list.getInt(3));
+        assertEquals(0, list.getInt(4));
     }
 
     @Test

--- a/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntArrayListTest.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static org.agrona.collections.IntArrayList.DEFAULT_NULL_VALUE;
@@ -918,5 +920,50 @@ class IntArrayListTest
         assertEquals(1, list.getInt(1));
         assertEquals(5, list.getInt(2));
         assertEquals(DEFAULT_NULL_VALUE, list.getInt(3));
+    }
+
+    @Test
+    void removeIfIsANoOpIfNoValueMatchesTheFilter()
+    {
+        final Predicate<Integer> filter = Objects::isNull;
+        list.addInt(1);
+        list.addInt(2);
+
+        assertFalse(list.removeIf(filter));
+
+        assertEquals(2, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(2, list.getInt(1));
+    }
+
+    @Test
+    void removeIfRemovesNullValues()
+    {
+        final Predicate<Integer> filter = Objects::isNull;
+        list.addInt(1);
+        list.add(null);
+        list.addInt(5);
+        list.addInt(DEFAULT_NULL_VALUE);
+
+        assertTrue(list.removeIf(filter));
+
+        assertEquals(2, list.size());
+        assertEquals(1, list.getInt(0));
+        assertEquals(5, list.getInt(1));
+    }
+
+    @Test
+    void removeIfRemovesMatchingValues()
+    {
+        final Predicate<Integer> filter = (v) -> v > 2;
+        list.addInt(10);
+        list.addInt(5);
+        list.addInt(3);
+        list.addInt(2);
+
+        assertTrue(list.removeIf(filter));
+
+        assertEquals(1, list.size());
+        assertEquals(2, list.getInt(0));
     }
 }

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -28,6 +28,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -1083,6 +1085,72 @@ public class IntHashSetTest
         assertEquals(2, testSet.size());
         assertTrue(testSet.contains(1));
         assertTrue(testSet.contains(2));
+    }
+
+    @Test
+    void removeIfIntIsANoOpIfNoValuesMatchFilter()
+    {
+        final IntPredicate filter = (v) -> v < 0;
+        testSet.add(1);
+        testSet.add(2);
+        testSet.add(0);
+
+        assertFalse(testSet.removeIfInt(filter));
+
+        assertEquals(3, testSet.size());
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(2));
+        assertTrue(testSet.contains(0));
+    }
+
+    @Test
+    void removeIfIntDeletesAllMatchingValues()
+    {
+        final IntPredicate filter = (v) -> v < 0;
+        testSet.add(1);
+        testSet.add(-2);
+        testSet.add(0);
+        testSet.add(MISSING_VALUE);
+
+        assertTrue(testSet.removeIfInt(filter));
+
+        assertEquals(2, testSet.size());
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(0));
+        assertFalse(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    void removeIfIsANoOpIfNoValuesMatchFilter()
+    {
+        final Predicate<Integer> filter = (v) -> v < 0;
+        testSet.add(1);
+        testSet.add(2);
+        testSet.add(0);
+
+        assertFalse(testSet.removeIf(filter));
+
+        assertEquals(3, testSet.size());
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(2));
+        assertTrue(testSet.contains(0));
+    }
+
+    @Test
+    void removeIfDeletesAllMatchingValues()
+    {
+        final Predicate<Integer> filter = (v) -> v < 0;
+        testSet.add(1);
+        testSet.add(-2);
+        testSet.add(0);
+        testSet.add(MISSING_VALUE);
+
+        assertTrue(testSet.removeIf(filter));
+
+        assertEquals(2, testSet.size());
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(0));
+        assertFalse(testSet.contains(MISSING_VALUE));
     }
 
     private static void addTwoElements(final IntHashSet obj)

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -18,9 +18,11 @@ package org.agrona.collections;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
@@ -850,8 +852,7 @@ public class IntHashSetTest
     @Test
     void forEachIsANoOpIfTheSetIsEmpty()
     {
-        @SuppressWarnings("unchecked")
-        final Consumer<Integer> consumer = mock(Consumer.class);
+        @SuppressWarnings("unchecked") final Consumer<Integer> consumer = mock(Consumer.class);
 
         testSet.forEach(consumer);
 
@@ -861,8 +862,7 @@ public class IntHashSetTest
     @Test
     void forEachShouldInvokeConsumerWithEveryValueAddedToTheSet()
     {
-        @SuppressWarnings("unchecked")
-        final Consumer<Integer> consumer = mock(Consumer.class);
+        @SuppressWarnings("unchecked") final Consumer<Integer> consumer = mock(Consumer.class);
 
         testSet.add(15);
         testSet.add(-2);
@@ -883,8 +883,7 @@ public class IntHashSetTest
     @Test
     void forEachShouldInvokeConsumerWithTheMissingValueAtTheIfOneWasAddedToTheSet()
     {
-        @SuppressWarnings("unchecked")
-        final Consumer<Integer> consumer = mock(Consumer.class);
+        @SuppressWarnings("unchecked") final Consumer<Integer> consumer = mock(Consumer.class);
 
         testSet.add(MISSING_VALUE);
         testSet.add(15);
@@ -944,6 +943,105 @@ public class IntHashSetTest
         inOrder.verify(consumer).accept(15);
         inOrder.verify(consumer).accept(MISSING_VALUE);
         verifyNoMoreInteractions(consumer);
+    }
+
+    @Test
+    void retainAllCollectionIsANoOpIfCollectionHasAllOfTheElementsFromTheSet()
+    {
+        final List<Integer> coll = Arrays.asList(0, 5, -3, 42, 21, MISSING_VALUE);
+        testSet.add(MISSING_VALUE);
+        testSet.add(42);
+        testSet.add(-3);
+
+        assertFalse(testSet.retainAll(coll));
+
+        assertEquals(3, testSet.size());
+        assertTrue(testSet.contains(MISSING_VALUE));
+        assertTrue(testSet.contains(42));
+        assertTrue(testSet.contains(-3));
+    }
+
+    @Test
+    void retainAllCollectionRemovesNonMissingValuesNotFoundInAGivenCollection()
+    {
+        final List<Integer> coll = Arrays.asList(100, 5, 21, 8);
+        testSet.add(0);
+        testSet.add(8);
+        testSet.add(100);
+        testSet.add(-999);
+
+        assertTrue(testSet.retainAll(coll));
+
+        assertEquals(2, testSet.size());
+        assertTrue(testSet.contains(8));
+        assertTrue(testSet.contains(100));
+        assertFalse(testSet.contains(-999));
+        assertFalse(testSet.contains(0));
+    }
+
+    @Test
+    void retainAllCollectionRemovesMissingValueWhichWasAddedToTheSet()
+    {
+        final List<Integer> coll = Arrays.asList(42, 42, 42, 0, 500);
+        testSet.add(MISSING_VALUE);
+        testSet.add(42);
+
+        assertTrue(testSet.retainAll(coll));
+
+        assertEquals(1, testSet.size());
+        assertTrue(testSet.contains(42));
+        assertFalse(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    void retainAllIsANoOpIfCollectionHasAllOfTheElementsFromTheSet()
+    {
+        final IntHashSet coll = new IntHashSet();
+        coll.addAll(Arrays.asList(0, 5, -3, 42, 21, MISSING_VALUE));
+        testSet.add(MISSING_VALUE);
+        testSet.add(42);
+        testSet.add(-3);
+
+        assertFalse(testSet.retainAll(coll));
+
+        assertEquals(3, testSet.size());
+        assertTrue(testSet.contains(MISSING_VALUE));
+        assertTrue(testSet.contains(42));
+        assertTrue(testSet.contains(-3));
+    }
+
+    @Test
+    void retainAllRemovesNonMissingValuesNotFoundInAGivenCollection()
+    {
+        final IntHashSet coll = new IntHashSet();
+        coll.addAll(Arrays.asList(100, 5, 21, 8));
+        testSet.add(0);
+        testSet.add(8);
+        testSet.add(100);
+        testSet.add(-999);
+
+        assertTrue(testSet.retainAll(coll));
+
+        assertEquals(2, testSet.size());
+        assertTrue(testSet.contains(8));
+        assertTrue(testSet.contains(100));
+        assertFalse(testSet.contains(-999));
+        assertFalse(testSet.contains(0));
+    }
+
+    @Test
+    void retainAllRemovesMissingValueWhichWasAddedToTheSet()
+    {
+        final IntHashSet coll = new IntHashSet();
+        coll.addAll(Arrays.asList(42, 42, 42, 0, 500));
+        testSet.add(MISSING_VALUE);
+        testSet.add(42);
+
+        assertTrue(testSet.retainAll(coll));
+
+        assertEquals(1, testSet.size());
+        assertTrue(testSet.contains(42));
+        assertFalse(testSet.contains(MISSING_VALUE));
     }
 
     private static void addTwoElements(final IntHashSet obj)

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -805,7 +805,7 @@ public class IntHashSetTest
     public void shouldGenerateStringRepresentation()
     {
         final IntHashSet set = new IntHashSet(16, -9990999);
-        final int[] testEntries = {-9990999, 3, 1, -1, 19, 7, 11, 12, 7, -1, 3, 3, -1 };
+        final int[] testEntries = { -9990999, 3, 1, -1, 19, 7, 11, 12, 7, -1, 3, 3, -1 };
 
         for (final int testEntry : testEntries)
         {
@@ -1036,7 +1036,7 @@ public class IntHashSetTest
     @Test
     void retainAllRemovesMissingValueWhichWasAddedToTheSet()
     {
-        final IntHashSet coll = new IntHashSet();
+        final IntHashSet coll = new IntHashSet(5, 0);
         coll.addAll(Arrays.asList(42, 42, 42, 0, 500));
         testSet.add(MISSING_VALUE);
         testSet.add(42);
@@ -1046,6 +1046,43 @@ public class IntHashSetTest
         assertEquals(1, testSet.size());
         assertTrue(testSet.contains(42));
         assertFalse(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    void removeAllIsANoOpIfTwoCollectionsHaveNoValuesInCommon()
+    {
+        final IntHashSet other = new IntHashSet(10, 100);
+        other.add(4);
+        other.add(5);
+        other.add(100);
+        testSet.add(1);
+        testSet.add(2);
+        testSet.add(MISSING_VALUE);
+
+        assertFalse(testSet.removeAll(other));
+
+        assertEquals(3, testSet.size());
+        assertTrue(testSet.contains(MISSING_VALUE));
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(2));
+    }
+
+    @Test
+    void removeAllRemovesMissingValueOfTheOtherSet()
+    {
+        final IntHashSet other = new IntHashSet(10, 100);
+        other.add(4);
+        other.add(5);
+        other.add(100);
+        testSet.add(1);
+        testSet.add(2);
+        testSet.add(100);
+
+        assertTrue(testSet.removeAll(other));
+
+        assertEquals(2, testSet.size());
+        assertTrue(testSet.contains(1));
+        assertTrue(testSet.contains(2));
     }
 
     private static void addTwoElements(final IntHashSet obj)

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -1153,6 +1153,75 @@ public class IntHashSetTest
         assertFalse(testSet.contains(MISSING_VALUE));
     }
 
+    @Test
+    void addAllShouldAddOnlyNonMissingValuesIfTheSourceListDoesNotContainExplicitMissingValue()
+    {
+        final IntHashSet other = new IntHashSet(5, 888);
+        other.add(1);
+        other.add(2);
+        other.add(3);
+        other.add(4);
+        other.add(5);
+        testSet.add(1);
+        testSet.add(5);
+        testSet.add(MISSING_VALUE);
+
+        assertTrue(testSet.addAll(other));
+
+        assertEquals(6, testSet.size());
+        for (int i = 1; i <= 5; i++)
+        {
+            assertTrue(testSet.contains(i));
+        }
+        assertTrue(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    void addAllShouldAddMissingVaueFromAnotherSet()
+    {
+        final IntHashSet other = new IntHashSet(5, 3);
+        other.add(1);
+        other.add(2);
+        other.add(3);
+        testSet.add(0);
+
+        assertTrue(testSet.addAll(other));
+
+        assertEquals(4, testSet.size());
+        for (int i = 0; i <= 3; i++)
+        {
+            assertTrue(testSet.contains(i));
+        }
+        assertFalse(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    void containsAllReturnsTrueIfTheSetContainsAllNonMissingValues()
+    {
+        final IntHashSet other = new IntHashSet(2, 9);
+        other.add(0);
+        other.add(2);
+        other.add(4);
+        other.add(6);
+        testSet.add(MISSING_VALUE);
+        for (int i = 0; i < 9; i++)
+        {
+            testSet.add(i);
+        }
+
+        assertTrue(testSet.containsAll(other));
+    }
+
+    @Test
+    void containsAllReturnsTrueIfTheSetContainsTheMissingValueOfAnotherSet()
+    {
+        final IntHashSet other = new IntHashSet(2, 9);
+        other.add(9);
+        testSet.add(9);
+
+        assertTrue(testSet.containsAll(other));
+    }
+
     private static void addTwoElements(final IntHashSet obj)
     {
         obj.add(1);

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -46,7 +46,7 @@ public class IntHashSetTest
     private final IntHashSet testSet = new IntHashSet(INITIAL_CAPACITY, MISSING_VALUE);
 
     @Test
-    public void initiallyContainsNoElements()
+    void initiallyContainsNoElements()
     {
         for (int i = 0; i < 10_000; i++)
         {
@@ -55,7 +55,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void initiallyContainsNoBoxedElements()
+    void initiallyContainsNoBoxedElements()
     {
         for (int i = 0; i < 10_000; i++)
         {
@@ -64,7 +64,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsAddedElement()
+    void containsAddedElement()
     {
         assertTrue(testSet.add(1));
 
@@ -72,7 +72,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void addingAnElementTwiceDoesNothing()
+    void addingAnElementTwiceDoesNothing()
     {
         assertTrue(testSet.add(1));
 
@@ -80,7 +80,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsAddedBoxedElements()
+    void containsAddedBoxedElements()
     {
         assertTrue(testSet.add(1));
         assertTrue(testSet.add(Integer.valueOf(2)));
@@ -90,13 +90,13 @@ public class IntHashSetTest
     }
 
     @Test
-    public void removingAnElementFromAnEmptyListDoesNothing()
+    void removingAnElementFromAnEmptyListDoesNothing()
     {
         assertFalse(testSet.remove(0));
     }
 
     @Test
-    public void removingAPresentElementRemovesIt()
+    void removingAPresentElementRemovesIt()
     {
         assertTrue(testSet.add(1));
 
@@ -106,13 +106,13 @@ public class IntHashSetTest
     }
 
     @Test
-    public void sizeIsInitiallyZero()
+    void sizeIsInitiallyZero()
     {
         assertEquals(0, testSet.size());
     }
 
     @Test
-    public void sizeIncrementsWithNumberOfAddedElements()
+    void sizeIncrementsWithNumberOfAddedElements()
     {
         addTwoElements(testSet);
 
@@ -121,7 +121,7 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("OverwrittenKey")
-    public void sizeContainsNumberOfNewElements()
+    void sizeContainsNumberOfNewElements()
     {
         testSet.add(1);
         testSet.add(1);
@@ -130,7 +130,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsListElements()
+    void iteratorsListElements()
     {
         addTwoElements(testSet);
 
@@ -138,7 +138,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsStartFromTheBeginningEveryTime()
+    void iteratorsStartFromTheBeginningEveryTime()
     {
         iteratorsListElements();
 
@@ -146,7 +146,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsListElementsWithoutHasNext()
+    void iteratorsListElementsWithoutHasNext()
     {
         addTwoElements(testSet);
 
@@ -154,7 +154,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
+    void iteratorsStartFromTheBeginningEveryTimeWithoutHasNext()
     {
         iteratorsListElementsWithoutHasNext();
 
@@ -162,7 +162,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsThrowNoSuchElementException()
+    void iteratorsThrowNoSuchElementException()
     {
         addTwoElements(testSet);
 
@@ -170,7 +170,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
+    void iteratorsThrowNoSuchElementExceptionFromTheBeginningEveryTime()
     {
         addTwoElements(testSet);
 
@@ -186,19 +186,19 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorHasNoElements()
+    void iteratorHasNoElements()
     {
         assertFalse(testSet.iterator().hasNext());
     }
 
     @Test
-    public void iteratorThrowExceptionForEmptySet()
+    void iteratorThrowExceptionForEmptySet()
     {
         assertThrows(NoSuchElementException.class, () -> testSet.iterator().next());
     }
 
     @Test
-    public void clearRemovesAllElementsOfTheSet()
+    void clearRemovesAllElementsOfTheSet()
     {
         addTwoElements(testSet);
 
@@ -210,7 +210,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void differenceReturnsNullIfBothSetsEqual()
+    void differenceReturnsNullIfBothSetsEqual()
     {
         addTwoElements(testSet);
 
@@ -221,19 +221,73 @@ public class IntHashSetTest
     }
 
     @Test
-    public void differenceReturnsSetDifference()
+    void differenceReturnsElementsOfTheOriginalSetThatNotContainedInTheOtherSet()
     {
-        addTwoElements(testSet);
-
-        final IntHashSet other = new IntHashSet(100);
+        final IntHashSet other = new IntHashSet(10, 10);
+        other.add(10);
         other.add(1);
+        other.add(5);
+        other.add(42);
+        other.add(MISSING_VALUE);
+        final IntHashSet otherCopy = new IntHashSet(10, 10);
+        otherCopy.copy(other);
+        testSet.add(1);
+        testSet.add(3);
+        testSet.add(5);
+        testSet.add(21);
+        testSet.add(MISSING_VALUE);
 
         final IntHashSet diff = testSet.difference(other);
-        assertThat(diff, containsInAnyOrder(1001));
+
+        assertNotNull(diff);
+        assertEquals(2, diff.size());
+        assertEquals(MISSING_VALUE, diff.missingValue());
+        assertTrue(diff.contains(3));
+        assertTrue(diff.contains(21));
+
+        assertEquals(otherCopy, other);
     }
 
     @Test
-    public void copiesOtherIntHashSet()
+    void differenceReturnsASetWithOnlyAMissingValueIfItIsNotContainedInAnotherSet()
+    {
+        final IntHashSet one = new IntHashSet(1, 1);
+        one.add(1);
+        one.add(5);
+        final IntHashSet two = new IntHashSet(1, 2);
+        two.add(2);
+
+        final IntHashSet diff = two.difference(one);
+
+        assertNotNull(diff);
+        assertEquals(1, diff.size());
+        assertEquals(2, diff.missingValue());
+        assertTrue(diff.contains(2));
+        assertFalse(diff.contains(1));
+        assertFalse(diff.contains(5));
+    }
+
+    @Test
+    void differenceReturnsASetWithAMissingValueIfItIsNotContainedInAnotherSet()
+    {
+        final IntHashSet one = new IntHashSet(1, 1);
+        one.add(1);
+        one.add(5);
+        final IntHashSet two = new IntHashSet(1, 2);
+        two.add(2);
+
+        final IntHashSet diff = one.difference(two);
+
+        assertNotNull(diff);
+        assertEquals(2, diff.size());
+        assertEquals(1, diff.missingValue());
+        assertTrue(diff.contains(1));
+        assertTrue(diff.contains(5));
+        assertFalse(diff.contains(2));
+    }
+
+    @Test
+    void copiesOtherIntHashSet()
     {
         addTwoElements(testSet);
 
@@ -244,14 +298,14 @@ public class IntHashSetTest
     }
 
     @Test
-    public void twoEmptySetsAreEqual()
+    void twoEmptySetsAreEqual()
     {
         final IntHashSet other = new IntHashSet(100);
         assertEquals(testSet, other);
     }
 
     @Test
-    public void setsWithTheSameValuesAreEqual()
+    void setsWithTheSameValuesAreEqual()
     {
         final IntHashSet other = new IntHashSet(100);
 
@@ -262,7 +316,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void setsWithTheDifferentSizesAreNotEqual()
+    void setsWithTheDifferentSizesAreNotEqual()
     {
         final IntHashSet other = new IntHashSet(100);
 
@@ -274,7 +328,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void setsWithTheDifferentValuesAreNotEqual()
+    void setsWithTheDifferentValuesAreNotEqual()
     {
         final IntHashSet other = new IntHashSet(100);
 
@@ -287,13 +341,13 @@ public class IntHashSetTest
     }
 
     @Test
-    public void twoEmptySetsHaveTheSameHashcode()
+    void twoEmptySetsHaveTheSameHashcode()
     {
         assertEquals(testSet.hashCode(), new IntHashSet(100).hashCode());
     }
 
     @Test
-    public void setsWithTheSameValuesHaveTheSameHashcode()
+    void setsWithTheSameValuesHaveTheSameHashcode()
     {
         final IntHashSet other = new IntHashSet(100);
 
@@ -305,7 +359,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void reducesSizeWhenElementRemoved()
+    void reducesSizeWhenElementRemoved()
     {
         addTwoElements(testSet);
 
@@ -316,14 +370,14 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("SuspiciousToArrayCall")
-    public void toArrayThrowsArrayStoreExceptionForWrongType()
+    void toArrayThrowsArrayStoreExceptionForWrongType()
     {
         assertThrows(ArrayStoreException.class, () -> testSet.toArray(new String[1]));
     }
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    public void toArrayThrowsNullPointerExceptionForNullArgument()
+    void toArrayThrowsNullPointerExceptionForNullArgument()
     {
         final Integer[] into = null;
         assertThrows(NullPointerException.class, () -> testSet.toArray(into));
@@ -331,7 +385,7 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArrayCopiesElementsIntoSufficientlySizedArray()
+    void toArrayCopiesElementsIntoSufficientlySizedArray()
     {
         addTwoElements(testSet);
 
@@ -342,7 +396,7 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArrayCopiesElementsIntoNewArray()
+    void toArrayCopiesElementsIntoNewArray()
     {
         addTwoElements(testSet);
 
@@ -353,7 +407,7 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArraySupportsEmptyCollection()
+    void toArraySupportsEmptyCollection()
     {
         final Integer[] result = testSet.toArray(new Integer[testSet.size()]);
 
@@ -362,7 +416,7 @@ public class IntHashSetTest
 
     // Test case from usage bug.
     @Test
-    public void chainCompactionShouldNotCauseElementsToBeMovedBeforeTheirHash()
+    void chainCompactionShouldNotCauseElementsToBeMovedBeforeTheirHash()
     {
         final IntHashSet requiredFields = new IntHashSet(14);
 
@@ -379,7 +433,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldResizeWhenItHitsCapacity()
+    void shouldResizeWhenItHitsCapacity()
     {
         for (int i = 0; i < 2 * INITIAL_CAPACITY; i++)
         {
@@ -393,7 +447,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsEmptySet()
+    void containsEmptySet()
     {
         final IntHashSet other = new IntHashSet(100);
 
@@ -402,7 +456,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsSubset()
+    void containsSubset()
     {
         addTwoElements(testSet);
 
@@ -415,7 +469,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void doesNotContainDisjointSet()
+    void doesNotContainDisjointSet()
     {
         addTwoElements(testSet);
 
@@ -429,7 +483,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void doesNotContainSuperset()
+    void doesNotContainSuperset()
     {
         addTwoElements(testSet);
 
@@ -443,7 +497,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void addingEmptySetDoesNothing()
+    void addingEmptySetDoesNothing()
     {
         addTwoElements(testSet);
 
@@ -453,7 +507,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void addingSubsetDoesNothing()
+    void addingSubsetDoesNothing()
     {
         addTwoElements(testSet);
 
@@ -469,7 +523,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void addingEqualSetDoesNothing()
+    void addingEqualSetDoesNothing()
     {
         addTwoElements(testSet);
 
@@ -485,7 +539,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsValuesAddedFromDisjointSetPrimitive()
+    void containsValuesAddedFromDisjointSetPrimitive()
     {
         addTwoElements(testSet);
 
@@ -501,7 +555,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsValuesAddedFromDisjointSet()
+    void containsValuesAddedFromDisjointSet()
     {
         addTwoElements(testSet);
 
@@ -517,7 +571,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsValuesAddedFromIntersectingSetPrimitive()
+    void containsValuesAddedFromIntersectingSetPrimitive()
     {
         addTwoElements(testSet);
 
@@ -533,7 +587,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void containsValuesAddedFromIntersectingSet()
+    void containsValuesAddedFromIntersectingSet()
     {
         addTwoElements(testSet);
 
@@ -549,7 +603,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void removingEmptySetDoesNothing()
+    void removingEmptySetDoesNothing()
     {
         addTwoElements(testSet);
 
@@ -559,7 +613,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void removingDisjointSetDoesNothing()
+    void removingDisjointSetDoesNothing()
     {
         addTwoElements(testSet);
 
@@ -574,7 +628,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void doesNotContainRemovedIntersectingSetPrimitive()
+    void doesNotContainRemovedIntersectingSetPrimitive()
     {
         addTwoElements(testSet);
 
@@ -589,7 +643,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void doesNotContainRemovedIntersectingSet()
+    void doesNotContainRemovedIntersectingSet()
     {
         addTwoElements(testSet);
 
@@ -604,7 +658,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void isEmptyAfterRemovingEqualSetPrimitive()
+    void isEmptyAfterRemovingEqualSetPrimitive()
     {
         addTwoElements(testSet);
 
@@ -617,7 +671,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void isEmptyAfterRemovingEqualSet()
+    void isEmptyAfterRemovingEqualSet()
     {
         addTwoElements(testSet);
 
@@ -630,7 +684,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void removeElementsFromIterator()
+    void removeElementsFromIterator()
     {
         addTwoElements(testSet);
 
@@ -648,13 +702,13 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldNotContainMissingValueInitially()
+    void shouldNotContainMissingValueInitially()
     {
         assertFalse(testSet.contains(MISSING_VALUE));
     }
 
     @Test
-    public void shouldAllowMissingValue()
+    void shouldAllowMissingValue()
     {
         assertTrue(testSet.add(MISSING_VALUE));
 
@@ -664,7 +718,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldAllowRemovalOfMissingValue()
+    void shouldAllowRemovalOfMissingValue()
     {
         assertTrue(testSet.add(MISSING_VALUE));
 
@@ -676,7 +730,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void sizeAccountsForMissingValue()
+    void sizeAccountsForMissingValue()
     {
         testSet.add(1);
         testSet.add(MISSING_VALUE);
@@ -686,7 +740,7 @@ public class IntHashSetTest
 
     @Test
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public void toArrayCopiesElementsIntoNewArrayIncludingMissingValue()
+    void toArrayCopiesElementsIntoNewArrayIncludingMissingValue()
     {
         addTwoElements(testSet);
 
@@ -698,7 +752,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void toObjectArrayCopiesElementsIntoNewArrayIncludingMissingValue()
+    void toObjectArrayCopiesElementsIntoNewArrayIncludingMissingValue()
     {
         addTwoElements(testSet);
 
@@ -710,7 +764,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void equalsAccountsForMissingValue()
+    void equalsAccountsForMissingValue()
     {
         addTwoElements(testSet);
         testSet.add(MISSING_VALUE);
@@ -729,7 +783,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void consecutiveValuesShouldBeCorrectlyStored()
+    void consecutiveValuesShouldBeCorrectlyStored()
     {
         for (int i = 0; i < 10_000; i++)
         {
@@ -748,7 +802,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void hashCodeAccountsForMissingValue()
+    void hashCodeAccountsForMissingValue()
     {
         addTwoElements(testSet);
         testSet.add(MISSING_VALUE);
@@ -767,7 +821,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorAccountsForMissingValue()
+    void iteratorAccountsForMissingValue()
     {
         addTwoElements(testSet);
         testSet.add(MISSING_VALUE);
@@ -786,7 +840,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void iteratorCanRemoveMissingValue()
+    void iteratorCanRemoveMissingValue()
     {
         addTwoElements(testSet);
         testSet.add(MISSING_VALUE);
@@ -804,7 +858,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldGenerateStringRepresentation()
+    void shouldGenerateStringRepresentation()
     {
         final IntHashSet set = new IntHashSet(16, -9990999);
         final int[] testEntries = { -9990999, 3, 1, -1, 19, 7, 11, 12, 7, -1, 3, 3, -1 };
@@ -819,7 +873,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldRemoveMissingValueWhenCleared()
+    void shouldRemoveMissingValueWhenCleared()
     {
         assertTrue(testSet.add(MISSING_VALUE));
 
@@ -829,7 +883,7 @@ public class IntHashSetTest
     }
 
     @Test
-    public void shouldHaveCompatibleEqualsAndHashcode()
+    void shouldHaveCompatibleEqualsAndHashcode()
     {
         final HashSet<Integer> compatibleSet = new HashSet<>();
         final long seed = System.nanoTime();

--- a/agrona/src/test/java/org/agrona/collections/Long2LongHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Long2LongHashMapTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.collections;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.LongPredicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Long2LongHashMapTest
+{
+    @Test
+    void removeIfLongOnKeySet()
+    {
+        final Long2LongHashMap map = new Long2LongHashMap(-1);
+        final LongPredicate filter = (v) -> v < 3;
+        map.put(1, 1);
+        map.put(2, 2);
+        map.put(3, 3);
+        map.put(4, 4);
+
+        assertTrue(map.keySet().removeIfLong(filter));
+
+        assertEquals(2, map.size());
+        assertEquals(3, map.get(3));
+        assertEquals(4, map.get(4));
+
+        assertFalse(map.keySet().removeIfLong(filter));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void removeIfLongOnValuesCollection()
+    {
+        final Long2LongHashMap map = new Long2LongHashMap(-1);
+        final LongPredicate filter = (v) -> v >= 20;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(3, 30);
+        map.put(4, 40);
+
+        assertTrue(map.values().removeIfLong(filter));
+
+        assertEquals(1, map.size());
+        assertEquals(10, map.get(1));
+
+        assertFalse(map.values().removeIfLong(filter));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void removeIfLongOnEntrySet()
+    {
+        final Long2LongHashMap map = new Long2LongHashMap(-1);
+        final LongLongPredicate filter = (k, v) -> k >= 2 && v <= 30;
+        map.put(1, 10);
+        map.put(2, 20);
+        map.put(3, 30);
+        map.put(4, 40);
+
+        assertTrue(map.entrySet().removeIfLong(filter));
+
+        assertEquals(2, map.size());
+        assertEquals(10, map.get(1));
+        assertEquals(40, map.get(4));
+
+        assertFalse(map.entrySet().removeIfLong(filter));
+        assertEquals(2, map.size());
+    }
+}


### PR DESCRIPTION
This PR contains the following changes:
- Adds overloaded versions of the methods added in JDK 8 to avoid boxing on keys or values.
- Deprecates `intForEach` in favor of `forEachInt` that added across all collections for consistency.
- Adds bulk add methods specialized on the collection type.
- Fixes null/missing value handling across collections. For example `IntArrayList.remove(int)` was returning `nullValue` instead of `null` that was put there originally.
