### PR TITLE
#270 fix shut down signal barrier jvm signal not called

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
@@ -16,6 +16,7 @@
 package org.agrona.concurrent;
 
 import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -36,10 +37,12 @@ public class ShutdownSignalBarrier
     {
         for (final String signalName : SIGNAL_NAMES)
         {
-            final var previous = Signal.handle(new Signal(signalName), (signal) -> {});
+            final SignalHandler previous = Signal.handle(new Signal(signalName), (signal) -> {});
             Signal.handle(new Signal(signalName), (signal) -> {
                 LATCHES.forEach(CountDownLatch::countDown);
-                previous.handle(signal);
+                if (previous != null) {
+                    previous.handle(signal);
+                }
             });
         }
     }

--- a/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
@@ -36,7 +36,11 @@ public class ShutdownSignalBarrier
     {
         for (final String signalName : SIGNAL_NAMES)
         {
-            Signal.handle(new Signal(signalName), (signal) -> LATCHES.forEach(CountDownLatch::countDown));
+            final var previous = Signal.handle(new Signal(signalName), (signal) -> {});
+            Signal.handle(new Signal(signalName), (signal) -> {
+                LATCHES.forEach(CountDownLatch::countDown);
+                previous.handle(signal);
+            });
         }
     }
 

--- a/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
@@ -38,7 +38,8 @@ public class ShutdownSignalBarrier
         for (final String signalName : SIGNAL_NAMES)
         {
             final SignalHandler previous = Signal.handle(new Signal(signalName), (signal) -> {});
-            Signal.handle(new Signal(signalName), (signal) -> {
+            Signal.handle(new Signal(signalName), (signal) ->
+            {
                 LATCHES.forEach(CountDownLatch::countDown);
                 if (previous != null)
                 {

--- a/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ShutdownSignalBarrier.java
@@ -40,7 +40,8 @@ public class ShutdownSignalBarrier
             final SignalHandler previous = Signal.handle(new Signal(signalName), (signal) -> {});
             Signal.handle(new Signal(signalName), (signal) -> {
                 LATCHES.forEach(CountDownLatch::countDown);
-                if (previous != null) {
+                if (previous != null)
+                {
                     previous.handle(signal);
                 }
             });


### PR DESCRIPTION
When the ShutdownSignalBarrier class is loaded, its static initialiser overrides the default JVM Signal handler. This means on shutdown of the JVM, when the SIGTERM signal is sent, the ShutdownSignalBarrier handler class is called. However, as the ShutdownSignalBarrier's registered signal handler does not then call the previous handler (which is what is returned from the Signal.handle(..) method), the JDK does not then run its own shutdown hooks, which can break logic of applications that have other resources they would like to gracefully shut down.

the fix allows the existing registered signal handler to still be called, taking lower priority that the SignalShutdownBarrier.

see issue: https://github.com/real-logic/agrona/issues/270 for full description.  