### PR TITLE
[Java] DataInput implementation over DirectBuffer

### DIFF
--- a/agrona/src/main/java/org/agrona/io/DirectBufferDataInput.java
+++ b/agrona/src/main/java/org/agrona/io/DirectBufferDataInput.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.io;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+
+import java.io.DataInput;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+/**
+ * A data input implementation that reads from a DirectBuffer. It adheres to the contract defined in DataInput
+ * description including throwing checked exception on end of file. It adds few more methods to read strings without
+ * allocations.
+ * Note about byte ordering: by default, this class conforms to {@link DataInput} contract and uses
+ * {@link ByteOrder#BIG_ENDIAN} byte order which allows it to read data produced by JDK {@link java.io.DataOutput}
+ * implementations. Agrona buffers use {@link ByteOrder#LITTLE_ENDIAN} (unless overridden). Use
+ * {@link #setByteOrder(ByteOrder)} method to switch between JDK and Agrona compatibility.
+s */
+public class DirectBufferDataInput implements DataInput
+{
+
+    private DirectBuffer buffer;
+
+    private ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+
+    private int length;
+    private int position;
+
+    /**
+     * Wrap given {@link DirectBuffer}.
+     *
+     * @param buffer to wrap.
+     */
+    public DirectBufferDataInput(final DirectBuffer buffer)
+    {
+        wrap(buffer, 0, buffer.capacity());
+    }
+
+    /**
+     * Wrap given {@link DirectBuffer}.
+     *
+     * @param buffer to wrap.
+     * @param offset into the buffer.
+     * @param length in bytes.
+     */
+    public DirectBufferDataInput(final DirectBuffer buffer, final int offset, final int length)
+    {
+        wrap(buffer, offset, length);
+    }
+
+    /**
+     * Wrap given {@link DirectBuffer}.
+     *
+     * @param buffer to wrap.
+     */
+    public void wrap(final DirectBuffer buffer)
+    {
+        wrap(buffer, 0, buffer.capacity());
+    }
+
+    /**
+     * Wrap given {@link DirectBuffer}.
+     *
+     * @param buffer to wrap.
+     * @param offset into the buffer.
+     * @param length in bytes.
+     */
+    public void wrap(final DirectBuffer buffer, final int offset, final int length)
+    {
+        if (null == buffer)
+        {
+            throw new NullPointerException("buffer cannot be null");
+        }
+
+        this.buffer = buffer;
+        this.length = length + offset;
+        this.position = offset;
+    }
+
+    /**
+     * Sets the byte order. By default, this class conforms to {@link DataInput} contract and uses
+     * {@link ByteOrder#BIG_ENDIAN} which allows it to read data produced by JDK {@link java.io.DataOutput} implementations.
+     * Agrona buffers use {@link ByteOrder#LITTLE_ENDIAN} (unless overridden).
+     * Use this method to switch compatibility between these two worlds.
+     *
+     * @param byteOrder of the underlying buffer.
+     */
+    public void setByteOrder(final ByteOrder byteOrder)
+    {
+        this.byteOrder = byteOrder;
+    }
+
+    /**
+     * Return the number of bytes remaining in the buffer.
+     *
+     * @return the number of bytes remaining.
+     */
+    public int remaining()
+    {
+        return length - position;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readFully(final byte[] destination) throws EOFException
+    {
+        if (destination == null)
+        {
+            throw new NullPointerException("Destination must not be null");
+        }
+
+        readFully(destination, 0, destination.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readFully(final byte[] destination, final int destinationOffset, final int length) throws EOFException
+    {
+        if (destination == null)
+        {
+            throw new NullPointerException("Destination must not be null");
+        }
+
+        if (destinationOffset < 0)
+        {
+            throw new IndexOutOfBoundsException("invalid destinationOffset: " + destinationOffset);
+        }
+
+        if (length < 0)
+        {
+            throw new IndexOutOfBoundsException("invalid length: " + length);
+        }
+
+        if (destinationOffset + length > destination.length)
+        {
+            throw new IndexOutOfBoundsException(
+                    "destinationOffset=" + destinationOffset + " length=" + length + " not valid for length=" + length);
+        }
+
+        boundsCheck0(length);
+        buffer.getBytes(position, destination, destinationOffset, length);
+        position += length;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int skipBytes(final int n)
+    {
+        final int toSkip = Math.min(n, remaining());
+        position += toSkip;
+
+        return toSkip;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean readBoolean() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_BYTE);
+
+        return buffer.getByte(position++) != 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte readByte() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_BYTE);
+
+        return buffer.getByte(position++);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int readUnsignedByte() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_BYTE);
+
+        return buffer.getByte(position++) & 0xFF;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public short readShort() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_SHORT);
+
+        final short result = buffer.getShort(position, byteOrder);
+        position += BitUtil.SIZE_OF_SHORT;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int readUnsignedShort() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_SHORT);
+
+        final int result = buffer.getShort(position, byteOrder) & 0xFFFF;
+        position += BitUtil.SIZE_OF_SHORT;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public char readChar() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_CHAR);
+
+        final char result = buffer.getChar(position, byteOrder);
+        position += BitUtil.SIZE_OF_CHAR;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int readInt() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_INT);
+
+        final int result = buffer.getInt(position, byteOrder);
+        position += BitUtil.SIZE_OF_INT;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long readLong() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_LONG);
+
+        final long result = buffer.getLong(position, byteOrder);
+        position += BitUtil.SIZE_OF_LONG;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public float readFloat() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_FLOAT);
+
+        final float result = buffer.getFloat(position, byteOrder);
+        position += BitUtil.SIZE_OF_FLOAT;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double readDouble() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_DOUBLE);
+
+        final double result = buffer.getDouble(position, byteOrder);
+        position += BitUtil.SIZE_OF_DOUBLE;
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String readLine() throws IOException
+    {
+        if (remaining() == 0)
+        {
+            return null;
+        }
+
+        final StringBuilder result = new StringBuilder();
+        readLine(result);
+
+        return result.toString();
+    }
+
+    /**
+     * Reads the next line of text from the input stream. It reads successive bytes, converting each byte separately
+     * into a character, until it encounters a line terminator or end of file; Adheres to the contract of {@link DataInput#readLine()}.
+     *
+     * @param appendable to append the chars to.
+     * @return number of bytes the stream advanced while reading the line (including line terminators).
+     * @throws IOException propagated from {@link Appendable#append(char)}.
+     */
+    public int readLine(final Appendable appendable) throws IOException
+    {
+        final int startingPosition = position;
+
+        while (remaining() > 0)
+        {
+            final int nextByte = readByte();
+            if (nextByte == '\n')
+            {
+                return position - startingPosition;
+            }
+
+            if (nextByte == '\r')
+            {
+                if (remaining() > 0)
+                {
+                    final byte peek = readByte();
+                    if (peek != '\n')
+                    {
+                        skipBytes(-1);
+                    }
+                }
+
+                return position - startingPosition;
+            }
+
+            appendable.append((char)nextByte);
+        }
+
+        return position - startingPosition;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String readUTF() throws EOFException
+    {
+        boundsCheck0(BitUtil.SIZE_OF_SHORT);
+        final short size = readShort();
+
+        boundsCheck0(size);
+        final String stringUtf8 = buffer.getStringWithoutLengthUtf8(position, size);
+
+        position += size;
+        return stringUtf8;
+    }
+
+    /**
+     * Reads in a string that has been encoded using UTF-8 format by
+     * {@link org.agrona.MutableDirectBuffer#putStringUtf8(int, String)}.
+     * <p>
+     * This is a thin wrapper over {@link DirectBuffer#getStringUtf8(int, ByteOrder)}. Honours byte order set by {@link #setByteOrder(ByteOrder)}
+     *
+     * @return the String as represented by the ASCII encoded bytes.
+     */
+    public String readStringUTF8()
+    {
+        final String stringUtf8 = buffer.getStringUtf8(position, byteOrder);
+
+        position += stringUtf8.length();
+        return stringUtf8;
+    }
+
+    /**
+     * Reads in a string that has been encoded using ASCII format by
+     * {@link org.agrona.MutableDirectBuffer#putStringAscii(int, CharSequence)}.
+     * <p>
+     * This is a thin wrapper over {@link DirectBuffer#getStringAscii(int, ByteOrder)}. Honours byte order set by {@link #setByteOrder(ByteOrder)}
+     *
+     * @return the String as represented by the ASCII encoded bytes.
+     */
+    public String readStringAscii()
+    {
+        final String stringAscii = buffer.getStringAscii(position, byteOrder);
+
+        position += stringAscii.length();
+        return stringAscii;
+    }
+
+    /**
+     * Get a String from bytes encoded in ASCII format that is length prefixed and append to an {@link Appendable}.
+     * This is a thin wrapper over {@link DirectBuffer#getStringAscii(int, Appendable, ByteOrder)}. Honours byte order set by {@link #setByteOrder(ByteOrder)}
+     *
+     * @param appendable to append the chars to.
+     * @return the number of bytes copied.
+     */
+    public int readStringAscii(final Appendable appendable)
+    {
+        final int bytesRead = buffer.getStringAscii(position, appendable, byteOrder);
+        position += bytesRead;
+
+        return bytesRead;
+    }
+
+    private void boundsCheck0(final int requestedReadBytes) throws EOFException
+    {
+        final long resultingPosition = position + requestedReadBytes;
+        if (resultingPosition > length)
+        {
+            throw new EOFException("position=" + position + " requestedReadBytes=" +
+                    requestedReadBytes + " capacity=" + length);
+        }
+    }
+}

--- a/agrona/src/test/java/org/agrona/io/DirectBufferDataInputAgronaTest.java
+++ b/agrona/src/test/java/org/agrona/io/DirectBufferDataInputAgronaTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.io;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+import java.io.DataOutput;
+import java.nio.ByteOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DirectBufferDataInputAgronaTest extends DirectBufferDataInputTest
+{
+
+    UnsafeBuffer toUnsafeBuffer(final ThrowingConsumer<DataOutput> dataProvider) throws Throwable
+    {
+        final ExpandableArrayBuffer out = new ExpandableArrayBuffer();
+        final MutableInteger index = new MutableInteger();
+        dataProvider.accept(new DataOutputForTest(out, index));
+
+        return new UnsafeBuffer(out.byteArray(), 0, index.get());
+    }
+
+    @Override
+    ByteOrder byteOrder()
+    {
+        return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Test
+    void shouldReadUtf()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+
+        buffer.putLong(0, 0);
+        final int bytesWritten = buffer.putStringUtf8(8, "zażółć gęślą jaźń北查爾斯頓");
+        buffer.putLong(8 + bytesWritten, 0);
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            8,
+            bytesWritten
+        );
+        dataInput.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+
+        assertEquals("zażółć gęślą jaźń北查爾斯頓", dataInput.readStringUTF8());
+    }
+
+    @Test
+    void shouldThrowWhenCannotReadSizeOfUtfString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> {});
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class, dataInput::readStringUTF8);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCannotReadString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.writeShort(42));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class, dataInput::readStringUTF8);
+    }
+
+    @Test
+    void shouldReadAsciiString()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+
+        buffer.putLong(0, 0);
+        final int bytesWritten = buffer.putStringAscii(8, "Cupcake ipsum dolor sit amet.");
+        buffer.putLong(8 + bytesWritten, 0);
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            8,
+            bytesWritten
+        );
+        dataInput.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+
+        assertEquals("Cupcake ipsum dolor sit amet.", dataInput.readStringAscii());
+    }
+
+    @Test
+    void shouldThrowWhenCannotReadSizeOfAsciiString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {});
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class, dataInput::readStringAscii);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCannotReadAsciiString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.writeShort(42));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class, dataInput::readStringAscii);
+    }
+
+    @Test
+    void shouldReadAsciiStringIntoAppendable()
+    {
+        final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+
+        buffer.putLong(0, 0);
+        final int bytesWritten = buffer.putStringAscii(8, "Cupcake ipsum dolor sit amet.");
+        buffer.putLong(8 + bytesWritten, 0);
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            8,
+            bytesWritten
+        );
+        dataInput.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+
+        final StringBuilder actual = new StringBuilder();
+        dataInput.readStringAscii(actual);
+
+        assertEquals("Cupcake ipsum dolor sit amet.", actual.toString());
+    }
+
+    private static class DataOutputForTest implements DataOutput
+    {
+
+        private final ExpandableArrayBuffer out;
+        private final MutableInteger index;
+
+        DataOutputForTest(final ExpandableArrayBuffer out, final MutableInteger index)
+        {
+            this.out = out;
+            this.index = index;
+        }
+
+        @Override
+        public void write(final int b)
+        {
+            out.putByte(index.get(), (byte)b);
+            index.increment();
+        }
+
+        @Override
+        public void write(final byte[] b)
+        {
+            out.putBytes(index.get(), b);
+            index.addAndGet(b.length);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len)
+        {
+            out.putBytes(index.get(), b, off, len);
+            index.addAndGet(len);
+        }
+
+        @Override
+        public void writeBoolean(final boolean v)
+        {
+            out.putByte(index.get(), (byte)(v ? 1 : 0));
+            index.increment();
+        }
+
+        @Override
+        public void writeByte(final int v)
+        {
+            out.putByte(index.get(), (byte)v);
+            index.increment();
+        }
+
+        @Override
+        public void writeShort(final int v)
+        {
+            out.putShort(index.get(), (short)v);
+            index.addAndGet(2);
+        }
+
+        @Override
+        public void writeChar(final int v)
+        {
+            out.putChar(index.get(), (char)v);
+            index.addAndGet(2);
+        }
+
+        @Override
+        public void writeInt(final int v)
+        {
+            out.putInt(index.get(), v);
+            index.addAndGet(4);
+        }
+
+        @Override
+        public void writeLong(final long v)
+        {
+            out.putLong(index.get(), v);
+            index.addAndGet(8);
+        }
+
+        @Override
+        public void writeFloat(final float v)
+        {
+            out.putFloat(index.get(), v);
+            index.addAndGet(4);
+        }
+
+        @Override
+        public void writeDouble(final double v)
+        {
+            out.putDouble(index.get(), v);
+            index.addAndGet(8);
+        }
+
+        @Override
+        public void writeBytes(final String s)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void writeChars(final String s)
+        {
+            for (int i = 0; i < s.length(); i++)
+            {
+                final char c = s.charAt(i);
+                out.putChar(index.get(), c);
+                index.addAndGet(2);
+            }
+        }
+
+        @Override
+        public void writeUTF(final String s)
+        {
+            final int startingPosition = index.get();
+            index.addAndGet(2);
+
+            final int bytesWritten = out.putStringWithoutLengthUtf8(index.get(), s);
+            index.addAndGet(bytesWritten);
+
+            out.putShort(startingPosition, (short)bytesWritten);
+        }
+    }
+}

--- a/agrona/src/test/java/org/agrona/io/DirectBufferDataInputJDKTest.java
+++ b/agrona/src/test/java/org/agrona/io/DirectBufferDataInputJDKTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.io;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.nio.ByteOrder;
+
+public class DirectBufferDataInputJDKTest extends DirectBufferDataInputTest
+{
+    UnsafeBuffer toUnsafeBuffer(final ThrowingConsumer<DataOutput> dataProvider) throws Throwable
+    {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream(20);
+        try (DataOutputStream out = new DataOutputStream(baos))
+        {
+            dataProvider.accept(out);
+        }
+
+        return new UnsafeBuffer(baos.toByteArray());
+    }
+
+    @Override
+    ByteOrder byteOrder()
+    {
+        return ByteOrder.BIG_ENDIAN;
+    }
+}

--- a/agrona/src/test/java/org/agrona/io/DirectBufferDataInputTest.java
+++ b/agrona/src/test/java/org/agrona/io/DirectBufferDataInputTest.java
@@ -1,0 +1,649 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.io;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+import java.io.DataOutput;
+import java.io.EOFException;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+abstract class DirectBufferDataInputTest
+{
+
+    abstract UnsafeBuffer toUnsafeBuffer(ThrowingConsumer<DataOutput> dataProvider) throws Throwable;
+
+    abstract ByteOrder byteOrder();
+
+    @Test
+    void shouldWrapBufferUsingConstructor() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(124325, dataInput.readInt());
+        assertEquals(2353242342L, dataInput.readLong());
+        assertEquals(31415926535L, dataInput.readLong());
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldWrapBuffer() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(124325, dataInput.readInt());
+        assertEquals(2353242342L, dataInput.readLong());
+        assertEquals(31415926535L, dataInput.readLong());
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldWrapBufferWithOffsetUsingConstructor() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(2353242342L, dataInput.readLong());
+        assertEquals(31415926535L, dataInput.readLong());
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldWrapBufferWithOffsetAndLengthUsingConstructor() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            8
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(2353242342L, dataInput.readLong());
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldWrapBufferWithOffsetAndLength() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(new UnsafeBuffer(new byte[0]));
+        dataInput.setByteOrder(byteOrder());
+
+        dataInput.wrap(
+            buffer,
+            4,
+            8
+        );
+
+        assertEquals(2353242342L, dataInput.readLong());
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldReadFully() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        final byte[] destination = new byte[16];
+        ThreadLocalRandom.current().nextBytes(destination);
+        dataInput.readFully(destination);
+
+        final UnsafeBuffer actual = new UnsafeBuffer(destination);
+        assertEquals(2353242342L, actual.getLong(0, byteOrder()));
+        assertEquals(31415926535L, actual.getLong(8, byteOrder()));
+    }
+
+    @Test
+    void shouldReadFullyWithDestinationAndOffset() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        final byte[] destination = new byte[64];
+        dataInput.readFully(destination, 20, 8);
+
+        final UnsafeBuffer actual = new UnsafeBuffer(destination);
+        assertEquals(0L, actual.getLong(0));
+        assertEquals(0L, actual.getLong(8));
+        assertEquals(0L, actual.getInt(16));
+        assertEquals(2353242342L, actual.getLong(20, byteOrder()));
+        assertEquals(0L, actual.getLong(28));
+    }
+
+    @Test
+    void shouldThrowNPEIfDestinationIsNull() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+
+        assertThrows(NullPointerException.class, () -> dataInput.readFully(null));
+        assertThrows(NullPointerException.class, () -> dataInput.readFully(null, 0, 0));
+    }
+
+    @Test
+    void shouldThrowIOOBEIfOffsetIsNegative() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class,
+            () -> dataInput.readFully(new byte[0], -1, 10)
+        );
+    }
+
+    @Test
+    void shouldThrowIOOBEIfLengthIsNegative() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class,
+            () -> dataInput.readFully(new byte[0], 10, -1)
+        );
+    }
+
+    @Test
+    void shouldThrowIOOBEIfOffsetPlusLengthIsGreaterThanArraySize() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(IndexOutOfBoundsException.class,
+            () -> dataInput.readFully(new byte[223], 11, 213)
+        );
+    }
+
+    @Test
+    void shouldSkipBytes() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        dataInput.skipBytes(3);
+        assertEquals(13, dataInput.remaining());
+
+        dataInput.skipBytes(2);
+        assertEquals(11, dataInput.remaining());
+
+        dataInput.skipBytes(1);
+        assertEquals(10, dataInput.remaining());
+
+        dataInput.skipBytes(-1);
+        assertEquals(11, dataInput.remaining());
+    }
+
+    @Test
+    void shouldSkipBytesButNotPastBufferSize() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(124325);
+            out.writeLong(2353242342L);
+            out.writeLong(31415926535L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        dataInput.skipBytes(500);
+        assertEquals(0, dataInput.remaining());
+    }
+
+    @Test
+    void shouldReadBoolean() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeBoolean(false);
+            out.writeBoolean(false);
+            out.writeBoolean(true);
+            out.writeBoolean(false);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            2,
+            2
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertTrue(dataInput.readBoolean());
+        assertFalse(dataInput.readBoolean());
+    }
+
+    @Test
+    void shouldReadByte() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(0);
+            out.writeByte((byte)-44);
+            out.writeByte((byte)223);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            2
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(-44, dataInput.readByte());
+        assertEquals(-33, dataInput.readByte());
+    }
+
+    @Test
+    void shouldReadUnsignedByte() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(0);
+            out.writeByte((byte)-44);
+            out.writeByte((byte)223);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            2
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(212, dataInput.readUnsignedByte());
+        assertEquals(223, dataInput.readUnsignedByte());
+    }
+
+    @Test
+    void shouldReadShort() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(0);
+            out.writeShort((short)13244);
+            out.writeShort((short)22321);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            4
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(13244, dataInput.readShort());
+        assertEquals(22321, dataInput.readShort());
+    }
+
+    @Test
+    void shouldReadUnsignedShort() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeInt(0);
+            out.writeShort((short)-13244);
+            out.writeShort((short)22321);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            4,
+            4
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(52292, dataInput.readUnsignedShort());
+        assertEquals(22321, dataInput.readUnsignedShort());
+    }
+
+    @Test
+    void shouldReadChar() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.writeChars("zażółć gęślą jaźń北查爾斯頓"));
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            30,
+            20
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals('ź', dataInput.readChar());
+        assertEquals('ń', dataInput.readChar());
+        assertEquals('北', dataInput.readChar());
+        assertEquals('查', dataInput.readChar());
+    }
+
+    @Test
+    void shouldReadInt() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeByte(0);
+            out.writeInt(352345324);
+            out.writeInt(314159265);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            1,
+            8
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(352345324, dataInput.readInt());
+        assertEquals(314159265, dataInput.readInt());
+    }
+
+    @Test
+    void shouldReadLong() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeByte(0);
+            out.writeLong(3523453241L);
+            out.writeLong(1231415239265L);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            1,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(3523453241L, dataInput.readLong());
+        assertEquals(1231415239265L, dataInput.readLong());
+    }
+
+    @Test
+    void shouldReadFloat() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeByte(0);
+            out.writeFloat(0.13f);
+            out.writeFloat(123141523926.0f);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            1,
+            8
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(0.13f, dataInput.readFloat());
+        assertEquals(123141523926.0f, dataInput.readFloat());
+    }
+
+    @Test
+    void shouldReadDouble() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeByte(0);
+            out.writeDouble(0.13f);
+            out.writeDouble(123141523926.0f);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            1,
+            16
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals(0.13f, dataInput.readDouble());
+        assertEquals(123141523926.0f, dataInput.readDouble());
+    }
+
+    @Test
+    void shouldReadLines() throws Throwable
+    {
+        final String text = "Cupcake ipsum dolor sit amet. Souffle chocolate bar fruitcake cookie toffee. Candy\n" +
+            "gummies cookie shortbread sweet cake topping wafer.\r\n" +
+            "Bear claw apple pie danish carrot cake carrot cake halvah danish carrot cake. Brownie\r" +
+            "danish toffee topping toffee. Sweet sesame snaps chocolate bar jujubes muffin shortbread.";
+
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.write(text.getBytes(StandardCharsets.US_ASCII)));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            8,
+            241
+        );
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals("ipsum dolor sit amet. Souffle chocolate bar fruitcake cookie toffee. Candy",
+            dataInput.readLine());
+        assertEquals("gummies cookie shortbread sweet cake topping wafer.", dataInput.readLine());
+        assertEquals("Bear claw apple pie danish carrot cake carrot cake halvah danish carrot cake. Brownie",
+            dataInput.readLine());
+        assertEquals("danish toffee topping toffe", dataInput.readLine());
+    }
+
+    @Test
+    void shouldReturnNullIfThereIsNothingToRead() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.write("Test".getBytes(StandardCharsets.US_ASCII)));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals("Test", dataInput.readLine());
+        assertNull(dataInput.readLine());
+    }
+
+    @Test
+    void shouldReadLinesIntoAppendable() throws Throwable
+    {
+        final String text = "Cupcake ipsum dolor sit amet. Souffle chocolate bar fruitcake cookie toffee. Candy\n" +
+            "gummies cookie shortbread sweet cake topping wafer.\r\n" +
+            "Bear claw apple pie danish carrot cake carrot cake halvah danish carrot cake. Brownie\r" +
+            "danish toffee topping toffee. Sweet sesame snaps chocolate bar jujubes muffin shortbread.";
+
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.write(text.getBytes(StandardCharsets.US_ASCII)));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        final StringBuilder actual = new StringBuilder();
+        final int bytesRead = dataInput.readLine(actual);
+
+        final String expected = "Cupcake ipsum dolor sit amet. Souffle chocolate bar fruitcake cookie toffee. Candy";
+        assertEquals(expected, actual.toString());
+        assertEquals(expected.length() + 1, bytesRead);
+    }
+
+    @Test
+    void shouldReadLinesIntoAppendableWhenEmpty() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        final StringBuilder actual = new StringBuilder();
+        final int bytesRead = dataInput.readLine(actual);
+
+        assertTrue(actual.toString().isEmpty());
+        assertEquals(0, bytesRead);
+    }
+
+    @Test
+    void shouldReadUtf() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+            out.writeLong(0);
+            out.writeUTF("zażółć gęślą jaźń北查爾斯頓");
+            out.writeLong(0);
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(
+            buffer,
+            8,
+            47);
+        dataInput.setByteOrder(byteOrder());
+
+        assertEquals("zażółć gęślą jaźń北查爾斯頓", dataInput.readUTF());
+    }
+
+    @Test
+    void shouldThrowWhenCannotReadSizeOfUtfString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out ->
+        {
+        });
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(EOFException.class, dataInput::readUTF);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCannotReadString() throws Throwable
+    {
+        final UnsafeBuffer buffer = toUnsafeBuffer(out -> out.writeShort(42));
+
+        final DirectBufferDataInput dataInput = new DirectBufferDataInput(buffer);
+        dataInput.setByteOrder(byteOrder());
+
+        assertThrows(EOFException.class, dataInput::readUTF);
+    }
+}


### PR DESCRIPTION
This PR addresses #273. I have added `DirectBufferDataInput` which implements JDK interface `DataInput`. This implementation adheres to the `DataInput` specification which, sadly, includes throwing checked EOF exception on underflow and being big endian by default. User can change byte order to make it read Agrona buffer's generated data. 

As a bonus it has few additional methods to read Agrona style strings into an `Appendable`.