### PR TITLE
add missing copy constructors on Object2ObjectHashMap and Int2IntHashMap

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -96,6 +96,22 @@ public class Int2IntHashMap implements Map<Integer, Integer>
     }
 
     /**
+     * Copy construct a new map from an existing one.
+     *
+     * @param mapToCopy for construction.
+     */
+    public Int2IntHashMap(final Int2IntHashMap mapToCopy)
+    {
+        this.loadFactor = mapToCopy.loadFactor;
+        this.resizeThreshold = mapToCopy.resizeThreshold;
+        this.size = mapToCopy.size;
+        this.shouldAvoidAllocation = mapToCopy.shouldAvoidAllocation;
+        this.missingValue = mapToCopy.missingValue;
+
+        entries = mapToCopy.entries.clone();
+    }
+
+    /**
      * The value to be used as a null marker in the map.
      *
      * @return value to be used as a null marker in the map.

--- a/agrona/src/main/java/org/agrona/collections/Object2NullableObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2NullableObjectHashMap.java
@@ -49,6 +49,16 @@ public class Object2NullableObjectHashMap<K, V> extends Object2ObjectHashMap<K, 
         super(initialCapacity, loadFactor, shouldAvoidAllocation);
     }
 
+    /**
+     * Copy construct a new map from an existing one.
+     *
+     * @param mapToCopy for construction.
+     */
+    public Object2NullableObjectHashMap(final Object2ObjectHashMap<K, V> mapToCopy)
+    {
+        super(mapToCopy);
+    }
+
     protected Object mapNullValue(final Object value)
     {
         return value == null ? NullReference.INSTANCE : value;

--- a/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Object2ObjectHashMap.java
@@ -83,6 +83,21 @@ public class Object2ObjectHashMap<K, V> implements Map<K, V>
     }
 
     /**
+     * Copy construct a new map from an existing one.
+     *
+     * @param mapToCopy for construction.
+     */
+    public Object2ObjectHashMap(final Object2ObjectHashMap<K, V> mapToCopy)
+    {
+        this.loadFactor = mapToCopy.loadFactor;
+        this.resizeThreshold = mapToCopy.resizeThreshold;
+        this.size = mapToCopy.size;
+        this.shouldAvoidAllocation = mapToCopy.shouldAvoidAllocation;
+
+        entries = mapToCopy.entries.clone();
+    }
+
+    /**
      * Get the load factor applied for resize operations.
      *
      * @return the load factor applied for resize operations.

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -740,6 +740,21 @@ class Int2IntHashMapTest
     }
 
     @Test
+    void shouldCopyConstructAndBeEqual()
+    {
+        final int[] testEntries = { 3, 1, 19, 7, 11, 12, 7 };
+
+        final Int2IntHashMap map = new Int2IntHashMap(Integer.MIN_VALUE);
+        for (final int testEntry : testEntries)
+        {
+            map.put(testEntry, testEntry + 1);
+        }
+
+        final Int2IntHashMap mapCopy = new Int2IntHashMap(map);
+        assertThat(mapCopy, is(map));
+    }
+
+    @Test
     void shouldToArray()
     {
         final Int2IntHashMap map = new Int2IntHashMap(-127);

--- a/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Object2ObjectHashMapTest.java
@@ -20,7 +20,10 @@ import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Object2ObjectHashMapTest
 {
@@ -189,4 +192,20 @@ class Object2ObjectHashMapTest
 
         assertEquals(copyTwo, copyOne);
     }
+
+    @Test
+    void shouldCopyConstructAndBeEqual()
+    {
+        final int[] testEntries = { 3, 1, 19, 7, 11, 12, 7 };
+
+        final Object2ObjectHashMap<String, Integer> map = new Object2ObjectHashMap<>();
+        for (final int testEntry : testEntries)
+        {
+            map.put(String.valueOf(testEntry), testEntry);
+        }
+
+        final Object2ObjectHashMap<String, Integer> mapCopy = new Object2ObjectHashMap<>(map);
+        assertThat(mapCopy, is(map));
+    }
+
 }


### PR DESCRIPTION
Currently, only Object2IntHashMap and Int2ObjectHashMap have efficient copy constructors that clone the underlying arrays.
There is no such constructor for Object2ObjectHashMap and Int2IntHashMap.

Since there is no concurrent versions of these map, having such copy constructor is valuable for implementing copy-on-write patterns when the data is mostly read.