### PR TITLE
Not clearing buffer after message is read

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBuffer.java
@@ -172,11 +172,14 @@ public final class ManyToOneRingBuffer implements RingBuffer
 
         final AtomicBuffer buffer = this.buffer;
         final int headPositionIndex = this.headPositionIndex;
+
         final long head = buffer.getLong(headPositionIndex);
+        final int headIndex = (int)head & (capacity - 1);
+
+        final long tail = buffer.getLongVolatile(tailPositionIndex);
 
         final int capacity = this.capacity;
-        final int headIndex = (int)head & (capacity - 1);
-        final int maxBlockLength = capacity - headIndex;
+        final int maxBlockLength = (int)Math.min(capacity - headIndex, tail - head);
         int bytesRead = 0;
 
         try
@@ -206,7 +209,6 @@ public final class ManyToOneRingBuffer implements RingBuffer
         {
             if (bytesRead > 0)
             {
-                buffer.setMemory(headIndex, bytesRead, (byte)0);
                 buffer.putLongOrdered(headPositionIndex, head + bytesRead);
             }
         }
@@ -231,11 +233,14 @@ public final class ManyToOneRingBuffer implements RingBuffer
 
         final AtomicBuffer buffer = this.buffer;
         final int headPositionIndex = this.headPositionIndex;
+
         long head = buffer.getLong(headPositionIndex);
+        int headIndex = (int)head & (capacity - 1);
+
+        final long tail = buffer.getLongVolatile(tailPositionIndex);
 
         final int capacity = this.capacity;
-        int headIndex = (int)head & (capacity - 1);
-        final int maxBlockLength = capacity - headIndex;
+        final int maxBlockLength = (int)Math.min(capacity - headIndex, tail - head);
         int bytesRead = 0;
 
         try
@@ -275,7 +280,6 @@ public final class ManyToOneRingBuffer implements RingBuffer
                 }
                 if (COMMIT == action)
                 {
-                    buffer.setMemory(headIndex, bytesRead, (byte)0);
                     buffer.putLongOrdered(headPositionIndex, head + bytesRead);
                     headIndex += bytesRead;
                     head += bytesRead;
@@ -287,7 +291,6 @@ public final class ManyToOneRingBuffer implements RingBuffer
         {
             if (bytesRead > 0)
             {
-                buffer.setMemory(headIndex, bytesRead, (byte)0);
                 buffer.putLongOrdered(headPositionIndex, head + bytesRead);
             }
         }

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/ManyToOneRingBufferTest.java
@@ -248,8 +248,6 @@ class ManyToOneRingBufferTest
         assertThat(times.get(), is(0));
 
         final InOrder inOrder = inOrder(buffer);
-        inOrder.verify(buffer, times(1)).getIntVolatile(lengthOffset(headIndex));
-        inOrder.verify(buffer, times(0)).setMemory(headIndex, 0, (byte)0);
         inOrder.verify(buffer, times(0)).putLongOrdered(HEAD_COUNTER_INDEX, headIndex);
     }
 
@@ -268,6 +266,7 @@ class ManyToOneRingBufferTest
         when(buffer.getIntVolatile(lengthOffset(headIndex))).thenReturn(recordLength);
         when(buffer.getInt(typeOffset(headIndex + alignedRecordLength))).thenReturn(MSG_TYPE_ID);
         when(buffer.getIntVolatile(lengthOffset(headIndex + alignedRecordLength))).thenReturn(recordLength);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tail);
 
         final MutableInteger times = new MutableInteger();
         final MessageHandler handler = (msgTypeId, buffer, index, length) -> times.increment();
@@ -277,7 +276,6 @@ class ManyToOneRingBufferTest
         assertThat(times.get(), is(2));
 
         final InOrder inOrder = inOrder(buffer);
-        inOrder.verify(buffer, times(1)).setMemory(headIndex, alignedRecordLength * 2, (byte)0);
         inOrder.verify(buffer, times(1)).putLongOrdered(HEAD_COUNTER_INDEX, tail);
     }
 
@@ -293,6 +291,7 @@ class ManyToOneRingBufferTest
         when(buffer.getLong(HEAD_COUNTER_INDEX)).thenReturn(head);
         when(buffer.getInt(typeOffset(headIndex))).thenReturn(MSG_TYPE_ID);
         when(buffer.getIntVolatile(lengthOffset(headIndex))).thenReturn(recordLength);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn((long)alignedRecordLength);
 
         final MutableInteger times = new MutableInteger();
         final MessageHandler handler = (msgTypeId, buffer, index, length) -> times.increment();
@@ -303,7 +302,6 @@ class ManyToOneRingBufferTest
         assertThat(times.get(), is(1));
 
         final InOrder inOrder = inOrder(buffer);
-        inOrder.verify(buffer, times(1)).setMemory(headIndex, alignedRecordLength, (byte)0);
         inOrder.verify(buffer, times(1)).putLongOrdered(HEAD_COUNTER_INDEX, head + alignedRecordLength);
     }
 
@@ -322,6 +320,7 @@ class ManyToOneRingBufferTest
         when(buffer.getIntVolatile(lengthOffset(headIndex))).thenReturn(recordLength);
         when(buffer.getInt(typeOffset(headIndex + alignedRecordLength))).thenReturn(MSG_TYPE_ID);
         when(buffer.getIntVolatile(lengthOffset(headIndex + alignedRecordLength))).thenReturn(recordLength);
+        when(buffer.getLongVolatile(TAIL_COUNTER_INDEX)).thenReturn(tail);
 
         final MutableInteger times = new MutableInteger();
         final MessageHandler handler =
@@ -342,7 +341,6 @@ class ManyToOneRingBufferTest
             assertThat(times.get(), is(2));
 
             final InOrder inOrder = inOrder(buffer);
-            inOrder.verify(buffer, times(1)).setMemory(headIndex, alignedRecordLength * 2, (byte)0);
             inOrder.verify(buffer, times(1)).putLongOrdered(HEAD_COUNTER_INDEX, tail);
 
             return;


### PR DESCRIPTION
 This requires reader to check tail pointer on every read so not to go over real data and read garbage. This might severely impact scalability but for us it's still better than locking and allocation.