### PR TITLE
Fix NPE in SigInt.java

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/SigInt.java
+++ b/agrona/src/main/java/org/agrona/concurrent/SigInt.java
@@ -43,17 +43,14 @@ public class SigInt
             new Signal(signalName),
             (signal) ->
             {
-                Throwable error = null;
                 try
                 {
                     task.run();
                 }
                 catch (final Throwable t)
                 {
-                    error = t;
+                    LangUtil.rethrowUnchecked(t);
                 }
-
-                LangUtil.rethrowUnchecked(error);
             });
     }
 }


### PR DESCRIPTION
It should fix the following NPE:
```
java.lang.NullPointerException: Cannot throw exception because "t" is null
	at org.agrona.LangUtil.rethrow(LangUtil.java:40)
	at org.agrona.LangUtil.rethrowUnchecked(LangUtil.java:34)
	at org.agrona.concurrent.SigInt.lambda$register$0(SigInt.java:56)
	at jdk.unsupported/sun.misc.Signal$InternalMiscHandler.handle(Signal.java:198)
	at java.base/jdk.internal.misc.Signal$1.run(Signal.java:219)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
