### PR TITLE
[Java] Call bound check instead of capacity expansion in AbstractMutableDirectBuffer.getInt

### DIFF
--- a/agrona/src/main/java/org/agrona/AbstractMutableDirectBuffer.java
+++ b/agrona/src/main/java/org/agrona/AbstractMutableDirectBuffer.java
@@ -182,7 +182,10 @@ public abstract class AbstractMutableDirectBuffer implements MutableDirectBuffer
      */
     public int getInt(final int index, final ByteOrder byteOrder)
     {
-        ensureCapacity(index, SIZE_OF_INT);
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_INT);
+        }
 
         int bits = UNSAFE.getInt(byteArray, addressOffset + index);
         if (NATIVE_BYTE_ORDER != byteOrder)

--- a/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
+++ b/agrona/src/test/java/org/agrona/ExpandableArrayBufferTest.java
@@ -15,6 +15,7 @@
  */
 package org.agrona;
 
+import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -144,4 +145,19 @@ class ExpandableArrayBufferTest extends MutableDirectBufferTests
         assertTrue(limit <= buffer.capacity());
         assertNotSame(originalArray, buffer.byteArray());
     }
+
+    @Test
+    void shouldThrowExceptionForReadingIntAboveCapacity()
+    {
+        final MutableDirectBuffer buffer = newBuffer(3);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getInt(4, ByteOrder.BIG_ENDIAN));
+    }
+
+    @Test
+    void shouldThrowExceptionForReadingLongAboveCapacity()
+    {
+        final MutableDirectBuffer buffer = newBuffer(3);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getLong(4, ByteOrder.BIG_ENDIAN));
+    }
+
 }


### PR DESCRIPTION
Quite minor issue, the `getInt` method should call `boundsCheck0` rather than `ensureCapacity`