### PR TITLE
[Java] Fix {Int,Long}2ObjectCache.

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2ObjectCache.java
@@ -50,6 +50,17 @@ import static org.agrona.collections.CollectionUtil.validatePositivePowerOfTwo;
  */
 public class Int2ObjectCache<V> implements Map<Integer, V>
 {
+    /*
+     * Example for numSets=2 and setSize=4:
+     *
+     *               newest               oldest
+     * keys:        [  0  ][  1  ][  2  ][  3  ][  4  ][  5  ][  6  ][  7  ]
+     * values:      [  0  ][  1  ][  2  ][  3  ][  4  ][  5  ][  6  ][  7  ]
+     *              <-         set 0          -><-         set 1          ->
+     * shuffleUp:       <---   <---   <---  X
+     * shuffleDown:    X  --->   --->   --->
+     */
+
     private long cachePuts = 0;
     private long cacheHits = 0;
     private long cacheMisses = 0;
@@ -742,13 +753,14 @@ public class Int2ObjectCache<V> implements Map<Integer, V>
     {
         final int[] keys = this.keys;
         final Object[] values = this.values;
-        values[toIndex] = null;
 
         for (@DoNotSub int i = fromIndex; i < toIndex; i++)
         {
             values[i] = values[i + 1];
             keys[i] = keys[i + 1];
         }
+
+        values[toIndex] = null;
     }
 
     @DoNotSub private void shuffleDown(final int setBeginIndex)


### PR DESCRIPTION
Replacing or removing a key might corrupt the cache leading to an exception like this:

```
java.util.NoSuchElementException
	at org.agrona.collections.Int2ObjectCache$AbstractIterator.findNext(Int2ObjectCache.java:1180)
	at org.agrona.collections.Int2ObjectCache$ValueIterator.next(Int2ObjectCache.java:1215)
```

When shuffling up, we need to clear the last element *after* it has been copied.