### PR TITLE
Fixes 2 bugs in the BufferUtil boundCheck.

### DIFF
--- a/agrona/src/main/java/org/agrona/BufferUtil.java
+++ b/agrona/src/main/java/org/agrona/BufferUtil.java
@@ -83,14 +83,13 @@ public final class BufferUtil
      * Bounds check the access range and throw a {@link IndexOutOfBoundsException} if exceeded.
      *
      * @param buffer to be checked.
-     * @param index  at which the access will begin.
-     * @param length of the range accessed.
+     * @param index  at which the access will begin. The value should not be negative.
+     * @param length of the range accessed. The value should not be negative.
      */
     public static void boundsCheck(final byte[] buffer, final long index, final int length)
     {
         final int capacity = buffer.length;
-        final long resultingPosition = index + (long)length;
-        if (index < 0 || resultingPosition > capacity)
+        if (index < 0 || length < 0 || index > capacity - length)
         {
             throw new IndexOutOfBoundsException("index=" + index + " length=" + length + " capacity=" + capacity);
         }
@@ -100,14 +99,13 @@ public final class BufferUtil
      * Bounds check the access range and throw a {@link IndexOutOfBoundsException} if exceeded.
      *
      * @param buffer to be checked.
-     * @param index  at which the access will begin.
-     * @param length of the range accessed.
+     * @param index  at which the access will begin. The value should not be negative.
+     * @param length of the range accessed. The value should not be negative.
      */
     public static void boundsCheck(final ByteBuffer buffer, final long index, final int length)
     {
         final int capacity = buffer.capacity();
-        final long resultingPosition = index + (long)length;
-        if (index < 0 || resultingPosition > capacity)
+        if (index < 0 || length < 0 || index > capacity - length)
         {
             throw new IndexOutOfBoundsException("index=" + index + " length=" + length + " capacity=" + capacity);
         }

--- a/agrona/src/test/java/org/agrona/BufferUtilTest.java
+++ b/agrona/src/test/java/org/agrona/BufferUtilTest.java
@@ -133,4 +133,28 @@ class BufferUtilTest
 
         assertThrows(IllegalArgumentException.class, () -> BufferUtil.free(buffer));
     }
+
+    @Test
+    void shouldBoundsCheckByteArrayIndexWithoutLongOverflow()
+    {
+        final byte[] buffer = new byte[8];
+        final long index = Long.MAX_VALUE - 3;
+        final int length = 10;
+
+        assertThrows(IndexOutOfBoundsException.class, () ->
+            BufferUtil.boundsCheck(buffer, index, length)
+        );
+    }
+
+    @Test
+    void shouldBoundsCheckByteBufferIndexWithoutLongOverflow()
+    {
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(8);
+        final long index = Long.MAX_VALUE - 3;
+        final int length = 10;
+
+        assertThrows(IndexOutOfBoundsException.class, () ->
+            BufferUtil.boundsCheck(buffer, index, length)
+        );
+    }
 }


### PR DESCRIPTION
If the index is close to Long.MAX_VALUE, then the resulting pos can becomes negative due to overflow.

As a consequence, the resultingPos > capacity will not be triggered even though the resultingPos has exceeded the capacity of the buffer.

In the Agrona codebase this has never lead to problems because only int values are passed to index and therefor there won't be any overflow.