### PR TITLE
[DO NOT MERGE] [Java] Allow use of environment variables in configuration files

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 
 == 2.5.0 (xxxx-xx-xx)
 
+* Support environment variable interpolation in properties files loaded by `SystemUtil`. Values containing
+`${VAR_NAME}` are expanded using the process environment at load time. An `IllegalArgumentException` is thrown
+if a referenced variable is not set or the reference is malformed (missing closing `}`).
+
 * Upgrade to `JUnit` 6.0.2.
 * Upgrade to `Shadow`  9.3.1.
 

--- a/agrona/src/main/java/org/agrona/SystemUtil.java
+++ b/agrona/src/main/java/org/agrona/SystemUtil.java
@@ -228,8 +228,15 @@ public final class SystemUtil
      * <p>
      * File is first searched for in resources using the system {@link ClassLoader},
      * then file system, then URL. All are loaded if multiples found.
+     * <p>
+     * Property values may contain environment variable references in the form {@code ${VAR_NAME}}.
+     * Each reference is replaced with the value of the named environment variable at load time.
+     * An {@link IllegalArgumentException} is thrown if a referenced variable is not set or a reference
+     * is malformed (missing closing {@code }}).
      *
      * @param filenameOrUrl that holds properties.
+     * @throws IllegalArgumentException if a property value references an environment variable that is not set,
+     *                                  or contains a malformed reference.
      */
     public static void loadPropertiesFile(final String filenameOrUrl)
     {
@@ -241,9 +248,16 @@ public final class SystemUtil
      * <p>
      * File is first searched for in resources using the system {@link ClassLoader},
      * then file system, then URL. All are loaded if multiples found.
+     * <p>
+     * Property values may contain environment variable references in the form {@code ${VAR_NAME}}.
+     * Each reference is replaced with the value of the named environment variable at load time.
+     * An {@link IllegalArgumentException} is thrown if a referenced variable is not set or a reference
+     * is malformed (missing closing {@code }}).
      *
      * @param propertyAction to take with each loaded property.
      * @param filenameOrUrl  that holds properties.
+     * @throws IllegalArgumentException if a property value references an environment variable that is not set,
+     *                                  or contains a malformed reference.
      */
     public static void loadPropertiesFile(final PropertyAction propertyAction, final String filenameOrUrl)
     {
@@ -639,6 +653,49 @@ public final class SystemUtil
         return arch.equals("amd64") || arch.equals("x86_64") || arch.equals("x64");
     }
 
+    static String expandEnvVars(final String value)
+    {
+        final int firstBegin = value.indexOf("${");
+        if (firstBegin < 0)
+        {
+            return value;
+        }
+
+        final StringBuilder sb = new StringBuilder(value.length());
+        int pos = 0;
+
+        while (pos < value.length())
+        {
+            final int begin = value.indexOf("${", pos);
+            if (begin < 0)
+            {
+                sb.append(value, pos, value.length());
+                break;
+            }
+
+            final int end = value.indexOf('}', begin + 2);
+            if (end < 0)
+            {
+                throw new IllegalArgumentException(
+                    "malformed environment variable reference, missing '}': " + value.substring(begin));
+            }
+
+            sb.append(value, pos, begin);
+
+            final String envName = value.substring(begin + 2, end);
+            final String envValue = System.getenv(envName);
+            if (envValue == null)
+            {
+                throw new IllegalArgumentException("environment variable not set: " + envName);
+            }
+
+            sb.append(envValue);
+            pos = end + 1;
+        }
+
+        return sb.toString();
+    }
+
     private static void loadProperties(final PropertyAction propertyAction, final InputStream in) throws IOException
     {
         final Properties systemProperties = System.getProperties();
@@ -648,18 +705,19 @@ public final class SystemUtil
         properties.forEach(
             (k, v) ->
             {
+                final String expandedValue = expandEnvVars((String)v);
                 switch (propertyAction)
                 {
                     case PRESERVE:
                         if (!systemProperties.containsKey(k))
                         {
-                            systemProperties.setProperty((String)k, (String)v);
+                            systemProperties.setProperty((String)k, expandedValue);
                         }
                         break;
 
                     case REPLACE:
                     default:
-                        systemProperties.setProperty((String)k, (String)v);
+                        systemProperties.setProperty((String)k, expandedValue);
                         break;
                 }
             });

--- a/agrona/src/test/java/org/agrona/SystemUtilTest.java
+++ b/agrona/src/test/java/org/agrona/SystemUtilTest.java
@@ -397,4 +397,72 @@ class SystemUtilTest
         assertFalse(SystemUtil.isLinux());
         assertFalse(SystemUtil.isWindows());
     }
+
+    @Test
+    void expandEnvVarsShouldReturnSameInstanceWhenNoSyntaxPresent()
+    {
+        final String value = "plainvalue";
+        assertSame(value, SystemUtil.expandEnvVars(value));
+    }
+
+    @Test
+    void expandEnvVarsShouldThrowWhenEnvVarIsUndefined()
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> SystemUtil.expandEnvVars("${AGRONA_ENV_VAR_NOT_SET}"));
+        assertEquals("environment variable not set: AGRONA_ENV_VAR_NOT_SET", exception.getMessage());
+    }
+
+    @Test
+    void expandEnvVarsShouldThrowWhenClosingBraceIsMissing()
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> SystemUtil.expandEnvVars("${UNCLOSED"));
+        assertEquals("malformed environment variable reference, missing '}': ${UNCLOSED", exception.getMessage());
+    }
+
+    @Test
+    void expandEnvVarsShouldThrowForUndefinedVarInCompoundValue()
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> SystemUtil.expandEnvVars("prefix_${AGRONA_ENV_VAR_NOT_SET}_suffix"));
+        assertEquals("environment variable not set: AGRONA_ENV_VAR_NOT_SET", exception.getMessage());
+    }
+
+    @Test
+    void expandEnvVarsShouldExpandKnownEnvVar()
+    {
+        final String path = System.getenv("PATH");
+        assertNotNull(path);
+        assertEquals(path, SystemUtil.expandEnvVars("${PATH}"));
+    }
+
+    @Test
+    void expandEnvVarsShouldExpandEnvVarInCompoundValue()
+    {
+        final String path = System.getenv("PATH");
+        assertNotNull(path);
+        assertEquals("begin_" + path + "_end", SystemUtil.expandEnvVars("begin_${PATH}_end"));
+    }
+
+    @Test
+    void shouldExpandEnvVarsWhenLoadingPropertiesFile()
+    {
+        try
+        {
+            SystemUtil.loadPropertiesFile("TestFileEnvVar.properties");
+            assertEquals("noEnvVar", System.getProperty("var.plain"));
+            assertEquals(System.getenv("PATH"), System.getProperty("var.path"));
+            assertEquals("begin_" + System.getenv("PATH") + "_end", System.getProperty("var.multiple"));
+        }
+        finally
+        {
+            System.clearProperty("var.plain");
+            System.clearProperty("var.path");
+            System.clearProperty("var.multiple");
+        }
+    }
 }

--- a/agrona/src/test/resources/TestFileEnvVar.properties
+++ b/agrona/src/test/resources/TestFileEnvVar.properties
@@ -1,0 +1,3 @@
+var.plain=noEnvVar
+var.path=${PATH}
+var.multiple=begin_${PATH}_end


### PR DESCRIPTION
This change allows keeping configuration files more static, while templating in simple differences between systems at startup time, through env vars.

I'm specifically targeting things like Node & Archive IDs and similar.