### PR TITLE
Fixed the testUnsafeBufferFromSlicedHeapByteBuffer test

### DIFF
--- a/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
+++ b/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
@@ -77,7 +77,7 @@ class BufferAlignmentAgentTest
     @Test
     void testUnsafeBufferFromSlicedHeapByteBuffer()
     {
-        final ByteBuffer nioBuffer = ByteBuffer.allocateDirect(256);
+        final ByteBuffer nioBuffer = ByteBuffer.allocate(256);
         nioBuffer.position(1);
         final UnsafeBuffer buffer = new UnsafeBuffer(nioBuffer.slice());
         assertTrue(buffer.addressOffset() % 4 != 0);


### PR DESCRIPTION
So it actually uses a heap-allocated ByteBuffer instead of a direct ByteBuffer, per original intent.

This should fix the failing CI tests with Java 27.  Interestingly, the reason the old (slightly wrong) test started failing was that starting in Java 27, compact object headers (https://openjdk.org/jeps/519) are on by default, so the header offset for direct ByteBuffers is slightly different (4 bytes less).