### PR TITLE
Reject missingValue in Int2IntHashMap.replace

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
+++ b/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java
@@ -960,10 +960,16 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      * @param value value to be associated with the specified key.
      * @return the previous value associated with the specified key, or
      * {@link #missingValue()} if there was no mapping for the key.
+     * @throws IllegalArgumentException if value is {@link #missingValue()}
      */
     public int replace(final int key, final int value)
     {
         final int missingValue = this.missingValue;
+        if (missingValue == value)
+        {
+            throw new IllegalArgumentException("cannot accept missingValue");
+        }
+
         final int[] entries = this.entries;
         @DoNotSub final int mask = entries.length - 1;
         @DoNotSub int keyIndex = Hashing.evenHash(key, mask);
@@ -990,10 +996,16 @@ public class Int2IntHashMap implements Map<Integer, Integer>
      * @param oldValue value expected to be associated with the specified key.
      * @param newValue value to be associated with the specified key.
      * @return {@code true} if the value was replaced.
+     * @throws IllegalArgumentException if newValue is {@link #missingValue()}
      */
     public boolean replace(final int key, final int oldValue, final int newValue)
     {
         final int missingValue = this.missingValue;
+        if (missingValue == newValue)
+        {
+            throw new IllegalArgumentException("cannot accept missingValue");
+        }
+
         final int[] entries = this.entries;
         @DoNotSub final int mask = entries.length - 1;
         @DoNotSub int keyIndex = Hashing.evenHash(key, mask);

--- a/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
+++ b/agrona/src/test/java/org/agrona/collections/Int2IntHashMapTest.java
@@ -1069,6 +1069,36 @@ class Int2IntHashMapTest
     }
 
     @Test
+    void replaceShouldThrowIllegalArgumentExceptionIfValueIsMissingValue()
+    {
+        final int key = 42;
+        final int value = 8;
+        map.put(key, value);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.replace(key, MISSING_VALUE));
+        assertEquals("cannot accept missingValue", exception.getMessage());
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
+    void replaceShouldThrowIllegalArgumentExceptionIfNewValueIsMissingValue()
+    {
+        final int key = 42;
+        final int value = 8;
+        map.put(key, value);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> map.replace(key, value, MISSING_VALUE));
+        assertEquals("cannot accept missingValue", exception.getMessage());
+
+        assertEquals(1, map.size());
+        assertEquals(value, map.get(key));
+    }
+
+    @Test
     void replaceAllIntShouldThrowIllegalArgumentExceptionIfANewValueIsAMissingValue()
     {
         final IntIntFunction function = (key, value) -> MISSING_VALUE;


### PR DESCRIPTION
Both `replace(int, int)` and `replace(int, int, int)` write the caller's value into the entry slot with no guard. Passing `missingValue` therefore makes an occupied slot indistinguishable from an empty one: the entry disappears from `get`/`containsKey`/iteration while `size` is left unchanged, so the map becomes internally inconsistent (`size() == 1` for an observably empty map).

This rejects `missingValue` with `IllegalArgumentException`, consistent with `put`/`putIfAbsent`/`merge` in this class and with the sibling `Object2IntHashMap.replace` and `Int2IntCounterMap.replace`. Added tests covering both overloads.