### PR TITLE
[Java] Mask high bytes to Latin-1 in AsciiSequenceView.charAt

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiSequenceView.java
+++ b/agrona/src/main/java/org/agrona/AsciiSequenceView.java
@@ -83,7 +83,7 @@ public class AsciiSequenceView implements CharSequence
             throw new StringIndexOutOfBoundsException("index=" + index + " length=" + length);
         }
 
-        return (char)buffer.getByte(offset + index);
+        return (char)(buffer.getByte(offset + index) & 0xFF);
     }
 
     /**

--- a/agrona/src/test/java/org/agrona/AsciiSequenceViewTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiSequenceViewTest.java
@@ -47,6 +47,18 @@ class AsciiSequenceViewTest
     }
 
     @Test
+    void shouldMapHighBytesToLatin1WithoutSignExtension()
+    {
+        buffer.putByte(INDEX, (byte)0x80);
+        buffer.putByte(INDEX + 1, (byte)0xFF);
+
+        asciiSequenceView.wrap(buffer, INDEX, 2);
+
+        assertThat(asciiSequenceView.charAt(0), is(''));
+        assertThat(asciiSequenceView.charAt(1), is('ÿ'));
+    }
+
+    @Test
     void shouldToString()
     {
         final String data = "a little bit of ascii";


### PR DESCRIPTION
`AsciiSequenceView.charAt` is the one ASCII reader in the codebase that does not normalize high bytes:

```java
return (char)buffer.getByte(offset + index);
```

`DirectBuffer.getByte` returns a **signed** byte, so bytes `0x80`–`0xFF` sign-extend before the `char` cast and land in the `U+FF80`–`U+FFFF` range (e.g. `0xFF` becomes `￿`) instead of their natural Latin-1 code points.

Every sibling ASCII path in `MutableDirectBuffer` already normalizes the high range:
- `getStringAscii(index, length, Appendable)` and `getStringWithoutLengthAscii(index, length, Appendable)` guard with `c > 127 ? '?' : c`.
- `putStringAscii` / `putStringWithoutLengthAscii` write `'?'` for chars `> 127`.
- `getStringAscii(index, length)` decodes via `new String(dst, US_ASCII)`.

So `charAt` is the sole outlier: the same buffer read back through `toString()`/`getStringWithoutLengthAscii` and through `charAt` disagree for high bytes. This change makes `charAt` consistent with the rest of the API by masking to the low 8 bits:

```java
return (char)(buffer.getByte(offset + index) & 0xFF);
```

`& 0xFF` is the same idiom used elsewhere in the codebase, and it yields the stable Latin-1 mapping (`U+0080`–`U+00FF`) rather than a sign-extended value. This is the least surprising result for a byte that is outside the 7-bit ASCII domain.

Added a focused test (`shouldMapHighBytesToLatin1WithoutSignExtension`) that wraps a buffer containing `0x80` and `0xFF` and asserts `charAt` returns `U+0080` / `U+00FF`. Existing ASCII coverage is unchanged.