### PR TITLE
Reject non-ASCII digit look-alikes in AsciiEncoding CharSequence parsing

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -244,6 +244,17 @@ public final class AsciiEncoding
     }
 
     /**
+     * Check if the {@code value} is an ASCII-encoded digit.
+     *
+     * @param value to be checked.
+     * @return {@code true} if the {@code value} is an ASCII-encoded digit.
+     */
+    public static boolean isDigit(final char value)
+    {
+        return value >= 0x30 && value <= 0x39;
+    }
+
+    /**
      * Get the digit value of an ASCII encoded {@code byte}.
      *
      * @param index within the string the value is encoded.
@@ -427,8 +438,8 @@ public final class AsciiEncoding
             i += 4;
         }
 
-        byte digit;
-        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+        char digit;
+        while (i < end && isDigit(digit = cs.charAt(i)))
         {
             tally = (tally * 10) + (digit - 0x30);
             i++;
@@ -458,8 +469,8 @@ public final class AsciiEncoding
             tally = parseEightDigitsLittleEndian(octet);
             i += 8;
 
-            byte digit;
-            while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+            char digit;
+            while (i < end && isDigit(digit = cs.charAt(i)))
             {
                 tally = (tally * 10L) + (digit - 0x30);
                 i++;
@@ -502,8 +513,8 @@ public final class AsciiEncoding
             i += 4;
         }
 
-        byte digit;
-        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+        char digit;
+        while (i < end && isDigit(digit = cs.charAt(i)))
         {
             tally = (tally * 10) + (digit - 0x30);
             i++;
@@ -552,9 +563,9 @@ public final class AsciiEncoding
             i += 8;
         }
 
-        byte digit;
+        char digit;
         int lastDigits = 0;
-        while (i < end && isDigit(digit = (byte)cs.charAt(i)))
+        while (i < end && isDigit(digit = cs.charAt(i)))
         {
             lastDigits = (lastDigits * 10) + (digit - 0x30);
             i++;

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -102,6 +102,23 @@ class AsciiEncodingTest
     }
 
     @Test
+    void shouldRejectNonAsciiCharsWhoseLowByteLooksLikeADigit()
+    {
+        // U+0130 / U+0132 have digit low bytes (0x30 / 0x32); narrowing to byte
+        // would accept them as digits, so they must be rejected like getDigit is.
+        assertFalse(isDigit('İ'));
+        assertThrows(AsciiNumberFormatException.class, () -> getDigit(0, 'İ'));
+
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("İ", 0, 1));
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("1Ĳ", 0, 2));
+        assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("İ", 0, 1));
+        // 10-digit int / 19-digit long tails exercise the overflow-check paths.
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("123456789İ", 0, 10));
+        assertThrows(
+            AsciiNumberFormatException.class, () -> parseLongAscii("123456789012345678İ", 0, 19));
+    }
+
+    @Test
     void shouldThrowExceptionWhenParsingLongWhichCanOverFlow()
     {
         final String maxValuePlusOneDigit = Long.MAX_VALUE + "1";


### PR DESCRIPTION
The `CharSequence` overloads of `parseIntAscii`/`parseLongAscii` narrow each character to a `byte` in their scalar tail loops (`isDigit(digit = (byte)cs.charAt(i))`). That drops the high 8 bits, so a non-ASCII character whose low byte falls in `0x30`–`0x39` — e.g. `İ` (U+0130, low byte `0x30`) — is accepted as a digit and silently mis-parsed. `AsciiEncoding.parseIntAscii("İ", 0, 1)` returns `0` instead of throwing.

`getDigit(int, char)` — the per-char public API — already range-checks the full `char` and rejects these. This makes the bulk parsers consistent with it: added an `isDigit(char)` overload (mirroring `isDigit(byte)`) and used it so the whole character is validated; a non-digit then leaves `i != end` and the existing parse error is thrown. The `readFourBytes`/`readEightBytes` SIMD fast paths already mask high bits and are unaffected.

Added `AsciiEncodingTest.shouldRejectNonAsciiCharsWhoseLowByteLooksLikeADigit`, covering the scalar and overflow-check paths for both int and long.